### PR TITLE
fix: 컨텍스트 추천 에러를 명확한 오류 응답으로 변경

### DIFF
--- a/src/__tests__/api/suggest-context.test.ts
+++ b/src/__tests__/api/suggest-context.test.ts
@@ -254,12 +254,13 @@ describe('POST /api/v1/suggest-context', () => {
       apis: [{ name: 'A', description: 'd', category: 'c' }],
     }));
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(503);
     const json = await response.json();
-    expect(json.data.suggestions).toEqual([]);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('AI_UNAVAILABLE');
   });
 
-  it('AI generateCode 실패 시 빈 배열을 반환한다 (400 에러)', async () => {
+  it('AI generateCode 실패 시 502를 반환한다', async () => {
     const error400 = Object.assign(new Error('invalid_request_error'), { status: 400 });
     await setupProvider(mockAiProviderError(error400));
 
@@ -268,12 +269,13 @@ describe('POST /api/v1/suggest-context', () => {
       apis: [{ name: 'A', description: 'd', category: 'c' }],
     }));
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(502);
     const json = await response.json();
-    expect(json.data.suggestions).toEqual([]);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('AI_GENERATION_FAILED');
   });
 
-  it('AI generateCode 타임아웃 시 빈 배열을 반환한다', async () => {
+  it('AI generateCode 타임아웃 시 502를 반환한다', async () => {
     const timeoutError = new Error('Request timed out');
     await setupProvider(mockAiProviderError(timeoutError));
 
@@ -282,12 +284,12 @@ describe('POST /api/v1/suggest-context', () => {
       apis: [{ name: 'A', description: 'd', category: 'c' }],
     }));
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(502);
     const json = await response.json();
-    expect(json.data.suggestions).toEqual([]);
+    expect(json.success).toBe(false);
   });
 
-  it('AI generateCode 429 에러 시 빈 배열을 반환한다', async () => {
+  it('AI generateCode 429 에러 시 502를 반환한다', async () => {
     const error429 = Object.assign(new Error('rate limited'), { status: 429 });
     await setupProvider(mockAiProviderError(error429));
 
@@ -296,8 +298,8 @@ describe('POST /api/v1/suggest-context', () => {
       apis: [{ name: 'A', description: 'd', category: 'c' }],
     }));
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(502);
     const json = await response.json();
-    expect(json.data.suggestions).toEqual([]);
+    expect(json.success).toBe(false);
   });
 });

--- a/src/app/(main)/builder/page.tsx
+++ b/src/app/(main)/builder/page.tsx
@@ -260,10 +260,15 @@ export default function BuilderPage() {
           })),
         }),
       });
-      if (!res.ok) throw new Error('Failed to fetch suggestions');
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => ({}));
+        console.error('[suggest-context]', res.status, errBody?.error?.message ?? 'Unknown error');
+        throw new Error(errBody?.error?.message ?? `HTTP ${res.status}`);
+      }
       const data = await res.json();
       setSuggestions(data.data?.suggestions ?? []);
-    } catch {
+    } catch (err) {
+      console.error('[suggest-context] failed:', err instanceof Error ? err.message : err);
       setSuggestions([]);
     } finally {
       setIsSuggestionsLoading(false);

--- a/src/app/api/v1/suggest-context/route.ts
+++ b/src/app/api/v1/suggest-context/route.ts
@@ -48,10 +48,12 @@ export async function POST(request: Request): Promise<Response> {
     try {
       provider = AiProviderFactory.createForTask('suggestion');
     } catch (err) {
-      logger.warn('Context suggestion: AI provider unavailable', {
-        error: err instanceof Error ? err.message : 'Unknown',
-      });
-      return jsonResponse({ success: true, data: { suggestions: [] } });
+      const reason = err instanceof Error ? err.message : 'Unknown';
+      logger.error('Context suggestion: AI provider unavailable', { error: reason });
+      return jsonResponse(
+        { success: false, error: { code: 'AI_UNAVAILABLE', message: `AI 서비스를 초기화할 수 없습니다: ${reason}` } },
+        { status: 503 },
+      );
     }
 
     let aiResponse;
@@ -68,20 +70,25 @@ export async function POST(request: Request): Promise<Response> {
 - 마크다운, 코드 블록, 추가 설명 없이 순수 JSON 배열만 반환`,
         user: `선택된 API:\n${apiList}\n\n이 API들을 활용한 웹 서비스 아이디어 3가지를 JSON 배열로 제안해주세요.`,
         temperature: 0.8,
-        maxTokens: 600,
+        maxTokens: 1024,
       });
     } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
       logger.error('Context suggestion: AI generation failed', {
-        error: err instanceof Error ? err.message : String(err),
+        error: reason,
         apiCount: apis.length,
+        model: provider.model,
       });
-      return jsonResponse({ success: true, data: { suggestions: [] } });
+      return jsonResponse(
+        { success: false, error: { code: 'AI_GENERATION_FAILED', message: `AI 추천 생성에 실패했습니다: ${reason}` } },
+        { status: 502 },
+      );
     }
 
     // Extract JSON array from response (tolerates surrounding text or code blocks)
-    const match = aiResponse.content.match(/\[[\s\S]*?\]/);
+    const match = aiResponse.content.match(/\[[\s\S]*\]/);
     if (!match) {
-      logger.warn('Context suggestion: could not parse AI response', { content: aiResponse.content.slice(0, 200) });
+      logger.warn('Context suggestion: could not parse AI response', { content: aiResponse.content.slice(0, 500) });
       return jsonResponse({ success: true, data: { suggestions: [] } });
     }
 
@@ -94,7 +101,7 @@ export async function POST(request: Request): Promise<Response> {
         .map((s: unknown) => String(s).trim())
         .filter((s) => s.length > 0);
     } catch {
-      logger.warn('Context suggestion: JSON parse failed', { raw: match[0].slice(0, 200) });
+      logger.warn('Context suggestion: JSON parse failed', { raw: match[0].slice(0, 500) });
       return jsonResponse({ success: true, data: { suggestions: [] } });
     }
 


### PR DESCRIPTION
## Summary
- AI Provider 초기화 실패 시 503, AI 생성 실패 시 502 반환 (이전: 200 + 빈 배열)
- 프론트엔드에 에러 로깅 추가 (브라우저 콘솔에서 원인 확인 가능)
- maxTokens 600→1024, 정규식 greedy 변경

## Test plan
- [x] 전체 테스트 17파일 194개 통과

https://claude.ai/code/session_01WrpvoXQAbcBCu3zs9mMk42