### PR TITLE
fix: suggest 라우트 AI Provider 실패 시 graceful fallback

### DIFF
--- a/src/app/api/v1/suggest-apis/route.ts
+++ b/src/app/api/v1/suggest-apis/route.ts
@@ -38,7 +38,16 @@ export async function POST(request: Request): Promise<Response> {
       .map((a) => `- [ID:${a.id}] ${a.name} (${a.category}): ${a.description}`)
       .join('\n');
 
-    const provider = AiProviderFactory.createForTask('suggestion');
+    let provider;
+    try {
+      provider = AiProviderFactory.createForTask('suggestion');
+    } catch (err) {
+      logger.warn('API suggestion: AI provider unavailable', {
+        error: err instanceof Error ? err.message : 'Unknown',
+      });
+      return jsonResponse({ success: true, data: { recommendations: [] } });
+    }
+
     const aiResponse = await provider.generateCode({
       system: `당신은 웹 서비스 아이디어에 가장 적합한 API를 추천하는 전문가입니다.
 사용자가 만들고 싶은 서비스 설명을 읽고, 주어진 API 목록에서 가장 적합한 API를 1~5개 선택하세요.

--- a/src/app/api/v1/suggest-context/route.ts
+++ b/src/app/api/v1/suggest-context/route.ts
@@ -44,7 +44,16 @@ export async function POST(request: Request): Promise<Response> {
 
     const apiList = apis.map((a) => `- ${a.name}: ${a.description}`).join('\n');
 
-    const provider = AiProviderFactory.createForTask('suggestion');
+    let provider;
+    try {
+      provider = AiProviderFactory.createForTask('suggestion');
+    } catch (err) {
+      logger.warn('Context suggestion: AI provider unavailable', {
+        error: err instanceof Error ? err.message : 'Unknown',
+      });
+      return jsonResponse({ success: true, data: { suggestions: [] } });
+    }
+
     const aiResponse = await provider.generateCode({
       system: `당신은 웹 서비스 아이디어를 제안하는 도우미입니다.
 사용자가 선택한 API들을 기반으로 만들 수 있는 웹 서비스 아이디어 3가지를 제안하세요.


### PR DESCRIPTION
## Summary
- suggest-context, suggest-apis 라우트에서 AI Provider 초기화 실패 시 500 에러 대신 빈 배열로 graceful 응답
- API 1개만 선택해도 컨텍스트 제안이 정상 동작하도록 보장

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] 전체 테스트 176/176 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)