### PR TITLE
fix: suggestion 모델을 Sonnet으로 통일 — 컨텍스트 추천 실패 해결

### DIFF
--- a/src/providers/ai/AiProviderFactory.test.ts
+++ b/src/providers/ai/AiProviderFactory.test.ts
@@ -79,11 +79,11 @@ describe('AiProviderFactory.createForTask()', () => {
     expect(provider.model).toBe('claude-sonnet-4-6-20250514');
   });
 
-  it('suggestion 태스크는 Haiku 모델을 사용한다', () => {
+  it('suggestion 태스크도 Sonnet 모델을 기본 사용한다', () => {
     process.env.ANTHROPIC_API_KEY = 'test-key';
     delete process.env.AI_PROVIDER;
     const provider = AiProviderFactory.createForTask('suggestion');
-    expect(provider.model).toBe('claude-haiku-4-5-20251001');
+    expect(provider.model).toBe('claude-sonnet-4-6-20250514');
   });
 
   it('같은 태스크는 싱글톤으로 반환된다', () => {

--- a/src/providers/ai/AiProviderFactory.ts
+++ b/src/providers/ai/AiProviderFactory.ts
@@ -41,7 +41,7 @@ export class AiProviderFactory {
     if (!apiKey) throw new Error('ANTHROPIC_API_KEY is not set');
 
     const model = task === 'suggestion'
-      ? (process.env.CLAUDE_SUGGESTION_MODEL ?? 'claude-haiku-4-5-20251001')
+      ? (process.env.CLAUDE_SUGGESTION_MODEL ?? 'claude-sonnet-4-6-20250514')
       : (process.env.CLAUDE_GENERATION_MODEL ?? 'claude-sonnet-4-6-20250514');
     const provider = new ClaudeProvider(apiKey, model);
 


### PR DESCRIPTION
## Summary
- Haiku 모델 접근 문제로 컨텍스트 추천("선택한 API 기반 AI 추천")이 실패하던 버그 수정
- suggestion 태스크의 기본 모델을 동작이 확인된 Sonnet으로 변경
- 필요 시 `CLAUDE_SUGGESTION_MODEL` 환경변수로 모델 변경 가능

## Test plan
- [x] 전체 테스트 17파일 194개 통과

https://claude.ai/code/session_01WrpvoXQAbcBCu3zs9mMk42