### PR TITLE
fix: 전체 AI 파이프라인 품질 강화 + Health 체크 Claude 대응

### DIFF
--- a/src/__tests__/api/health.test.ts
+++ b/src/__tests__/api/health.test.ts
@@ -42,6 +42,7 @@ describe('GET /api/v1/health', () => {
     expect(['healthy', 'degraded']).toContain(body.status);
     expect(body.checks.database).toBe('ok');
     expect(body.checks.ai).toBeDefined();
+    expect(body.checks.aiProvider).toBeDefined();
     expect(body.checks.deploy).toBeDefined();
     expect(body.timestamp).toBeDefined();
     expect(body.usage).toBeDefined();

--- a/src/__tests__/api/suggest-context.test.ts
+++ b/src/__tests__/api/suggest-context.test.ts
@@ -18,10 +18,6 @@ vi.mock('@/lib/utils/logger', () => ({
 
 // ---------- Test data ----------
 const mockUser = { id: 'user-1', email: 'test@test.com' };
-const mockApis = [
-  { name: 'Weather API', description: '날씨 정보 제공', category: 'weather' },
-  { name: 'News API', description: '뉴스 기사 제공', category: 'news' },
-];
 
 function makeSupabaseMock(user: typeof mockUser | null = mockUser) {
   return { auth: { getUser: vi.fn().mockResolvedValue({ data: { user } }) } };
@@ -43,6 +39,33 @@ function makeRawRequest(rawBody: string) {
   });
 }
 
+function mockAiProvider(content: string) {
+  return {
+    name: 'claude',
+    generateCode: vi.fn().mockResolvedValue({
+      content,
+      provider: 'claude',
+      model: 'claude-haiku-4-5',
+      durationMs: 500,
+      tokensUsed: { input: 50, output: 100 },
+    }),
+  };
+}
+
+function mockAiProviderError(error: Error) {
+  return {
+    name: 'claude',
+    generateCode: vi.fn().mockRejectedValue(error),
+  };
+}
+
+async function setupProvider(providerMock: ReturnType<typeof mockAiProvider>) {
+  const { createClient } = await import('@/lib/supabase/server');
+  vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
+  const { AiProviderFactory } = await import('@/providers/ai/AiProviderFactory');
+  (AiProviderFactory.createForTask as ReturnType<typeof vi.fn>).mockReturnValue(providerMock);
+}
+
 // ---------- Tests ----------
 describe('POST /api/v1/suggest-context', () => {
   beforeEach(() => {
@@ -50,22 +73,23 @@ describe('POST /api/v1/suggest-context', () => {
     vi.resetModules();
   });
 
+  // ── 인증 ──
   it('비로그인 시 401을 반환한다', async () => {
     const { createClient } = await import('@/lib/supabase/server');
     vi.mocked(createClient).mockResolvedValue(makeSupabaseMock(null) as never);
 
     const { POST } = await import('@/app/api/v1/suggest-context/route');
-    const response = await POST(makeRequest({ apis: mockApis }));
+    const response = await POST(makeRequest({ apis: [{ name: 'A', description: 'd', category: 'c' }] }));
     expect(response.status).toBe(401);
   });
 
+  // ── 입력 유효성 ──
   it('apis 없으면 400을 반환한다', async () => {
     const { createClient } = await import('@/lib/supabase/server');
     vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
 
     const { POST } = await import('@/app/api/v1/suggest-context/route');
-    const response = await POST(makeRequest({}));
-    expect(response.status).toBe(400);
+    expect((await POST(makeRequest({}))).status).toBe(400);
   });
 
   it('apis 빈 배열이면 400을 반환한다', async () => {
@@ -73,8 +97,7 @@ describe('POST /api/v1/suggest-context', () => {
     vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
 
     const { POST } = await import('@/app/api/v1/suggest-context/route');
-    const response = await POST(makeRequest({ apis: [] }));
-    expect(response.status).toBe(400);
+    expect((await POST(makeRequest({ apis: [] }))).status).toBe(400);
   });
 
   it('apis 6개 초과 시 400을 반환한다', async () => {
@@ -82,14 +105,10 @@ describe('POST /api/v1/suggest-context', () => {
     vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
 
     const sixApis = Array.from({ length: 6 }, (_, i) => ({
-      name: `API ${i}`,
-      description: `desc ${i}`,
-      category: `cat ${i}`,
+      name: `API ${i}`, description: `desc`, category: `cat`,
     }));
-
     const { POST } = await import('@/app/api/v1/suggest-context/route');
-    const response = await POST(makeRequest({ apis: sixApis }));
-    expect(response.status).toBe(400);
+    expect((await POST(makeRequest({ apis: sixApis }))).status).toBe(400);
   });
 
   it('잘못된 JSON이면 400을 반환한다', async () => {
@@ -97,63 +116,188 @@ describe('POST /api/v1/suggest-context', () => {
     vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
 
     const { POST } = await import('@/app/api/v1/suggest-context/route');
-    const response = await POST(makeRawRequest('not-json'));
-    expect(response.status).toBe(400);
+    expect((await POST(makeRawRequest('not-json'))).status).toBe(400);
   });
 
-  it('정상 요청 시 suggestions를 반환한다', async () => {
-    const { createClient } = await import('@/lib/supabase/server');
-    vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
-
-    const suggestions = [
-      '날씨와 뉴스를 결합한 대시보드를 만들고 싶어요',
-      '지역별 날씨에 맞는 뉴스를 추천해주는 서비스',
-      '날씨 변화에 따른 뉴스 트렌드 분석 도구',
-    ];
-
-    const { AiProviderFactory } = await import('@/providers/ai/AiProviderFactory');
-    (AiProviderFactory.createForTask as ReturnType<typeof vi.fn>).mockReturnValue({
-      name: 'xai',
-      generateCode: vi.fn().mockResolvedValue({
-        content: JSON.stringify(suggestions),
-        provider: 'xai',
-        model: 'grok-beta',
-        durationMs: 800,
-        tokensUsed: { input: 50, output: 100 },
-      }),
-    });
+  // ── API 1개 선택 시나리오 (핵심 테스트) ──
+  it('API 1개만 선택해도 suggestions를 반환한다', async () => {
+    const suggestions = ['날씨 대시보드를 만들고 싶어요', '일기예보 알림 서비스', '여행 날씨 플래너'];
+    await setupProvider(mockAiProvider(JSON.stringify(suggestions)));
 
     const { POST } = await import('@/app/api/v1/suggest-context/route');
-    const response = await POST(makeRequest({ apis: mockApis }));
+    const response = await POST(makeRequest({
+      apis: [{ name: 'Weather API', description: '날씨 정보', category: 'weather' }],
+    }));
 
     expect(response.status).toBe(200);
     const json = await response.json();
     expect(json.success).toBe(true);
-    expect(json.data.suggestions).toEqual(suggestions);
+    expect(json.data.suggestions).toHaveLength(3);
   });
 
-  it('AI 응답 파싱 실패 시 빈 배열을 반환한다', async () => {
+  it('API 1개 선택 시 createForTask를 suggestion 태스크로 호출한다', async () => {
+    await setupProvider(mockAiProvider('["a","b","c"]'));
+
+    const { AiProviderFactory } = await import('@/providers/ai/AiProviderFactory');
+    const { POST } = await import('@/app/api/v1/suggest-context/route');
+    await POST(makeRequest({
+      apis: [{ name: 'Weather API', description: '날씨', category: 'weather' }],
+    }));
+
+    expect(AiProviderFactory.createForTask).toHaveBeenCalledWith('suggestion');
+  });
+
+  // ── 다양한 API 조합 ──
+  it('API 2개 선택 시 정상 동작한다', async () => {
+    await setupProvider(mockAiProvider('["아이디어1","아이디어2","아이디어3"]'));
+
+    const { POST } = await import('@/app/api/v1/suggest-context/route');
+    const response = await POST(makeRequest({
+      apis: [
+        { name: 'Weather API', description: '날씨', category: 'weather' },
+        { name: 'News API', description: '뉴스', category: 'news' },
+      ],
+    }));
+
+    const json = await response.json();
+    expect(json.data.suggestions).toHaveLength(3);
+  });
+
+  it('API 5개 (최대) 선택 시 정상 동작한다', async () => {
+    await setupProvider(mockAiProvider('["a","b","c"]'));
+
+    const fiveApis = Array.from({ length: 5 }, (_, i) => ({
+      name: `API${i}`, description: `desc${i}`, category: `cat${i}`,
+    }));
+    const { POST } = await import('@/app/api/v1/suggest-context/route');
+    const response = await POST(makeRequest({ apis: fiveApis }));
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.data.suggestions).toHaveLength(3);
+  });
+
+  // ── AI 응답 파싱 엣지 케이스 ──
+  it('AI 응답이 코드 블록으로 감싸져 있어도 파싱한다', async () => {
+    await setupProvider(mockAiProvider('```json\n["제안1","제안2","제안3"]\n```'));
+
+    const { POST } = await import('@/app/api/v1/suggest-context/route');
+    const response = await POST(makeRequest({
+      apis: [{ name: 'A', description: 'd', category: 'c' }],
+    }));
+
+    const json = await response.json();
+    expect(json.data.suggestions).toHaveLength(3);
+  });
+
+  it('AI 응답에 추가 텍스트가 있어도 JSON 배열을 추출한다', async () => {
+    await setupProvider(mockAiProvider('다음은 제안입니다:\n["제안A","제안B","제안C"]\n참고하세요.'));
+
+    const { POST } = await import('@/app/api/v1/suggest-context/route');
+    const response = await POST(makeRequest({
+      apis: [{ name: 'A', description: 'd', category: 'c' }],
+    }));
+
+    const json = await response.json();
+    expect(json.data.suggestions).toEqual(['제안A', '제안B', '제안C']);
+  });
+
+  it('AI 응답이 JSON이 아니면 빈 배열을 반환한다', async () => {
+    await setupProvider(mockAiProvider('이것은 JSON이 아닌 일반 텍스트입니다.'));
+
+    const { POST } = await import('@/app/api/v1/suggest-context/route');
+    const response = await POST(makeRequest({
+      apis: [{ name: 'A', description: 'd', category: 'c' }],
+    }));
+
+    const json = await response.json();
+    expect(json.success).toBe(true);
+    expect(json.data.suggestions).toEqual([]);
+  });
+
+  it('AI 응답이 빈 배열이면 빈 배열을 반환한다', async () => {
+    await setupProvider(mockAiProvider('[]'));
+
+    const { POST } = await import('@/app/api/v1/suggest-context/route');
+    const response = await POST(makeRequest({
+      apis: [{ name: 'A', description: 'd', category: 'c' }],
+    }));
+
+    const json = await response.json();
+    expect(json.data.suggestions).toEqual([]);
+  });
+
+  it('AI 응답이 4개 이상이면 3개만 반환한다', async () => {
+    await setupProvider(mockAiProvider('["a","b","c","d","e"]'));
+
+    const { POST } = await import('@/app/api/v1/suggest-context/route');
+    const response = await POST(makeRequest({
+      apis: [{ name: 'A', description: 'd', category: 'c' }],
+    }));
+
+    const json = await response.json();
+    expect(json.data.suggestions).toHaveLength(3);
+  });
+
+  // ── AI Provider 에러 처리 ──
+  it('AI Provider 생성 실패 시 빈 배열을 반환한다 (500 아님)', async () => {
     const { createClient } = await import('@/lib/supabase/server');
     vi.mocked(createClient).mockResolvedValue(makeSupabaseMock() as never);
 
     const { AiProviderFactory } = await import('@/providers/ai/AiProviderFactory');
-    (AiProviderFactory.createForTask as ReturnType<typeof vi.fn>).mockReturnValue({
-      name: 'xai',
-      generateCode: vi.fn().mockResolvedValue({
-        content: '이것은 JSON이 아닌 일반 텍스트 응답입니다.',
-        provider: 'xai',
-        model: 'grok-beta',
-        durationMs: 800,
-        tokensUsed: { input: 50, output: 100 },
-      }),
+    (AiProviderFactory.createForTask as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('ANTHROPIC_API_KEY is not set');
     });
 
     const { POST } = await import('@/app/api/v1/suggest-context/route');
-    const response = await POST(makeRequest({ apis: mockApis }));
+    const response = await POST(makeRequest({
+      apis: [{ name: 'A', description: 'd', category: 'c' }],
+    }));
 
     expect(response.status).toBe(200);
     const json = await response.json();
-    expect(json.success).toBe(true);
+    expect(json.data.suggestions).toEqual([]);
+  });
+
+  it('AI generateCode 실패 시 빈 배열을 반환한다 (400 에러)', async () => {
+    const error400 = Object.assign(new Error('invalid_request_error'), { status: 400 });
+    await setupProvider(mockAiProviderError(error400));
+
+    const { POST } = await import('@/app/api/v1/suggest-context/route');
+    const response = await POST(makeRequest({
+      apis: [{ name: 'A', description: 'd', category: 'c' }],
+    }));
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.data.suggestions).toEqual([]);
+  });
+
+  it('AI generateCode 타임아웃 시 빈 배열을 반환한다', async () => {
+    const timeoutError = new Error('Request timed out');
+    await setupProvider(mockAiProviderError(timeoutError));
+
+    const { POST } = await import('@/app/api/v1/suggest-context/route');
+    const response = await POST(makeRequest({
+      apis: [{ name: 'A', description: 'd', category: 'c' }],
+    }));
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.data.suggestions).toEqual([]);
+  });
+
+  it('AI generateCode 429 에러 시 빈 배열을 반환한다', async () => {
+    const error429 = Object.assign(new Error('rate limited'), { status: 429 });
+    await setupProvider(mockAiProviderError(error429));
+
+    const { POST } = await import('@/app/api/v1/suggest-context/route');
+    const response = await POST(makeRequest({
+      apis: [{ name: 'A', description: 'd', category: 'c' }],
+    }));
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
     expect(json.data.suggestions).toEqual([]);
   });
 });

--- a/src/app/api/v1/health/route.ts
+++ b/src/app/api/v1/health/route.ts
@@ -22,8 +22,14 @@ export async function GET(): Promise<Response> {
     status = 'unhealthy';
   }
 
-  // AI service check (verify env key is configured)
-  checks.ai = process.env.XAI_API_KEY ? 'ok' : 'unconfigured';
+  // AI service check (verify env key is configured for the active provider)
+  const aiProvider = (process.env.AI_PROVIDER as string) ?? 'claude';
+  const hasAiKey =
+    aiProvider === 'claude'
+      ? !!process.env.ANTHROPIC_API_KEY
+      : !!process.env.XAI_API_KEY;
+  checks.ai = hasAiKey ? 'ok' : 'unconfigured';
+  checks.aiProvider = aiProvider;
   if (checks.ai !== 'ok') status = status === 'healthy' ? 'degraded' : status;
 
   // Deploy service check (verify env keys are configured)

--- a/src/providers/ai/ClaudeProvider.test.ts
+++ b/src/providers/ai/ClaudeProvider.test.ts
@@ -2,15 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ClaudeProvider } from './ClaudeProvider';
 
 // Anthropic SDK mock
-const mockCreate = vi.fn().mockResolvedValue({
-  content: [{ type: 'text', text: '```html\n<p>test</p>\n```' }],
-  usage: { input_tokens: 150, output_tokens: 300 },
-});
-
+const mockCreate = vi.fn();
 const mockStreamOn = vi.fn();
-const mockFinalMessage = vi.fn().mockResolvedValue({
-  usage: { input_tokens: 150, output_tokens: 300 },
-});
+const mockFinalMessage = vi.fn();
 
 const mockStream = vi.fn().mockReturnValue({
   on: mockStreamOn,
@@ -18,29 +12,6 @@ const mockStream = vi.fn().mockReturnValue({
 });
 
 vi.mock('@anthropic-ai/sdk', () => {
-  const RateLimitError = class extends Error {
-    status = 429;
-    constructor() {
-      super('rate limited');
-      this.name = 'RateLimitError';
-    }
-  };
-  const InternalServerError = class extends Error {
-    status = 500;
-    constructor() {
-      super('internal error');
-      this.name = 'InternalServerError';
-    }
-  };
-  const APIError = class extends Error {
-    status: number;
-    constructor(status: number, message: string) {
-      super(message);
-      this.status = status;
-      this.name = 'APIError';
-    }
-  };
-
   return {
     default: vi.fn().mockImplementation(() => ({
       messages: {
@@ -48,29 +19,30 @@ vi.mock('@anthropic-ai/sdk', () => {
         stream: mockStream,
       },
     })),
-    Anthropic: {
-      RateLimitError,
-      InternalServerError,
-      APIError,
-    },
   };
 });
+
+function makeSuccessResponse(text = '```html\n<p>test</p>\n```') {
+  return {
+    content: [{ type: 'text', text }],
+    usage: { input_tokens: 150, output_tokens: 300 },
+  };
+}
 
 describe('ClaudeProvider', () => {
   let provider: ClaudeProvider;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCreate.mockResolvedValue({
-      content: [{ type: 'text', text: '```html\n<p>test</p>\n```' }],
-      usage: { input_tokens: 150, output_tokens: 300 },
-    });
+    mockCreate.mockResolvedValue(makeSuccessResponse());
     mockFinalMessage.mockResolvedValue({
       usage: { input_tokens: 150, output_tokens: 300 },
     });
+    mockStreamOn.mockImplementation(() => {});
     provider = new ClaudeProvider('test-api-key');
   });
 
+  // ── 기본 속성 ──────────────────────────────────
   it('name이 claude이다', () => {
     expect(provider.name).toBe('claude');
   });
@@ -84,21 +56,22 @@ describe('ClaudeProvider', () => {
     expect(p.model).toBe('claude-haiku-4-5');
   });
 
+  // ── generateCode() ─────────────────────────────
   describe('generateCode()', () => {
     it('AI 응답 내용을 content로 반환한다', async () => {
       const result = await provider.generateCode({ system: 'sys', user: 'user' });
       expect(result.content).toBe('```html\n<p>test</p>\n```');
     });
 
-    it('provider 이름이 claude이다', async () => {
+    it('provider와 model 정보를 반환한다', async () => {
       const result = await provider.generateCode({ system: 'sys', user: 'user' });
       expect(result.provider).toBe('claude');
+      expect(result.model).toBe('claude-sonnet-4-6');
     });
 
     it('token 사용량을 반환한다', async () => {
       const result = await provider.generateCode({ system: 'sys', user: 'user' });
-      expect(result.tokensUsed.input).toBe(150);
-      expect(result.tokensUsed.output).toBe(300);
+      expect(result.tokensUsed).toEqual({ input: 150, output: 300 });
     });
 
     it('durationMs가 0 이상이다', async () => {
@@ -106,10 +79,13 @@ describe('ClaudeProvider', () => {
       expect(result.durationMs).toBeGreaterThanOrEqual(0);
     });
 
-    it('API 에러 시 에러를 전파한다', async () => {
-      mockCreate.mockRejectedValueOnce(new Error('API 호출 실패'));
-      await expect(provider.generateCode({ system: 'sys', user: 'user' })).rejects.toThrow(
-        'API 호출 실패'
+    it('system 프롬프트를 top-level 필드로 전달한다', async () => {
+      await provider.generateCode({ system: 'test-system', user: 'test-user' });
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          system: 'test-system',
+          messages: [{ role: 'user', content: 'test-user' }],
+        })
       );
     });
 
@@ -123,17 +99,123 @@ describe('ClaudeProvider', () => {
       expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ max_tokens: 32000 }));
     });
 
-    it('system 프롬프트를 별도 필드로 전달한다', async () => {
-      await provider.generateCode({ system: 'test-system', user: 'test-user' });
+    // ── 커스텀 파라미터 ──
+    it('커스텀 temperature를 전달한다', async () => {
+      await provider.generateCode({ system: 'sys', user: 'user', temperature: 0.3 });
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ temperature: 0.3 }));
+    });
+
+    it('커스텀 maxTokens를 전달한다', async () => {
+      await provider.generateCode({ system: 'sys', user: 'user', maxTokens: 600 });
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ max_tokens: 600 }));
+    });
+
+    it('suggest-context와 동일한 파라미터로 호출한다 (temperature:0.8, maxTokens:600)', async () => {
+      await provider.generateCode({
+        system: '당신은 웹 서비스 아이디어를 제안하는 도우미입니다.',
+        user: '선택된 API:\n- Weather API: 날씨 정보 제공\n\n아이디어 3가지를 JSON 배열로 제안해주세요.',
+        temperature: 0.8,
+        maxTokens: 600,
+      });
+      expect(mockCreate).toHaveBeenCalledWith({
+        model: 'claude-sonnet-4-6',
+        system: '당신은 웹 서비스 아이디어를 제안하는 도우미입니다.',
+        messages: [{ role: 'user', content: expect.stringContaining('Weather API') }],
+        temperature: 0.8,
+        max_tokens: 600,
+      });
+    });
+
+    // ── Haiku 모델 호출 ──
+    it('Haiku 모델로 suggestion 호출이 정상 동작한다', async () => {
+      const haiku = new ClaudeProvider('key', 'claude-haiku-4-5');
+      await haiku.generateCode({ system: 'sys', user: 'user', maxTokens: 600 });
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          system: 'test-system',
-          messages: [{ role: 'user', content: 'test-user' }],
+          model: 'claude-haiku-4-5',
+          max_tokens: 600,
         })
       );
     });
+
+    // ── 응답 처리 엣지 케이스 ──
+    it('빈 content 배열 시 빈 문자열을 반환한다', async () => {
+      mockCreate.mockResolvedValueOnce({
+        content: [],
+        usage: { input_tokens: 10, output_tokens: 0 },
+      });
+      const result = await provider.generateCode({ system: 'sys', user: 'user' });
+      expect(result.content).toBe('');
+    });
+
+    it('thinking 블록이 포함된 응답에서 text만 추출한다', async () => {
+      mockCreate.mockResolvedValueOnce({
+        content: [
+          { type: 'thinking', thinking: 'reasoning...' },
+          { type: 'text', text: 'actual response' },
+        ],
+        usage: { input_tokens: 50, output_tokens: 100 },
+      });
+      const result = await provider.generateCode({ system: 'sys', user: 'user' });
+      expect(result.content).toBe('actual response');
+    });
+
+    it('JSON 배열 응답을 올바르게 반환한다 (suggest-context 시나리오)', async () => {
+      const jsonResponse = '["날씨 대시보드를 만들고 싶어요", "일기예보 알림 서비스", "여행 날씨 플래너"]';
+      mockCreate.mockResolvedValueOnce(makeSuccessResponse(jsonResponse));
+      const result = await provider.generateCode({ system: 'sys', user: 'user' });
+      expect(result.content).toBe(jsonResponse);
+      const parsed = JSON.parse(result.content);
+      expect(parsed).toHaveLength(3);
+    });
+
+    // ── 에러 처리 ──
+    it('비재시도 에러 시 즉시 전파한다', async () => {
+      mockCreate.mockRejectedValueOnce(new Error('API 호출 실패'));
+      await expect(provider.generateCode({ system: 'sys', user: 'user' })).rejects.toThrow('API 호출 실패');
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it('400 에러(invalid_request)는 재시도하지 않는다', async () => {
+      const error400 = Object.assign(new Error('invalid_request_error'), { status: 400 });
+      mockCreate.mockRejectedValue(error400);
+      await expect(provider.generateCode({ system: 'sys', user: 'user' })).rejects.toThrow();
+      expect(mockCreate).toHaveBeenCalledTimes(1); // 재시도 없이 1번만 호출
+    });
+
+    it('429 에러는 최대 2회 재시도한다', async () => {
+      const error429 = Object.assign(new Error('rate limited'), { status: 429 });
+      mockCreate.mockRejectedValue(error429);
+      await expect(provider.generateCode({ system: 'sys', user: 'user' })).rejects.toThrow();
+      expect(mockCreate).toHaveBeenCalledTimes(3); // 원본 + 2회 재시도
+    });
+
+    it('500 에러는 최대 2회 재시도한다', async () => {
+      const error500 = Object.assign(new Error('server error'), { status: 500 });
+      mockCreate.mockRejectedValue(error500);
+      await expect(provider.generateCode({ system: 'sys', user: 'user' })).rejects.toThrow();
+      expect(mockCreate).toHaveBeenCalledTimes(3);
+    });
+
+    it('재시도 중 성공하면 결과를 반환한다', async () => {
+      const error502 = Object.assign(new Error('bad gateway'), { status: 502 });
+      mockCreate
+        .mockRejectedValueOnce(error502)
+        .mockResolvedValueOnce(makeSuccessResponse('recovered'));
+      const result = await provider.generateCode({ system: 'sys', user: 'user' });
+      expect(result.content).toBe('recovered');
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it('네트워크 에러는 재시도한다', async () => {
+      const fetchError = Object.assign(new Error('fetch failed'), { code: 'ECONNRESET' });
+      mockCreate.mockRejectedValue(fetchError);
+      await expect(provider.generateCode({ system: 'sys', user: 'user' })).rejects.toThrow();
+      expect(mockCreate).toHaveBeenCalledTimes(3);
+    });
   });
 
+  // ── generateCodeStream() ───────────────────────
   describe('generateCodeStream()', () => {
     it('스트리밍 응답을 누적하여 반환한다', async () => {
       mockStreamOn.mockImplementation((event: string, callback: (text: string) => void) => {
@@ -151,40 +233,143 @@ describe('ClaudeProvider', () => {
 
       expect(chunks).toEqual(['chunk1', 'chunk2']);
       expect(result.content).toBe('chunk1chunk2');
-      expect(result.tokensUsed.input).toBe(150);
-      expect(result.tokensUsed.output).toBe(300);
+      expect(result.tokensUsed).toEqual({ input: 150, output: 300 });
     });
 
     it('provider와 model 정보를 반환한다', async () => {
+      const result = await provider.generateCodeStream(
+        { system: 'sys', user: 'user' },
+        () => {}
+      );
+      expect(result.provider).toBe('claude');
+      expect(result.model).toBe('claude-sonnet-4-6');
+    });
+
+    it('stream에 올바른 파라미터를 전달한다', async () => {
+      await provider.generateCodeStream({ system: 'sys', user: 'user' }, () => {});
+      expect(mockStream).toHaveBeenCalledWith({
+        model: 'claude-sonnet-4-6',
+        system: 'sys',
+        messages: [{ role: 'user', content: 'user' }],
+        temperature: 0.7,
+        max_tokens: 32000,
+      });
+    });
+
+    it('커스텀 파라미터로 스트리밍한다', async () => {
+      await provider.generateCodeStream(
+        { system: 'sys', user: 'user', temperature: 0.5, maxTokens: 16000 },
+        () => {}
+      );
+      expect(mockStream).toHaveBeenCalledWith(expect.objectContaining({
+        temperature: 0.5,
+        max_tokens: 16000,
+      }));
+    });
+
+    it('빈 스트림도 정상 처리한다', async () => {
       mockStreamOn.mockImplementation(() => {});
+      const result = await provider.generateCodeStream(
+        { system: 'sys', user: 'user' },
+        () => {}
+      );
+      expect(result.content).toBe('');
+    });
+
+    it('긴 HTML 스트림을 정상 누적한다', async () => {
+      const htmlChunks = ['<!DOCTYPE html>', '<html>', '<head>', '</head>', '<body>', '<p>Hello</p>', '</body>', '</html>'];
+      mockStreamOn.mockImplementation((event: string, callback: (text: string) => void) => {
+        if (event === 'text') {
+          htmlChunks.forEach(c => callback(c));
+        }
+      });
 
       const result = await provider.generateCodeStream(
         { system: 'sys', user: 'user' },
         () => {}
       );
+      expect(result.content).toBe(htmlChunks.join(''));
+    });
 
+    it('스트림 에러 시 재시도한다 (502)', async () => {
+      const error502 = Object.assign(new Error('bad gateway'), { status: 502 });
+      mockStream
+        .mockImplementationOnce(() => { throw error502; })
+        .mockReturnValueOnce({ on: mockStreamOn, finalMessage: mockFinalMessage });
+
+      const result = await provider.generateCodeStream(
+        { system: 'sys', user: 'user' },
+        () => {}
+      );
       expect(result.provider).toBe('claude');
-      expect(result.model).toBe('claude-sonnet-4-6');
+      expect(mockStream).toHaveBeenCalledTimes(2);
     });
   });
 
+  // ── checkAvailability() ────────────────────────
   describe('checkAvailability()', () => {
     it('API 성공 시 available: true를 반환한다', async () => {
       const result = await provider.checkAvailability();
       expect(result.available).toBe(true);
     });
 
+    it('max_tokens: 1로 최소 토큰만 사용한다', async () => {
+      await provider.checkAvailability();
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ max_tokens: 1 }));
+    });
+
     it('429 에러 시 available: false, remainingQuota: 0을 반환한다', async () => {
       mockCreate.mockRejectedValueOnce({ status: 429 });
       const result = await provider.checkAvailability();
-      expect(result.available).toBe(false);
-      expect(result.remainingQuota).toBe(0);
+      expect(result).toEqual({ available: false, remainingQuota: 0 });
     });
 
-    it('기타 에러 시 available: false를 반환한다', async () => {
+    it('401 에러 시 available: false를 반환한다 (API 키 오류)', async () => {
+      mockCreate.mockRejectedValueOnce({ status: 401 });
+      const result = await provider.checkAvailability();
+      expect(result).toEqual({ available: false });
+    });
+
+    it('네트워크 에러 시 available: false를 반환한다', async () => {
       mockCreate.mockRejectedValueOnce(new Error('network error'));
       const result = await provider.checkAvailability();
-      expect(result.available).toBe(false);
+      expect(result).toEqual({ available: false });
+    });
+  });
+
+  // ── API 파라미터 무결성 (다양한 실제 시나리오) ──
+  describe('API 파라미터 무결성', () => {
+    it('한국어 시스템 프롬프트를 올바르게 전달한다', async () => {
+      const koreanSystem = '당신은 웹 서비스 아이디어를 제안하는 도우미입니다.\n규칙:\n- 한국어로 작성';
+      await provider.generateCode({ system: koreanSystem, user: '테스트' });
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ system: koreanSystem }));
+    });
+
+    it('매우 긴 시스템 프롬프트도 정상 전달한다 (312줄 프롬프트 시뮬레이션)', async () => {
+      const longPrompt = Array.from({ length: 312 }, (_, i) => `규칙 ${i + 1}: 내용`).join('\n');
+      await provider.generateCode({ system: longPrompt, user: 'user' });
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ system: longPrompt }));
+    });
+
+    it('API 1개만 포함된 짧은 user 프롬프트도 정상 전달한다', async () => {
+      const shortUser = '선택된 API:\n- Weather API: 날씨 조회\n\n아이디어 3가지를 제안해주세요.';
+      await provider.generateCode({ system: 'sys', user: shortUser, temperature: 0.8, maxTokens: 600 });
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+        messages: [{ role: 'user', content: shortUser }],
+        temperature: 0.8,
+        max_tokens: 600,
+      }));
+    });
+
+    it('model 필드가 정확히 전달된다 (Haiku)', async () => {
+      const haiku = new ClaudeProvider('key', 'claude-haiku-4-5');
+      await haiku.generateCode({ system: 's', user: 'u' });
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-haiku-4-5' }));
+    });
+
+    it('model 필드가 정확히 전달된다 (Sonnet)', async () => {
+      await provider.generateCode({ system: 's', user: 'u' });
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-sonnet-4-6' }));
     });
   });
 });


### PR DESCRIPTION
## Summary
- Health 체크: `XAI_API_KEY` → `AI_PROVIDER` 기반으로 올바른 키 확인
- suggest-context/suggest-apis: `generateCode()` 호출 실패도 graceful 처리 (빈 배열 반환)
- ClaudeProvider 에러 로깅: model, status, message 상세 출력
- 테스트 대폭 강화: 211개 (기존 176개)

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] 전체 테스트 211/211 통과
- [x] 10회 반복 검증 전체 통과, flaky 0건
- [x] ClaudeProvider: 35개 (리트라이/파라미터 무결성/엣지케이스/에러 시나리오)
- [x] suggest-context: 19개 (API 1개~5개 선택/AI 실패/파싱 엣지케이스)

🤖 Generated with [Claude Code](https://claude.com/claude-code)