### PR TITLE
fix: Claude 모델 ID를 정식 ID로 변경 (400 에러 해결)

### DIFF
--- a/src/providers/ai/AiProviderFactory.test.ts
+++ b/src/providers/ai/AiProviderFactory.test.ts
@@ -18,7 +18,7 @@ vi.mock('./GrokProvider', () => ({
 vi.mock('./ClaudeProvider', () => ({
   ClaudeProvider: vi.fn().mockImplementation((_apiKey: string, model?: string) => ({
     name: 'claude',
-    model: model ?? 'claude-sonnet-4-6',
+    model: model ?? 'claude-sonnet-4-6-20250514',
     generateCode: vi.fn(),
     generateCodeStream: vi.fn(),
     checkAvailability: vi.fn().mockResolvedValue({ available: true }),
@@ -107,14 +107,14 @@ describe('AiProviderFactory.createForTask()', () => {
     process.env.ANTHROPIC_API_KEY = 'test-key';
     delete process.env.AI_PROVIDER;
     const provider = AiProviderFactory.createForTask('generation');
-    expect(provider.model).toBe('claude-sonnet-4-6');
+    expect(provider.model).toBe('claude-sonnet-4-6-20250514');
   });
 
   it('suggestion 태스크는 Haiku 모델을 사용한다', () => {
     process.env.ANTHROPIC_API_KEY = 'test-key';
     delete process.env.AI_PROVIDER;
     const provider = AiProviderFactory.createForTask('suggestion');
-    expect(provider.model).toBe('claude-haiku-4-5');
+    expect(provider.model).toBe('claude-haiku-4-5-20251001');
   });
 
   it('같은 태스크는 싱글톤으로 반환된다', () => {

--- a/src/providers/ai/AiProviderFactory.ts
+++ b/src/providers/ai/AiProviderFactory.ts
@@ -56,7 +56,9 @@ export class AiProviderFactory {
     const apiKey = process.env.ANTHROPIC_API_KEY;
     if (!apiKey) throw new Error('ANTHROPIC_API_KEY is not set');
 
-    const model = task === 'suggestion' ? 'claude-haiku-4-5' : 'claude-sonnet-4-6';
+    const model = task === 'suggestion'
+      ? (process.env.CLAUDE_SUGGESTION_MODEL ?? 'claude-haiku-4-5-20251001')
+      : (process.env.CLAUDE_GENERATION_MODEL ?? 'claude-sonnet-4-6-20250514');
     const provider = new ClaudeProvider(apiKey, model);
 
     this.providers.set(cacheKey, provider);

--- a/src/providers/ai/ClaudeProvider.test.ts
+++ b/src/providers/ai/ClaudeProvider.test.ts
@@ -47,13 +47,13 @@ describe('ClaudeProvider', () => {
     expect(provider.name).toBe('claude');
   });
 
-  it('기본 model이 claude-sonnet-4-6이다', () => {
-    expect(provider.model).toBe('claude-sonnet-4-6');
+  it('기본 model이 claude-sonnet-4-6-20250514이다', () => {
+    expect(provider.model).toBe('claude-sonnet-4-6-20250514');
   });
 
   it('커스텀 모델을 지정할 수 있다', () => {
-    const p = new ClaudeProvider('key', 'claude-haiku-4-5');
-    expect(p.model).toBe('claude-haiku-4-5');
+    const p = new ClaudeProvider('key', 'claude-haiku-4-5-20251001');
+    expect(p.model).toBe('claude-haiku-4-5-20251001');
   });
 
   // ── generateCode() ─────────────────────────────
@@ -66,7 +66,7 @@ describe('ClaudeProvider', () => {
     it('provider와 model 정보를 반환한다', async () => {
       const result = await provider.generateCode({ system: 'sys', user: 'user' });
       expect(result.provider).toBe('claude');
-      expect(result.model).toBe('claude-sonnet-4-6');
+      expect(result.model).toBe('claude-sonnet-4-6-20250514');
     });
 
     it('token 사용량을 반환한다', async () => {
@@ -118,7 +118,7 @@ describe('ClaudeProvider', () => {
         maxTokens: 600,
       });
       expect(mockCreate).toHaveBeenCalledWith({
-        model: 'claude-sonnet-4-6',
+        model: 'claude-sonnet-4-6-20250514',
         system: '당신은 웹 서비스 아이디어를 제안하는 도우미입니다.',
         messages: [{ role: 'user', content: expect.stringContaining('Weather API') }],
         temperature: 0.8,
@@ -128,11 +128,11 @@ describe('ClaudeProvider', () => {
 
     // ── Haiku 모델 호출 ──
     it('Haiku 모델로 suggestion 호출이 정상 동작한다', async () => {
-      const haiku = new ClaudeProvider('key', 'claude-haiku-4-5');
+      const haiku = new ClaudeProvider('key', 'claude-haiku-4-5-20251001');
       await haiku.generateCode({ system: 'sys', user: 'user', maxTokens: 600 });
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'claude-haiku-4-5',
+          model: 'claude-haiku-4-5-20251001',
           max_tokens: 600,
         })
       );
@@ -242,13 +242,13 @@ describe('ClaudeProvider', () => {
         () => {}
       );
       expect(result.provider).toBe('claude');
-      expect(result.model).toBe('claude-sonnet-4-6');
+      expect(result.model).toBe('claude-sonnet-4-6-20250514');
     });
 
     it('stream에 올바른 파라미터를 전달한다', async () => {
       await provider.generateCodeStream({ system: 'sys', user: 'user' }, () => {});
       expect(mockStream).toHaveBeenCalledWith({
-        model: 'claude-sonnet-4-6',
+        model: 'claude-sonnet-4-6-20250514',
         system: 'sys',
         messages: [{ role: 'user', content: 'user' }],
         temperature: 0.7,
@@ -362,14 +362,14 @@ describe('ClaudeProvider', () => {
     });
 
     it('model 필드가 정확히 전달된다 (Haiku)', async () => {
-      const haiku = new ClaudeProvider('key', 'claude-haiku-4-5');
+      const haiku = new ClaudeProvider('key', 'claude-haiku-4-5-20251001');
       await haiku.generateCode({ system: 's', user: 'u' });
-      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-haiku-4-5' }));
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-haiku-4-5-20251001' }));
     });
 
     it('model 필드가 정확히 전달된다 (Sonnet)', async () => {
       await provider.generateCode({ system: 's', user: 'u' });
-      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-sonnet-4-6' }));
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-sonnet-4-6-20250514' }));
     });
   });
 });

--- a/src/providers/ai/ClaudeProvider.ts
+++ b/src/providers/ai/ClaudeProvider.ts
@@ -35,7 +35,7 @@ export class ClaudeProvider implements IAiProvider {
   readonly model: string;
   private client: Anthropic;
 
-  constructor(apiKey: string, model = 'claude-sonnet-4-6') {
+  constructor(apiKey: string, model = 'claude-sonnet-4-6-20250514') {
     this.client = new Anthropic({ apiKey });
     this.model = model;
   }


### PR DESCRIPTION
## Summary
Railway 로그에서 확인된 **400 invalid_request_error**의 근본 원인:
Anthropic API가 모델 별칭(`claude-haiku-4-5`)을 인식하지 못함

- `claude-haiku-4-5` → `claude-haiku-4-5-20251001`
- `claude-sonnet-4-6` → `claude-sonnet-4-6-20250514`
- 환경변수 오버라이드 지원 (`CLAUDE_SUGGESTION_MODEL`, `CLAUDE_GENERATION_MODEL`)

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] 전체 테스트 211/211 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)