### PR TITLE
fix: Anthropic API 에러 상세 로깅 + Health 실제 검증

### DIFF
--- a/src/app/api/v1/health/route.ts
+++ b/src/app/api/v1/health/route.ts
@@ -22,14 +22,17 @@ export async function GET(): Promise<Response> {
     status = 'unhealthy';
   }
 
-  // AI service check (verify env key is configured for the active provider)
+  // AI service check (actual API validation)
   const aiProvider = (process.env.AI_PROVIDER as string) ?? 'claude';
-  const hasAiKey =
-    aiProvider === 'claude'
-      ? !!process.env.ANTHROPIC_API_KEY
-      : !!process.env.XAI_API_KEY;
-  checks.ai = hasAiKey ? 'ok' : 'unconfigured';
   checks.aiProvider = aiProvider;
+  try {
+    const { AiProviderFactory } = await import('@/providers/ai/AiProviderFactory');
+    const provider = AiProviderFactory.createForTask('suggestion');
+    const { available } = await provider.checkAvailability();
+    checks.ai = available ? 'ok' : 'unavailable';
+  } catch {
+    checks.ai = 'unconfigured';
+  }
   if (checks.ai !== 'ok') status = status === 'healthy' ? 'degraded' : status;
 
   // Deploy service check (verify env keys are configured)

--- a/src/providers/ai/ClaudeProvider.ts
+++ b/src/providers/ai/ClaudeProvider.ts
@@ -14,6 +14,19 @@ function getErrorStatus(error: unknown): number | undefined {
   return undefined;
 }
 
+function getErrorDetail(error: unknown): string {
+  // Anthropic SDK: error.error?.message contains the API's reason
+  if (error !== null && typeof error === 'object') {
+    const e = error as Record<string, unknown>;
+    if (e.error && typeof e.error === 'object') {
+      const apiError = e.error as Record<string, unknown>;
+      if (typeof apiError.message === 'string') return apiError.message;
+    }
+  }
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
 function isRetryableError(error: unknown): boolean {
   const status = getErrorStatus(error);
   if (status !== undefined && RETRYABLE_STATUS_CODES.has(status)) {
@@ -84,7 +97,7 @@ export class ClaudeProvider implements IAiProvider {
           attempt,
           model: this.model,
           status: getErrorStatus(error),
-          message: error instanceof Error ? error.message : String(error),
+          detail: getErrorDetail(error),
         });
         if (attempt < MAX_RETRIES && isRetryableError(error)) {
           continue;


### PR DESCRIPTION
## Summary
- ClaudeProvider: `error.error.message`(Anthropic API 상세 원인)을 `detail` 필드로 로깅
- Health 체크: 환경변수 존재 확인 → 실제 API ping 검증으로 변경
- 배포 후 Railway 로그에서 400 에러의 **정확한 원인 문구**를 확인 가능

## Test plan
- [x] 전체 테스트 211/211 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)