### PR TITLE
fix: Claude 모델 ID 404 오류 수정 — 컨텍스트 추천/코드 생성 복구

### DIFF
--- a/src/__tests__/api/generate.test.ts
+++ b/src/__tests__/api/generate.test.ts
@@ -93,7 +93,7 @@ const mockApis = [{ id: 'api-1', name: 'Test API', description: 'desc' }];
 const mockAiResponse = {
   content: '<html>...</html>',
   provider: 'claude',
-  model: 'claude-sonnet-4-6-20250514',
+  model: 'claude-sonnet-4-6',
   durationMs: 1500,
   tokensUsed: { input: 100, output: 200 },
 };

--- a/src/app/api/v1/health/route.ts
+++ b/src/app/api/v1/health/route.ts
@@ -23,8 +23,7 @@ export async function GET(): Promise<Response> {
   }
 
   // AI service check (actual API validation)
-  const aiProvider = (process.env.AI_PROVIDER as string) ?? 'claude';
-  checks.aiProvider = aiProvider;
+  checks.aiProvider = 'claude';
   try {
     const { AiProviderFactory } = await import('@/providers/ai/AiProviderFactory');
     const provider = AiProviderFactory.createForTask('suggestion');

--- a/src/app/api/v1/suggest-context/route.ts
+++ b/src/app/api/v1/suggest-context/route.ts
@@ -86,9 +86,13 @@ export async function POST(request: Request): Promise<Response> {
     }
 
     // Extract JSON array from response (tolerates surrounding text or code blocks)
-    const match = aiResponse.content.match(/\[[\s\S]*\]/);
+    // 비탐욕적 매칭으로 첫 번째 JSON 배열만 추출
+    const match = aiResponse.content.match(/\[[\s\S]*?\]/);
     if (!match) {
-      logger.warn('Context suggestion: could not parse AI response', { content: aiResponse.content.slice(0, 500) });
+      logger.warn('Context suggestion: could not parse AI response', {
+        content: aiResponse.content.slice(0, 500),
+        model: provider.model,
+      });
       return jsonResponse({ success: true, data: { suggestions: [] } });
     }
 

--- a/src/providers/ai/AiProviderFactory.test.ts
+++ b/src/providers/ai/AiProviderFactory.test.ts
@@ -6,7 +6,7 @@ import { ClaudeProvider } from './ClaudeProvider';
 vi.mock('./ClaudeProvider', () => ({
   ClaudeProvider: vi.fn().mockImplementation((_apiKey: string, model?: string) => ({
     name: 'claude',
-    model: model ?? 'claude-sonnet-4-6-20250514',
+    model: model ?? 'claude-sonnet-4-6',
     generateCode: vi.fn(),
     generateCodeStream: vi.fn(),
     checkAvailability: vi.fn().mockResolvedValue({ available: true }),
@@ -36,7 +36,7 @@ describe('AiProviderFactory.create()', () => {
     process.env.ANTHROPIC_API_KEY = 'test-key';
     const provider = AiProviderFactory.create('claude');
     expect(provider.name).toBe('claude');
-    expect(ClaudeProvider).toHaveBeenCalledWith('test-key', 'claude-sonnet-4-6-20250514');
+    expect(ClaudeProvider).toHaveBeenCalledWith('test-key', 'claude-sonnet-4-6');
   });
 
   it('같은 provider 타입은 싱글톤으로 반환된다', () => {
@@ -78,14 +78,14 @@ describe('AiProviderFactory.createForTask()', () => {
     process.env.ANTHROPIC_API_KEY = 'test-key';
     delete process.env.AI_PROVIDER;
     const provider = AiProviderFactory.createForTask('generation');
-    expect(provider.model).toBe('claude-sonnet-4-6-20250514');
+    expect(provider.model).toBe('claude-sonnet-4-6');
   });
 
   it('suggestion 태스크도 Sonnet 모델을 기본 사용한다', () => {
     process.env.ANTHROPIC_API_KEY = 'test-key';
     delete process.env.AI_PROVIDER;
     const provider = AiProviderFactory.createForTask('suggestion');
-    expect(provider.model).toBe('claude-sonnet-4-6-20250514');
+    expect(provider.model).toBe('claude-sonnet-4-6');
   });
 
   it('같은 태스크는 싱글톤으로 반환된다', () => {

--- a/src/providers/ai/AiProviderFactory.test.ts
+++ b/src/providers/ai/AiProviderFactory.test.ts
@@ -36,7 +36,7 @@ describe('AiProviderFactory.create()', () => {
     process.env.ANTHROPIC_API_KEY = 'test-key';
     const provider = AiProviderFactory.create('claude');
     expect(provider.name).toBe('claude');
-    expect(ClaudeProvider).toHaveBeenCalledWith('test-key');
+    expect(ClaudeProvider).toHaveBeenCalledWith('test-key', 'claude-sonnet-4-6-20250514');
   });
 
   it('같은 provider 타입은 싱글톤으로 반환된다', () => {
@@ -46,14 +46,16 @@ describe('AiProviderFactory.create()', () => {
     expect(p1).toBe(p2);
   });
 
-  it('알 수 없는 provider 타입은 에러를 던진다', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(() => AiProviderFactory.create('unknown' as any)).toThrow('Unknown AI provider');
-  });
-
   it('기본 provider가 claude이다', () => {
     process.env.ANTHROPIC_API_KEY = 'test-key';
     delete process.env.AI_PROVIDER;
+    const provider = AiProviderFactory.create();
+    expect(provider.name).toBe('claude');
+  });
+
+  it('AI_PROVIDER 환경변수가 레거시 값이어도 claude를 사용한다', () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    process.env.AI_PROVIDER = 'grok';
     const provider = AiProviderFactory.create();
     expect(provider.name).toBe('claude');
   });

--- a/src/providers/ai/AiProviderFactory.ts
+++ b/src/providers/ai/AiProviderFactory.ts
@@ -4,28 +4,24 @@ import { ClaudeProvider } from './ClaudeProvider';
 export type AiProviderType = 'claude';
 export type AiTaskType = 'generation' | 'suggestion';
 
+const DEFAULT_MODEL = 'claude-sonnet-4-6-20250514';
+
 export class AiProviderFactory {
   private static providers = new Map<string, IAiProvider>();
 
   static create(type?: AiProviderType): IAiProvider {
-    const providerType = type ?? (process.env.AI_PROVIDER as AiProviderType) ?? 'claude';
+    // AI_PROVIDER 환경변수는 무시 — Claude 단일 체제
+    const providerType: AiProviderType = type ?? 'claude';
 
     if (this.providers.has(providerType)) {
       return this.providers.get(providerType)!;
     }
 
-    let provider: IAiProvider;
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) throw new Error('ANTHROPIC_API_KEY is not set');
 
-    switch (providerType) {
-      case 'claude': {
-        const apiKey = process.env.ANTHROPIC_API_KEY;
-        if (!apiKey) throw new Error('ANTHROPIC_API_KEY is not set');
-        provider = new ClaudeProvider(apiKey);
-        break;
-      }
-      default:
-        throw new Error(`Unknown AI provider: ${providerType}`);
-    }
+    const model = process.env.CLAUDE_GENERATION_MODEL || DEFAULT_MODEL;
+    const provider = new ClaudeProvider(apiKey, model);
 
     this.providers.set(providerType, provider);
     return provider;
@@ -41,8 +37,8 @@ export class AiProviderFactory {
     if (!apiKey) throw new Error('ANTHROPIC_API_KEY is not set');
 
     const model = task === 'suggestion'
-      ? (process.env.CLAUDE_SUGGESTION_MODEL ?? 'claude-sonnet-4-6-20250514')
-      : (process.env.CLAUDE_GENERATION_MODEL ?? 'claude-sonnet-4-6-20250514');
+      ? (process.env.CLAUDE_SUGGESTION_MODEL || DEFAULT_MODEL)
+      : (process.env.CLAUDE_GENERATION_MODEL || DEFAULT_MODEL);
     const provider = new ClaudeProvider(apiKey, model);
 
     this.providers.set(cacheKey, provider);

--- a/src/providers/ai/AiProviderFactory.ts
+++ b/src/providers/ai/AiProviderFactory.ts
@@ -4,7 +4,7 @@ import { ClaudeProvider } from './ClaudeProvider';
 export type AiProviderType = 'claude';
 export type AiTaskType = 'generation' | 'suggestion';
 
-const DEFAULT_MODEL = 'claude-sonnet-4-6-20250514';
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
 
 export class AiProviderFactory {
   private static providers = new Map<string, IAiProvider>();

--- a/src/providers/ai/ClaudeProvider.test.ts
+++ b/src/providers/ai/ClaudeProvider.test.ts
@@ -47,13 +47,13 @@ describe('ClaudeProvider', () => {
     expect(provider.name).toBe('claude');
   });
 
-  it('기본 model이 claude-sonnet-4-6-20250514이다', () => {
-    expect(provider.model).toBe('claude-sonnet-4-6-20250514');
+  it('기본 model이 claude-sonnet-4-6이다', () => {
+    expect(provider.model).toBe('claude-sonnet-4-6');
   });
 
   it('커스텀 모델을 지정할 수 있다', () => {
-    const p = new ClaudeProvider('key', 'claude-haiku-4-5-20251001');
-    expect(p.model).toBe('claude-haiku-4-5-20251001');
+    const p = new ClaudeProvider('key', 'claude-haiku-4-5');
+    expect(p.model).toBe('claude-haiku-4-5');
   });
 
   // ── generateCode() ─────────────────────────────
@@ -66,7 +66,7 @@ describe('ClaudeProvider', () => {
     it('provider와 model 정보를 반환한다', async () => {
       const result = await provider.generateCode({ system: 'sys', user: 'user' });
       expect(result.provider).toBe('claude');
-      expect(result.model).toBe('claude-sonnet-4-6-20250514');
+      expect(result.model).toBe('claude-sonnet-4-6');
     });
 
     it('token 사용량을 반환한다', async () => {
@@ -118,7 +118,7 @@ describe('ClaudeProvider', () => {
         maxTokens: 600,
       });
       expect(mockCreate).toHaveBeenCalledWith({
-        model: 'claude-sonnet-4-6-20250514',
+        model: 'claude-sonnet-4-6',
         system: '당신은 웹 서비스 아이디어를 제안하는 도우미입니다.',
         messages: [{ role: 'user', content: expect.stringContaining('Weather API') }],
         temperature: 0.8,
@@ -128,11 +128,11 @@ describe('ClaudeProvider', () => {
 
     // ── Haiku 모델 호출 ──
     it('Haiku 모델로 suggestion 호출이 정상 동작한다', async () => {
-      const haiku = new ClaudeProvider('key', 'claude-haiku-4-5-20251001');
+      const haiku = new ClaudeProvider('key', 'claude-haiku-4-5');
       await haiku.generateCode({ system: 'sys', user: 'user', maxTokens: 600 });
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'claude-haiku-4-5-20251001',
+          model: 'claude-haiku-4-5',
           max_tokens: 600,
         })
       );
@@ -242,13 +242,13 @@ describe('ClaudeProvider', () => {
         () => {}
       );
       expect(result.provider).toBe('claude');
-      expect(result.model).toBe('claude-sonnet-4-6-20250514');
+      expect(result.model).toBe('claude-sonnet-4-6');
     });
 
     it('stream에 올바른 파라미터를 전달한다', async () => {
       await provider.generateCodeStream({ system: 'sys', user: 'user' }, () => {});
       expect(mockStream).toHaveBeenCalledWith({
-        model: 'claude-sonnet-4-6-20250514',
+        model: 'claude-sonnet-4-6',
         system: 'sys',
         messages: [{ role: 'user', content: 'user' }],
         temperature: 0.7,
@@ -362,14 +362,14 @@ describe('ClaudeProvider', () => {
     });
 
     it('model 필드가 정확히 전달된다 (Haiku)', async () => {
-      const haiku = new ClaudeProvider('key', 'claude-haiku-4-5-20251001');
+      const haiku = new ClaudeProvider('key', 'claude-haiku-4-5');
       await haiku.generateCode({ system: 's', user: 'u' });
-      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-haiku-4-5-20251001' }));
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-haiku-4-5' }));
     });
 
     it('model 필드가 정확히 전달된다 (Sonnet)', async () => {
       await provider.generateCode({ system: 's', user: 'u' });
-      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-sonnet-4-6-20250514' }));
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: 'claude-sonnet-4-6' }));
     });
   });
 });

--- a/src/providers/ai/ClaudeProvider.ts
+++ b/src/providers/ai/ClaudeProvider.ts
@@ -48,7 +48,7 @@ export class ClaudeProvider implements IAiProvider {
   readonly model: string;
   private client: Anthropic;
 
-  constructor(apiKey: string, model = 'claude-sonnet-4-6-20250514') {
+  constructor(apiKey: string, model = 'claude-sonnet-4-6') {
     this.client = new Anthropic({ apiKey });
     this.model = model;
   }

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -30,7 +30,7 @@ console.log('loaded');
 \`\`\``,
         },
       ],
-      model: 'claude-sonnet-4-6-20250514',
+      model: 'claude-sonnet-4-6',
       stop_reason: 'end_turn',
       usage: { input_tokens: 100, output_tokens: 200 },
     });


### PR DESCRIPTION
## Summary
- **근본 원인**: 모델 ID `claude-sonnet-4-6-20250514`가 Anthropic API에 존재하지 않아 404 반환
- `claude-sonnet-4-6-20250514` → `claude-sonnet-4-6` (올바른 모델 ID)
- `claude-haiku-4-5-20251001` → `claude-haiku-4-5` (올바른 모델 ID)
- AI_PROVIDER 레거시 환경변수 무시 처리, 정규식 비탐욕적 매칭 수정 포함

## Test plan
- [x] 타입체크 통과
- [x] 전체 테스트 17파일 194개 통과
- [ ] Railway 배포 후 컨텍스트 추천 정상 동작 확인
- [ ] 코드 생성 정상 동작 확인

https://claude.ai/code/session_01WrpvoXQAbcBCu3zs9mMk42