### PR TITLE
fix: Claude API 에러 로깅 강화 + suggest AI 호출 graceful 처리

### DIFF
--- a/src/app/api/v1/suggest-apis/route.ts
+++ b/src/app/api/v1/suggest-apis/route.ts
@@ -48,8 +48,10 @@ export async function POST(request: Request): Promise<Response> {
       return jsonResponse({ success: true, data: { recommendations: [] } });
     }
 
-    const aiResponse = await provider.generateCode({
-      system: `당신은 웹 서비스 아이디어에 가장 적합한 API를 추천하는 전문가입니다.
+    let aiResponse;
+    try {
+      aiResponse = await provider.generateCode({
+        system: `당신은 웹 서비스 아이디어에 가장 적합한 API를 추천하는 전문가입니다.
 사용자가 만들고 싶은 서비스 설명을 읽고, 주어진 API 목록에서 가장 적합한 API를 1~5개 선택하세요.
 
 반드시 아래 JSON 형식만 반환하세요:
@@ -61,16 +63,22 @@ export async function POST(request: Request): Promise<Response> {
 - 가장 관련성 높은 순서로 정렬
 - reason은 한국어로 간결하게 작성
 - 마크다운, 코드 블록, 추가 설명 없이 순수 JSON 배열만 반환`,
-      user: `## 사용 가능한 API 목록
+        user: `## 사용 가능한 API 목록
 ${apiListForAi}
 
 ## 사용자가 만들고 싶은 서비스
 ${context}
 
 위 서비스에 가장 적합한 API를 선택해주세요.`,
-      temperature: 0.3,
-      maxTokens: 500,
-    });
+        temperature: 0.3,
+        maxTokens: 500,
+      });
+    } catch (err) {
+      logger.error('API suggestion: AI generation failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return jsonResponse({ success: true, data: { recommendations: [] } });
+    }
 
     // Parse AI response
     const match = aiResponse.content.match(/\[[\s\S]*?\]/);

--- a/src/app/api/v1/suggest-context/route.ts
+++ b/src/app/api/v1/suggest-context/route.ts
@@ -54,8 +54,10 @@ export async function POST(request: Request): Promise<Response> {
       return jsonResponse({ success: true, data: { suggestions: [] } });
     }
 
-    const aiResponse = await provider.generateCode({
-      system: `당신은 웹 서비스 아이디어를 제안하는 도우미입니다.
+    let aiResponse;
+    try {
+      aiResponse = await provider.generateCode({
+        system: `당신은 웹 서비스 아이디어를 제안하는 도우미입니다.
 사용자가 선택한 API들을 기반으로 만들 수 있는 웹 서비스 아이디어 3가지를 제안하세요.
 반드시 JSON 배열만 반환하세요: ["제안1", "제안2", "제안3"]
 규칙:
@@ -64,10 +66,17 @@ export async function POST(request: Request): Promise<Response> {
 - 선택된 API를 자연스럽게 활용하는 아이디어
 - 3가지는 서로 다른 방향의 아이디어 (대시보드형/계산기형/정보조회형 등)
 - 마크다운, 코드 블록, 추가 설명 없이 순수 JSON 배열만 반환`,
-      user: `선택된 API:\n${apiList}\n\n이 API들을 활용한 웹 서비스 아이디어 3가지를 JSON 배열로 제안해주세요.`,
-      temperature: 0.8,
-      maxTokens: 600,
-    });
+        user: `선택된 API:\n${apiList}\n\n이 API들을 활용한 웹 서비스 아이디어 3가지를 JSON 배열로 제안해주세요.`,
+        temperature: 0.8,
+        maxTokens: 600,
+      });
+    } catch (err) {
+      logger.error('Context suggestion: AI generation failed', {
+        error: err instanceof Error ? err.message : String(err),
+        apiCount: apis.length,
+      });
+      return jsonResponse({ success: true, data: { suggestions: [] } });
+    }
 
     // Extract JSON array from response (tolerates surrounding text or code blocks)
     const match = aiResponse.content.match(/\[[\s\S]*?\]/);

--- a/src/providers/ai/ClaudeProvider.ts
+++ b/src/providers/ai/ClaudeProvider.ts
@@ -80,6 +80,12 @@ export class ClaudeProvider implements IAiProvider {
         };
       } catch (error) {
         lastError = error;
+        logger.error('Claude generateCode failed', {
+          attempt,
+          model: this.model,
+          status: getErrorStatus(error),
+          message: error instanceof Error ? error.message : String(error),
+        });
         if (attempt < MAX_RETRIES && isRetryableError(error)) {
           continue;
         }
@@ -137,6 +143,12 @@ export class ClaudeProvider implements IAiProvider {
         };
       } catch (error) {
         lastError = error;
+        logger.error('Claude generateCodeStream failed', {
+          attempt,
+          model: this.model,
+          status: getErrorStatus(error),
+          message: error instanceof Error ? error.message : String(error),
+        });
         if (attempt < MAX_RETRIES && isRetryableError(error)) {
           continue;
         }


### PR DESCRIPTION
## Summary
- ClaudeProvider에 상세 에러 로깅 추가 (model, status, message)
- suggest-context/suggest-apis에서 AI generateCode() 실패 시 500 대신 빈 배열로 graceful 응답
- Railway 배포 로그에서 400 에러 원인 추적 가능하도록 개선

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] 전체 테스트 176/176 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)