### PR TITLE
feat: AI 코드 생성 품질 극대화 — Phase 1~6 전면 개선

### DIFF
--- a/src/__tests__/api/generate.test.ts
+++ b/src/__tests__/api/generate.test.ts
@@ -74,6 +74,31 @@ vi.mock('@/lib/ai/codeValidator', () => ({
     errors: [],
     warnings: [],
   }),
+  evaluateQuality: vi.fn().mockReturnValue({
+    structuralScore: 80,
+    hasSemanticHtml: true,
+    hasMockData: true,
+    hasInteraction: true,
+    hasResponsiveClasses: true,
+    hasFooter: true,
+    hasImgAlt: true,
+    details: [],
+  }),
+}));
+
+vi.mock('@/lib/ai/categoryDesignMap', () => ({
+  inferDesignFromCategories: vi.fn().mockReturnValue({
+    theme: 'clean-light',
+    layout: 'hero-tabs-grid',
+    useChart: false,
+    useMap: false,
+    description: 'test',
+  }),
+}));
+
+vi.mock('@/lib/ai/qualityLoop', () => ({
+  shouldRetryGeneration: vi.fn().mockReturnValue(false),
+  buildQualityImprovementPrompt: vi.fn().mockReturnValue('improvement prompt'),
 }));
 
 vi.mock('@/lib/events/eventBus', () => ({
@@ -144,6 +169,7 @@ async function setupHappyPath() {
   const { AiProviderFactory } = await import('@/providers/ai/AiProviderFactory');
   (AiProviderFactory.createForTask as ReturnType<typeof vi.fn>).mockReturnValue({
     name: 'claude',
+    generateCode: vi.fn().mockResolvedValue(mockAiResponse),
     generateCodeStream: vi.fn().mockImplementation((_prompt: unknown, onChunk: (chunk: string, accumulated: string) => void) => {
       onChunk(mockAiResponse.content, mockAiResponse.content);
       return Promise.resolve(mockAiResponse);

--- a/src/app/(main)/builder/page.tsx
+++ b/src/app/(main)/builder/page.tsx
@@ -11,6 +11,7 @@ import ContextInput from '@/components/builder/ContextInput';
 import ContextSuggestions from '@/components/builder/ContextSuggestions';
 import GuideQuestions from '@/components/builder/GuideQuestions';
 import TemplateSelector from '@/components/builder/TemplateSelector';
+import DesignPreferences from '@/components/builder/DesignPreferences';
 import type { Template } from '@/components/builder/TemplateSelector';
 import GenerationProgress from '@/components/builder/GenerationProgress';
 import PreviewFrame from '@/components/builder/PreviewFrame';
@@ -59,6 +60,7 @@ export default function BuilderPage() {
     setContext,
     setTemplate,
     isValid: isContextValid,
+    getDesignPreferences,
     reset: resetContext,
   } = useContextStore();
 
@@ -153,6 +155,7 @@ export default function BuilderPage() {
           name: `프로젝트-${Date.now()}`,
           context,
           apiIds: selectedIds,
+          designPreferences: getDesignPreferences(),
         }),
       });
 
@@ -485,6 +488,7 @@ export default function BuilderPage() {
 
               <GuideQuestions onInsert={handleInsertGuide} />
               <TemplateSelector onSelect={handleApplyTemplate} />
+              <DesignPreferences />
             </div>
           )}
 
@@ -546,6 +550,7 @@ export default function BuilderPage() {
 
               <GuideQuestions onInsert={handleInsertGuide} />
               <TemplateSelector onSelect={handleApplyTemplate} />
+              <DesignPreferences />
             </div>
           )}
 

--- a/src/app/api/v1/generate/regenerate/route.ts
+++ b/src/app/api/v1/generate/regenerate/route.ts
@@ -9,7 +9,8 @@ import { AiProviderFactory } from '@/providers/ai/AiProviderFactory';
 import type { IAiProvider } from '@/providers/ai/IAiProvider';
 import { buildSystemPrompt, buildRegenerationPrompt } from '@/lib/ai/promptBuilder';
 import { parseGeneratedCode } from '@/lib/ai/codeParser';
-import { validateAll } from '@/lib/ai/codeValidator';
+import { validateAll, evaluateQuality } from '@/lib/ai/codeValidator';
+import { inferDesignFromCategories } from '@/lib/ai/categoryDesignMap';
 import { eventBus } from '@/lib/events/eventBus';
 import { getLimits } from '@/lib/config/features';
 import { getCorrelationId } from '@/lib/utils/correlationId';
@@ -180,6 +181,9 @@ export async function POST(request: Request): Promise<Response> {
             throw new Error(`생성된 코드에 보안 문제가 감지되었습니다: ${validation.errors.join(', ')}`);
           }
 
+          const categories = [...new Set(projectApis.map((a) => a.category).filter(Boolean))];
+          const inference = inferDesignFromCategories(categories);
+
           const nextVersion = await codeRepo.getNextVersion(projectId);
 
           const savedCode = await codeRepo.create({
@@ -199,6 +203,10 @@ export async function POST(request: Request): Promise<Response> {
               securityCheckPassed: validation.passed,
               validationErrors: [...validation.errors, ...validation.warnings],
               userFeedback: feedback,
+              ...evaluateQuality(parsed.html, parsed.css, parsed.js),
+              apiCategories: categories,
+              inferredTheme: inference.theme,
+              inferredLayout: inference.layout,
             },
           } as Parameters<typeof codeRepo.create>[0]);
 

--- a/src/app/api/v1/generate/route.ts
+++ b/src/app/api/v1/generate/route.ts
@@ -7,9 +7,12 @@ import { CodeRepository } from '@/repositories/codeRepository';
 import { EventRepository } from '@/repositories/eventRepository';
 import { AiProviderFactory } from '@/providers/ai/AiProviderFactory';
 import type { IAiProvider } from '@/providers/ai/IAiProvider';
+import type { DesignPreferences } from '@/types/project';
 import { buildSystemPrompt, buildUserPrompt } from '@/lib/ai/promptBuilder';
 import { parseGeneratedCode } from '@/lib/ai/codeParser';
-import { validateAll } from '@/lib/ai/codeValidator';
+import { validateAll, evaluateQuality } from '@/lib/ai/codeValidator';
+import { inferDesignFromCategories } from '@/lib/ai/categoryDesignMap';
+import { shouldRetryGeneration, buildQualityImprovementPrompt } from '@/lib/ai/qualityLoop';
 import { eventBus } from '@/lib/events/eventBus';
 import { getLimits } from '@/lib/config/features';
 import { getCorrelationId } from '@/lib/utils/correlationId';
@@ -72,7 +75,8 @@ export async function POST(request: Request): Promise<Response> {
 
     // Build prompt (시스템 프롬프트는 모듈 레벨 캐시 사용)
     const systemPrompt = buildSystemPrompt();
-    const userPrompt = buildUserPrompt(apis, project.context);
+    const designPreferences = (project.metadata as Record<string, unknown>)?.designPreferences as DesignPreferences | undefined;
+    const userPrompt = buildUserPrompt(apis, project.context, project.id, designPreferences);
     const limits = getLimits();
 
     // SSE stream with proper cancellation handling
@@ -154,7 +158,7 @@ export async function POST(request: Request): Promise<Response> {
             message: '디자인 적용 중...',
           });
 
-          const parsed = parseGeneratedCode(response.content);
+          let parsed = parseGeneratedCode(response.content);
 
           send('progress', {
             step: 'validating',
@@ -171,6 +175,43 @@ export async function POST(request: Request): Promise<Response> {
             });
             throw new Error(`생성된 코드에 보안 문제가 감지되었습니다: ${validation.errors.join(', ')}`);
           }
+
+          let quality = evaluateQuality(parsed.html, parsed.css, parsed.js);
+
+          // 품질 자동 재생성 (1회 제한)
+          let qualityLoopUsed = false;
+          if (shouldRetryGeneration(quality)) {
+            logger.info('Quality below threshold, attempting improvement', {
+              projectId,
+              score: quality.structuralScore,
+            });
+
+            send('progress', {
+              step: 'quality_improvement',
+              progress: 92,
+              message: '품질 개선 중...',
+            });
+
+            try {
+              const improvementPrompt = buildQualityImprovementPrompt(parsed, quality);
+              const retryResponse = await provider!.generateCode({ system: systemPrompt, user: improvementPrompt });
+              const retryParsed = parseGeneratedCode(retryResponse.content);
+
+              if (retryParsed.html) {
+                const retryQuality = evaluateQuality(retryParsed.html, retryParsed.css, retryParsed.js);
+                if (retryQuality.structuralScore > quality.structuralScore) {
+                  parsed = retryParsed;
+                  quality = retryQuality;
+                  qualityLoopUsed = true;
+                }
+              }
+            } catch (retryErr) {
+              logger.warn('Quality improvement retry failed', { projectId, retryErr });
+            }
+          }
+
+          const categories = [...new Set(apis.map((a) => a.category).filter(Boolean))];
+          const inference = inferDesignFromCategories(categories);
 
           const codeRepo = new CodeRepository(supabase);
           const nextVersion = await codeRepo.getNextVersion(projectId);
@@ -191,6 +232,11 @@ export async function POST(request: Request): Promise<Response> {
             metadata: {
               securityCheckPassed: validation.passed,
               validationErrors: [...validation.errors, ...validation.warnings],
+              ...quality,
+              apiCategories: categories,
+              inferredTheme: inference.theme,
+              inferredLayout: inference.layout,
+              qualityLoopUsed,
             },
           } as Parameters<typeof codeRepo.create>[0]);
 

--- a/src/app/api/v1/projects/route.ts
+++ b/src/app/api/v1/projects/route.ts
@@ -9,6 +9,13 @@ const createProjectSchema = z.object({
   context: z.string().min(50).max(2000),
   apiIds: z.array(z.string().uuid()).min(1).max(5),
   organizationId: z.string().uuid().optional(),
+  designPreferences: z
+    .object({
+      mood: z.enum(['auto', 'light', 'dark', 'warm', 'colorful', 'minimal']),
+      audience: z.enum(['general', 'business', 'youth', 'premium']),
+      layoutPreference: z.enum(['auto', 'dashboard', 'gallery', 'feed', 'landing', 'tool']),
+    })
+    .optional(),
 });
 
 export async function GET() {

--- a/src/components/builder/DesignPreferences.tsx
+++ b/src/components/builder/DesignPreferences.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import type { DesignMood, DesignAudience, DesignLayout } from '@/types/project';
+import { useContextStore } from '@/stores/contextStore';
+
+const MOOD_OPTIONS: { value: DesignMood; label: string }[] = [
+  { value: 'auto', label: '자동' },
+  { value: 'light', label: '밝고 깔끔' },
+  { value: 'dark', label: '어둡고 세련' },
+  { value: 'warm', label: '따뜻하고 친근' },
+  { value: 'colorful', label: '화려하고 역동' },
+  { value: 'minimal', label: '미니멀' },
+];
+
+const AUDIENCE_OPTIONS: { value: DesignAudience; label: string }[] = [
+  { value: 'general', label: '일반' },
+  { value: 'business', label: '비즈니스' },
+  { value: 'youth', label: '젊은층' },
+  { value: 'premium', label: '프리미엄' },
+];
+
+const LAYOUT_OPTIONS: { value: DesignLayout; label: string }[] = [
+  { value: 'auto', label: '자동' },
+  { value: 'dashboard', label: '대시보드' },
+  { value: 'gallery', label: '갤러리' },
+  { value: 'feed', label: '피드/목록' },
+  { value: 'landing', label: '랜딩페이지' },
+  { value: 'tool', label: '도구/유틸리티' },
+];
+
+function ChipGroup<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  options: { value: T; label: string }[];
+  value: T;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div>
+      <label className="mb-2 block text-xs font-medium" style={{ color: 'var(--text-muted)' }}>
+        {label}
+      </label>
+      <div className="flex flex-wrap gap-2">
+        {options.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onChange(opt.value)}
+            className="rounded-lg px-3 py-1.5 text-sm transition-all duration-150"
+            style={{
+              background: value === opt.value ? 'var(--accent-primary)' : 'var(--bg-card)',
+              color: value === opt.value ? 'white' : 'var(--text-secondary)',
+              border: `1px solid ${value === opt.value ? 'var(--accent-primary)' : 'var(--border)'}`,
+            }}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function DesignPreferences() {
+  const { mood, audience, layoutPreference, setMood, setAudience, setLayoutPreference } =
+    useContextStore();
+
+  return (
+    <details className="group">
+      <summary
+        className="flex cursor-pointer list-none items-center gap-1.5 text-sm font-medium transition-colors [&::-webkit-details-marker]:hidden"
+        style={{ color: 'var(--text-muted)' }}
+      >
+        <svg
+          className="h-3.5 w-3.5 transition-transform group-open:rotate-90"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+        디자인 선호도 설정 (선택사항)
+      </summary>
+      <div
+        className="mt-4 space-y-4 rounded-lg p-4"
+        style={{ background: 'var(--bg-card)', border: '1px solid var(--border)' }}
+      >
+        <ChipGroup label="분위기" options={MOOD_OPTIONS} value={mood} onChange={setMood} />
+        <ChipGroup
+          label="대상 고객"
+          options={AUDIENCE_OPTIONS}
+          value={audience}
+          onChange={setAudience}
+        />
+        <ChipGroup
+          label="레이아웃"
+          options={LAYOUT_OPTIONS}
+          value={layoutPreference}
+          onChange={setLayoutPreference}
+        />
+      </div>
+    </details>
+  );
+}

--- a/src/lib/ai/categoryDesignMap.test.ts
+++ b/src/lib/ai/categoryDesignMap.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { inferDesignFromCategories } from './categoryDesignMap';
+
+describe('inferDesignFromCategories', () => {
+  it('금융 카테고리는 모던 다크를 추천한다', () => {
+    const result = inferDesignFromCategories(['finance']);
+    expect(result.theme).toBe('modern-dark');
+    expect(result.useChart).toBe(true);
+  });
+
+  it('음식/여행 카테고리는 따뜻한 톤을 추천한다', () => {
+    const result = inferDesignFromCategories(['tourism', 'lifestyle']);
+    expect(result.theme).toBe('warm');
+  });
+
+  it('날씨 카테고리는 오션 블루를 추천한다', () => {
+    const result = inferDesignFromCategories(['weather']);
+    expect(result.theme).toBe('ocean-blue');
+    expect(result.useChart).toBe(true);
+  });
+
+  it('엔터테인먼트 카테고리는 선셋 그래디언트를 추천한다', () => {
+    const result = inferDesignFromCategories(['entertainment']);
+    expect(result.theme).toBe('sunset-gradient');
+  });
+
+  it('빈 배열이면 클린 라이트 기본값을 반환한다', () => {
+    const result = inferDesignFromCategories([]);
+    expect(result.theme).toBe('clean-light');
+  });
+
+  it('복수 카테고리는 첫 번째 매칭 우선', () => {
+    const result = inferDesignFromCategories(['finance', 'news']);
+    expect(result.theme).toBe('modern-dark');
+  });
+
+  it('useMap은 지도 카테고리에서만 true', () => {
+    expect(inferDesignFromCategories(['maps']).useMap).toBe(true);
+    expect(inferDesignFromCategories(['news']).useMap).toBe(false);
+  });
+});

--- a/src/lib/ai/categoryDesignMap.ts
+++ b/src/lib/ai/categoryDesignMap.ts
@@ -1,0 +1,119 @@
+export interface DesignInference {
+  theme: string;
+  layout: string;
+  useChart: boolean;
+  useMap: boolean;
+  description: string;
+}
+
+interface CategoryRule {
+  categories: string[];
+  theme: string;
+  layout: string;
+  useChart: boolean;
+  useMap: boolean;
+  description: string;
+}
+
+const CATEGORY_RULES: CategoryRule[] = [
+  {
+    categories: ['finance'],
+    theme: 'modern-dark',
+    layout: 'watchlist-table-chart',
+    useChart: true,
+    useMap: false,
+    description: '금융/투자 서비스 — 워치리스트 테이블 + 실시간 차트 + 종목 상세',
+  },
+  {
+    categories: ['weather'],
+    theme: 'ocean-blue',
+    layout: 'status-card-chart',
+    useChart: true,
+    useMap: false,
+    description: '날씨/환경 서비스 — 대형 현재 상태 카드 + 시간별 스크롤 + 주간 예보 차트',
+  },
+  {
+    categories: ['entertainment', 'fun'],
+    theme: 'sunset-gradient',
+    layout: 'hero-carousel-grid',
+    useChart: false,
+    useMap: false,
+    description: '엔터테인먼트 서비스 — 히어로 배너 + 가로 캐러셀 + 카드 그리드',
+  },
+  {
+    categories: ['news', 'social'],
+    theme: 'clean-light',
+    layout: 'hero-tabs-grid-sidebar',
+    useChart: false,
+    useMap: false,
+    description: '뉴스/미디어 서비스 — 히어로 헤드라인 + 카테고리 탭 + 카드 그리드 + 사이드바',
+  },
+  {
+    categories: ['tourism', 'lifestyle'],
+    theme: 'warm',
+    layout: 'hero-image-carousel-grid',
+    useChart: false,
+    useMap: false,
+    description: '여행/라이프스타일 서비스 — 큰 이미지 히어로 + 캐러셀 + 카드 그리드',
+  },
+  {
+    categories: ['maps', 'location', 'transport', 'realestate'],
+    theme: 'clean-light',
+    layout: 'map-with-sidebar',
+    useChart: false,
+    useMap: true,
+    description: '지도/위치 서비스 — Leaflet 전체 너비 지도 + 사이드 패널 목록 + 필터',
+  },
+  {
+    categories: ['science', 'data'],
+    theme: 'modern-dark',
+    layout: 'dashboard-stats-chart',
+    useChart: true,
+    useMap: false,
+    description: '데이터/과학 서비스 — 통계 대시보드 + 차트 + 데이터 테이블',
+  },
+  {
+    categories: ['image'],
+    theme: 'monochrome',
+    layout: 'gallery-masonry',
+    useChart: false,
+    useMap: false,
+    description: '이미지/갤러리 서비스 — 그리드 갤러리 + 필터 + 상세 모달',
+  },
+  {
+    categories: ['utility', 'dictionary', 'translation'],
+    theme: 'modern-dark',
+    layout: 'split-input-output',
+    useChart: false,
+    useMap: false,
+    description: '유틸리티/도구 서비스 — 좌우 분할 (입력/출력) + 히스토리 사이드바',
+  },
+];
+
+const DEFAULT_INFERENCE: DesignInference = {
+  theme: 'clean-light',
+  layout: 'hero-tabs-grid',
+  useChart: false,
+  useMap: false,
+  description: '일반 서비스 — 히어로 + 탭 + 카드 그리드 (기본 레이아웃)',
+};
+
+export function inferDesignFromCategories(categories: string[]): DesignInference {
+  if (categories.length === 0) return DEFAULT_INFERENCE;
+
+  const lowerCategories = categories.map((c) => c.toLowerCase());
+
+  for (const rule of CATEGORY_RULES) {
+    if (rule.categories.some((rc) => lowerCategories.includes(rc))) {
+      return {
+        theme: rule.theme,
+        layout: rule.layout,
+        useChart: rule.useChart,
+        useMap: rule.useMap,
+        description: rule.description,
+      };
+    }
+  }
+
+  return DEFAULT_INFERENCE;
+}

--- a/src/lib/ai/codeParser.test.ts
+++ b/src/lib/ai/codeParser.test.ts
@@ -50,14 +50,14 @@ describe('assembleHtml', () => {
   it('이미 <style>과 <script>가 있어도 별도 CSS/JS를 추가 주입한다', () => {
     const html = '<html><head><style>a{}</style></head><body><script>var x</script></body></html>';
     const result = assembleHtml({ html, css: 'body{}', js: 'alert()' });
-    expect(result).toContain('<style>\nbody{}\n</style>');
+    expect(result).toContain('body{}');
     expect(result).toContain('<script>\nalert()\n</script>');
   });
 
   it('</head>가 있는 HTML에 CSS를 주입한다', () => {
     const html = '<html><head></head><body></body></html>';
     const result = assembleHtml({ html, css: 'body { color: red; }', js: '' });
-    expect(result).toContain('<style>\nbody { color: red; }\n</style>');
+    expect(result).toContain('body { color: red; }');
     expect(result).toContain('</head>');
   });
 
@@ -73,5 +73,34 @@ describe('assembleHtml', () => {
     expect(result).toContain('<!DOCTYPE html>');
     expect(result).toContain('<html lang="ko">');
     expect(result).toContain('<p>content</p>');
+  });
+
+  it('OG 메타태그와 파비콘을 자동 주입한다', () => {
+    const html = '<html><head><title>테스트 서비스</title></head><body></body></html>';
+    const result = assembleHtml({ html, css: '', js: '' });
+    expect(result).toContain('og:type');
+    expect(result).toContain('og:locale');
+    expect(result).toContain('og:title');
+    expect(result).toContain('테스트 서비스');
+    expect(result).toContain('rel="icon"');
+  });
+
+  it('CSS 기본 변수와 프린트 스타일시트를 주입한다', () => {
+    const html = '<html><head></head><body></body></html>';
+    const result = assembleHtml({ html, css: '', js: '' });
+    expect(result).toContain('--transition-fast');
+    expect(result).toContain('--shadow-sm');
+    expect(result).toContain('@media print');
+  });
+
+  it('이미지에 lazy loading과 decoding을 추가한다', () => {
+    const html = '<html><head></head><body><img src="a.jpg"><img src="b.jpg"><img src="https://picsum.photos/seed/test/600/400"></body></html>';
+    const result = assembleHtml({ html, css: '', js: '' });
+    // 3rd image should have lazy loading
+    expect(result).toContain('loading="lazy"');
+    expect(result).toContain('decoding="async"');
+    // picsum.photos should get width/height
+    expect(result).toContain('width="600"');
+    expect(result).toContain('height="400"');
   });
 });

--- a/src/lib/ai/codeParser.ts
+++ b/src/lib/ai/codeParser.ts
@@ -34,6 +34,97 @@ function sanitizeCss(css: string): string {
     .replace(/-moz-binding\s*:/gi, '/* removed */:');
 }
 
+/**
+ * Extract <title> content from HTML string.
+ */
+function extractTitle(html: string): string {
+  const match = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+  return match ? match[1].trim() : '';
+}
+
+/**
+ * Build head injections: favicon, OG meta tags, CSS variables, print stylesheet.
+ * Only injects tags that are not already present.
+ */
+function buildHeadInjections(html: string, safeCss: string): string {
+  const parts: string[] = [];
+
+  // Favicon — only if no existing favicon link
+  if (!/<link[^>]*rel\s*=\s*["'](?:icon|shortcut icon)["']/i.test(html)) {
+    parts.push(
+      `<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌐</text></svg>">`
+    );
+  }
+
+  // OG meta tags — only if no existing og: tags
+  if (!/<meta[^>]*property\s*=\s*["']og:/i.test(html)) {
+    const title = extractTitle(html) || 'Generated Service';
+    parts.push(
+      `<meta property="og:type" content="website">`,
+      `<meta property="og:locale" content="ko_KR">`,
+      `<meta property="og:title" content="${title.replace(/"/g, '&quot;')}">`
+    );
+  }
+
+  // CSS custom properties + print stylesheet
+  const cssInjection = [
+    ':root {',
+    '  --transition-fast: 150ms ease;',
+    '  --transition-base: 300ms ease;',
+    '  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);',
+    '  --shadow-md: 0 4px 6px rgba(0,0,0,0.07);',
+    '  --radius-lg: 1rem;',
+    '  --radius-xl: 1.5rem;',
+    '}',
+    '@media print {',
+    '  header, footer, .no-print { display: none; }',
+    '  body { background: white !important; color: black !important; }',
+    '}',
+  ].join('\n');
+
+  const fullCss = cssInjection + (safeCss ? '\n' + safeCss : '');
+  parts.push(`<style>\n${fullCss}\n</style>`);
+
+  return parts.join('\n');
+}
+
+/**
+ * Post-process image tags: add lazy loading, decoding, and dimensions for picsum.photos.
+ * First 2 images skip lazy loading (above the fold).
+ */
+function optimizeImages(html: string): string {
+  let imgIndex = 0;
+  return html.replace(/<img\s([^>]*?)>/gi, (match, attrs: string) => {
+    imgIndex++;
+    let newAttrs = attrs;
+
+    // Add loading="lazy" for images after the first 2 (above the fold)
+    if (imgIndex > 2 && !/\bloading\s*=/i.test(newAttrs)) {
+      newAttrs += ' loading="lazy"';
+    }
+
+    // Add decoding="async"
+    if (!/\bdecoding\s*=/i.test(newAttrs)) {
+      newAttrs += ' decoding="async"';
+    }
+
+    // Extract width/height from picsum.photos URL pattern: /seed/x/{w}/{h} or /{w}/{h}
+    if (/picsum\.photos/i.test(newAttrs)) {
+      const sizeMatch = newAttrs.match(/picsum\.photos\/(?:seed\/[^/]+\/)?(\d+)\/(\d+)/i);
+      if (sizeMatch) {
+        if (!/\bwidth\s*=/i.test(newAttrs)) {
+          newAttrs += ` width="${sizeMatch[1]}"`;
+        }
+        if (!/\bheight\s*=/i.test(newAttrs)) {
+          newAttrs += ` height="${sizeMatch[2]}"`;
+        }
+      }
+    }
+
+    return `<img ${newAttrs}>`;
+  });
+}
+
 export function assembleHtml(parsed: ParsedCode): string {
   const safeCss = parsed.css ? sanitizeCss(parsed.css) : '';
 
@@ -55,13 +146,13 @@ export function assembleHtml(parsed: ParsedCode): string {
       }
     }
 
-    if (safeCss) {
-      const headIdx = assembled.lastIndexOf('</head>');
-      assembled =
-        assembled.slice(0, headIdx) +
-        `<style>\n${safeCss}\n</style>\n` +
-        assembled.slice(headIdx);
-    }
+    // Inject favicon, OG tags, CSS variables, and print stylesheet before </head>
+    const headCloseIdx = assembled.lastIndexOf('</head>');
+    assembled =
+      assembled.slice(0, headCloseIdx) +
+      buildHeadInjections(assembled, safeCss) +
+      '\n' +
+      assembled.slice(headCloseIdx);
 
     if (parsed.js) {
       const bodyIdx = assembled.lastIndexOf('</body>');
@@ -75,19 +166,23 @@ export function assembleHtml(parsed: ParsedCode): string {
       }
     }
 
+    // Post-process images for lazy loading and dimensions
+    assembled = optimizeImages(assembled);
+
     return assembled;
   }
 
   // Build complete HTML document
-  return `<!DOCTYPE html>
+  const title = extractTitle(parsed.html) || 'Generated Service';
+  const headInjections = buildHeadInjections('', safeCss);
+
+  let doc = `<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Generated Service</title>
-  <style>
-${safeCss}
-  </style>
+  <title>${title}</title>
+  ${headInjections}
 </head>
 <body>
 ${parsed.html}
@@ -96,4 +191,9 @@ ${parsed.js}
   </script>
 </body>
 </html>`;
+
+  // Post-process images for lazy loading and dimensions
+  doc = optimizeImages(doc);
+
+  return doc;
 }

--- a/src/lib/ai/codeValidator.test.ts
+++ b/src/lib/ai/codeValidator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateSecurity, validateFunctionality, validateAll } from './codeValidator';
+import { validateSecurity, validateFunctionality, validateAll, evaluateQuality } from './codeValidator';
 
 describe('validateSecurity', () => {
   it('eval() 사용 시 에러를 반환한다', () => {
@@ -75,5 +75,56 @@ describe('validateAll', () => {
     const js = 'document.querySelector("body").textContent = "Hello"';
     const result = validateAll(html, css, js);
     expect(result.passed).toBe(true);
+  });
+});
+
+describe('evaluateQuality', () => {
+  it('모든 품질 요소가 있으면 점수 100을 반환한다', () => {
+    const html = `<!DOCTYPE html><html><head></head><body>
+      <nav>네비</nav>
+      <main>
+        <article>
+          <img src="https://picsum.photos/seed/a/600/400" alt="테스트 이미지">
+        </article>
+      </main>
+      <footer>푸터</footer>
+      <div class="sm:grid-cols-2 lg:grid-cols-3 transition-all">카드</div>
+    </body></html>`;
+    const js = `
+      const mockData = [{ id: 1, title: '테스트' }];
+      document.addEventListener('DOMContentLoaded', () => {});
+      btn.addEventListener('click', () => {});
+      el.addEventListener('input', () => {});
+    `;
+    const result = evaluateQuality(html, '', js);
+    expect(result.structuralScore).toBe(100);
+    expect(result.hasSemanticHtml).toBe(true);
+    expect(result.hasMockData).toBe(true);
+    expect(result.hasInteraction).toBe(true);
+    expect(result.hasFooter).toBe(true);
+  });
+
+  it('빈 코드는 낮은 점수를 반환한다', () => {
+    const result = evaluateQuality('<div></div>', '', '');
+    expect(result.structuralScore).toBeLessThan(30);
+    expect(result.hasMockData).toBe(false);
+    expect(result.hasInteraction).toBe(false);
+  });
+
+  it('details에 부족한 항목이 나열된다', () => {
+    const result = evaluateQuality('<div></div>', '', '');
+    expect(result.details.length).toBeGreaterThan(0);
+    expect(result.details.some((d) => d.includes('시맨틱'))).toBe(true);
+  });
+
+  it('한국어 텍스트가 있으면 hasKorean 점수 포함', () => {
+    const result = evaluateQuality('<div>안녕하세요</div>', '', '');
+    expect(result.structuralScore).toBeGreaterThan(0);
+  });
+
+  it('반응형 클래스가 있으면 감지한다', () => {
+    const html = '<div class="sm:grid-cols-2 lg:grid-cols-3">test</div>';
+    const result = evaluateQuality(html, '', '');
+    expect(result.hasResponsiveClasses).toBe(true);
   });
 });

--- a/src/lib/ai/codeValidator.ts
+++ b/src/lib/ai/codeValidator.ts
@@ -88,6 +88,127 @@ export function validateFunctionality(html: string, _css: string, js: string): V
   };
 }
 
+export interface QualityMetrics {
+  structuralScore: number;
+  hasSemanticHtml: boolean;
+  hasMockData: boolean;
+  hasInteraction: boolean;
+  hasResponsiveClasses: boolean;
+  hasFooter: boolean;
+  hasImgAlt: boolean;
+  details: string[];
+}
+
+/**
+ * Evaluate structural quality of generated code.
+ * Returns a score (0-100) and individual quality flags.
+ * These are informational — they do not block code storage.
+ */
+export function evaluateQuality(html: string, _css: string, js: string): QualityMetrics {
+  const fullCode = `${html}\n${js}`;
+  const details: string[] = [];
+  let score = 0;
+  const maxScore = 10; // number of checks
+
+  // 1. Semantic HTML: <main>, <nav>, <article>, <section>, <footer>
+  const semanticTags = ['<main', '<nav', '<footer', '<section', '<article'];
+  const semanticCount = semanticTags.filter((tag) => html.includes(tag)).length;
+  const hasSemanticHtml = semanticCount >= 2;
+  if (hasSemanticHtml) {
+    score++;
+  } else {
+    details.push(`시맨틱 HTML 부족 (${semanticCount}/2 태그)`);
+  }
+
+  // 2. Mock data array exists
+  const hasMockData = /const\s+\w*(mock|data|items|list|posts|products|cards)\w*\s*=\s*\[/i.test(js);
+  if (hasMockData) {
+    score++;
+  } else {
+    details.push('목 데이터 배열이 감지되지 않았습니다');
+  }
+
+  // 3. DOMContentLoaded listener
+  const hasDomReady = /DOMContentLoaded|addEventListener\s*\(\s*['"]load['"]/i.test(js);
+  if (hasDomReady) {
+    score++;
+  } else {
+    details.push('DOMContentLoaded 리스너가 없습니다');
+  }
+
+  // 4. Event listeners (interaction)
+  const listenerCount = (js.match(/addEventListener\s*\(/g) ?? []).length;
+  const hasInteraction = listenerCount >= 2;
+  if (hasInteraction) {
+    score++;
+  } else {
+    details.push(`이벤트 리스너 부족 (${listenerCount}개)`);
+  }
+
+  // 5. Responsive Tailwind classes
+  const hasResponsiveClasses = /\b(sm|md|lg|xl):/i.test(fullCode);
+  if (hasResponsiveClasses) {
+    score++;
+  } else {
+    details.push('반응형 클래스(sm:/md:/lg:)가 없습니다');
+  }
+
+  // 6. Footer
+  const hasFooter = /<footer[\s>]/i.test(html);
+  if (hasFooter) {
+    score++;
+  } else {
+    details.push('<footer> 태그가 없습니다');
+  }
+
+  // 7. Image alt attributes
+  const imgTags = html.match(/<img\s[^>]*>/gi) ?? [];
+  const imgsWithAlt = imgTags.filter((tag) => /\balt\s*=/i.test(tag)).length;
+  const hasImgAlt = imgTags.length === 0 || imgsWithAlt >= imgTags.length * 0.7;
+  if (hasImgAlt) {
+    score++;
+  } else {
+    details.push(`이미지 alt 속성 부족 (${imgsWithAlt}/${imgTags.length})`);
+  }
+
+  // 8. Transitions / animations
+  const hasTransitions = /transition|animate|animation/i.test(fullCode);
+  if (hasTransitions) {
+    score++;
+  } else {
+    details.push('트랜지션/애니메이션이 없습니다');
+  }
+
+  // 9. Korean text present
+  const hasKorean = /[\uAC00-\uD7AF]/.test(fullCode);
+  if (hasKorean) {
+    score++;
+  } else {
+    details.push('한국어 텍스트가 감지되지 않았습니다');
+  }
+
+  // 10. Grid or flex layout
+  const hasGridOrFlex = /grid-cols|flex\s|flex-|display:\s*flex|display:\s*grid/i.test(fullCode);
+  if (hasGridOrFlex) {
+    score++;
+  } else {
+    details.push('그리드/플렉스 레이아웃이 없습니다');
+  }
+
+  const structuralScore = Math.round((score / maxScore) * 100);
+
+  return {
+    structuralScore,
+    hasSemanticHtml,
+    hasMockData,
+    hasInteraction,
+    hasResponsiveClasses,
+    hasFooter,
+    hasImgAlt,
+    details,
+  };
+}
+
 export function validateAll(html: string, css: string, js: string): ValidationResult {
   const fullCode = `${html}\n${css}\n${js}`;
   const securityResult = validateSecurity(fullCode);

--- a/src/lib/ai/promptBuilder.ts
+++ b/src/lib/ai/promptBuilder.ts
@@ -1,4 +1,6 @@
 import type { ApiCatalogItem } from '@/types/api';
+import type { DesignPreferences } from '@/types/project';
+import { inferDesignFromCategories } from './categoryDesignMap';
 
 // 시스템 프롬프트 모듈 레벨 캐싱 — 매 요청마다 재생성하지 않음
 let cachedSystemPrompt: string | null = null;
@@ -21,15 +23,20 @@ function _buildSystemPrompt(): string {
 4. **레이아웃은 가로 방향 flex/grid를 기본으로 한다.** 서비스 타이틀이 세로로 깨지거나 요소가 한 줄에 하나씩 쌓이는 것은 심각한 결함이다.
 5. **모든 텍스트는 한국어로 작성한다.** UI, 목 데이터, placeholder, 토스트, 에러 메시지 전부 한국어.
 
-## 필수 CDN
+## 필수 CDN (항상 포함)
 
 \`\`\`html
 <script src="https://cdn.tailwindcss.com"></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
 <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/packages/pretendard/dist/web/variable/pretendardvariable-dynamic-subset.min.css" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 \`\`\`
+
+## 조건부 CDN (필요한 경우에만 포함)
+
+- **Chart.js** — 차트, 그래프, 데이터 시각화가 필요한 서비스에만: \`<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>\`
+- **Leaflet** — 지도가 필요한 서비스에만: \`<link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css">\` + \`<script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>\`
+- 불필요한 CDN은 로드하지 마라. 갤러리, 쇼핑, 블로그 등 차트가 없는 서비스에 Chart.js를 넣지 마라.
 
 ## HTML 구조 필수 패턴
 
@@ -115,22 +122,143 @@ function _buildSystemPrompt(): string {
 - 사이드바: \`w-64 shrink-0 hidden lg:block\`
 - 메인: \`flex-1 min-w-0\`
 
-## 디자인 시스템 선택 (서비스에 맞게)
+## 디자인 시스템 선택 (서비스에 맞게 1개 선택)
 
-### 모던 다크 (금융, 개발자, 모니터링)
+### 1. 모던 다크 (금융, 개발자, 모니터링, 게임)
 body: \`bg-gray-950 text-gray-100\`
-카드: \`bg-gray-900 border border-gray-800\`
+카드: \`bg-gray-900 border border-gray-800 hover:border-gray-700\`
 액센트: \`text-blue-400 bg-blue-500/10\`
+헤더: \`bg-gray-950/80 border-gray-800\`
 
-### 클린 라이트 (뉴스, 쇼핑, 일반)
+### 2. 클린 라이트 (뉴스, 쇼핑, 일반, 교육)
 body: \`bg-gray-50 text-gray-900\`
-카드: \`bg-white shadow-sm\`
+카드: \`bg-white shadow-sm hover:shadow-lg\`
 액센트: \`text-blue-600 bg-blue-50\`
+헤더: \`bg-white/80 border-gray-200\`
 
-### 따뜻한 톤 (음식, 여행, 라이프스타일)
+### 3. 따뜻한 톤 (음식, 여행, 라이프스타일, 카페)
 body: \`bg-orange-50/30 text-gray-900\`
-카드: \`bg-white shadow-sm\`
+카드: \`bg-white shadow-sm hover:shadow-lg\`
 액센트: \`text-orange-600 bg-orange-50\`
+헤더: \`bg-orange-50/80 border-orange-100\`
+
+### 4. 오션 블루 (날씨, 여행, 물류, 교통)
+body: \`bg-slate-50 text-slate-900\`
+카드: \`bg-white shadow-sm border border-sky-100 hover:shadow-lg\`
+액센트: \`text-sky-600 bg-sky-50\`
+헤더: \`bg-white/80 border-sky-100\`
+특징: 물결/파도 느낌의 부드러운 곡선 섹션 구분선
+
+### 5. 포레스트 그린 (건강, 환경, 교육, 웰빙)
+body: \`bg-emerald-50/20 text-gray-900\`
+카드: \`bg-white shadow-sm hover:shadow-lg\`
+액센트: \`text-emerald-600 bg-emerald-50\`
+헤더: \`bg-white/80 border-emerald-100\`
+특징: 유기적인 둥근 모서리, 자연 톤 그래디언트
+
+### 6. 선셋 그래디언트 (엔터테인먼트, 음악, 이벤트, SNS)
+body: \`bg-gradient-to-br from-purple-950 via-indigo-950 to-slate-950 text-gray-100\`
+카드: \`bg-white/5 backdrop-blur-sm border border-white/10 hover:border-white/20\`
+액센트: \`text-purple-400 bg-purple-500/10\`
+헤더: \`bg-black/20 backdrop-blur-xl border-white/10\`
+특징: 그래디언트 배경, 글래스모피즘 카드, 네온 느낌 액센트
+
+### 7. 파스텔 (반려동물, 키즈, 커뮤니티, 취미)
+body: \`bg-pink-50/20 text-gray-800\`
+카드: \`bg-white shadow-sm rounded-3xl hover:shadow-lg\`
+액센트: \`text-rose-500 bg-rose-50\`
+헤더: \`bg-white/80 border-pink-100\`
+특징: 큰 둥근 모서리(\`rounded-3xl\`), 부드러운 파스텔 그래디언트, 아이콘 강조
+
+### 8. 모노크롬 (포트폴리오, 미니멀, 갤러리, 사진)
+body: \`bg-white text-gray-900\`
+카드: \`bg-gray-50 border border-gray-100 hover:border-gray-300\`
+액센트: \`text-gray-900 bg-gray-100\`
+헤더: \`bg-white border-gray-100\`
+특징: 여백 강조, 타이포그래피 중심, 흑백 + 단일 포인트 컬러
+
+## 히어로 섹션 변형 (서비스에 맞게 1개 선택)
+
+### 풀 이미지 히어로 (여행, 음식, 부동산)
+\`\`\`html
+<section class="relative h-[60vh] overflow-hidden">
+  <img src="https://picsum.photos/seed/hero/1920/1080" alt="히어로 배경" class="absolute inset-0 w-full h-full object-cover">
+  <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent"></div>
+  <div class="relative z-10 max-w-7xl mx-auto px-4 h-full flex items-end pb-16">
+    <div>
+      <h2 class="text-4xl sm:text-5xl font-bold text-white mb-4">제목 텍스트</h2>
+      <p class="text-lg text-gray-200 max-w-2xl">설명 텍스트</p>
+    </div>
+  </div>
+</section>
+\`\`\`
+
+### 스플릿 히어로 (쇼핑, SaaS, 교육)
+\`\`\`html
+<section class="max-w-7xl mx-auto px-4 sm:px-6 py-16">
+  <div class="grid lg:grid-cols-2 gap-12 items-center">
+    <div>
+      <h2 class="text-4xl sm:text-5xl font-bold tracking-tight mb-6">제목 텍스트</h2>
+      <p class="text-lg text-gray-600 mb-8">설명 텍스트</p>
+      <div class="flex gap-4">
+        <button class="px-6 py-3 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-colors">시작하기</button>
+        <button class="px-6 py-3 border border-gray-300 rounded-xl hover:bg-gray-50 transition-colors">자세히 보기</button>
+      </div>
+    </div>
+    <div class="relative">
+      <img src="https://picsum.photos/seed/split/800/600" alt="히어로 이미지" class="rounded-2xl shadow-2xl w-full">
+    </div>
+  </div>
+</section>
+\`\`\`
+
+### 그래디언트 히어로 (대시보드, 금융, 데이터)
+\`\`\`html
+<section class="bg-gradient-to-r from-blue-600 to-indigo-700 text-white py-16">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 text-center">
+    <h2 class="text-3xl sm:text-4xl font-bold mb-4">제목 텍스트</h2>
+    <p class="text-blue-100 text-lg mb-8 max-w-2xl mx-auto">설명 텍스트</p>
+    <div class="relative max-w-xl mx-auto">
+      <input type="text" placeholder="검색어를 입력하세요" class="w-full px-6 py-4 rounded-2xl text-gray-900 shadow-lg focus:ring-4 focus:ring-blue-300/50">
+      <button class="absolute right-2 top-2 px-6 py-2 bg-blue-600 text-white rounded-xl hover:bg-blue-700">검색</button>
+    </div>
+  </div>
+</section>
+\`\`\`
+
+## 카드 변형 (혼합 사용 가능)
+
+### 이미지 탑 카드 (기본 — 쇼핑, 블로그, 갤러리)
+카드 상단에 이미지, 하단에 텍스트. \`aspect-video object-cover\` 필수.
+
+### 오버레이 카드 (여행, 영화, 이벤트)
+이미지 위에 어두운 그래디언트 오버레이 + 하단에 흰색 텍스트:
+\`\`\`html
+<div class="relative group rounded-2xl overflow-hidden cursor-pointer">
+  <img src="..." alt="..." class="w-full aspect-[4/3] object-cover group-hover:scale-105 transition-transform duration-500">
+  <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent"></div>
+  <div class="absolute bottom-0 p-5 text-white">
+    <h3 class="text-lg font-bold">카드 제목</h3>
+    <p class="text-sm text-gray-300 mt-1">카드 설명</p>
+  </div>
+</div>
+\`\`\`
+
+### 호리즌탈 카드 (뉴스, 리뷰, 검색 결과)
+좌측 이미지 + 우측 텍스트 가로 배치:
+\`\`\`html
+<div class="flex gap-4 bg-white rounded-xl shadow-sm hover:shadow-lg transition-all p-4 cursor-pointer">
+  <img src="..." alt="..." class="w-32 h-24 rounded-lg object-cover shrink-0">
+  <div class="flex-1 min-w-0">
+    <h3 class="font-semibold line-clamp-1">카드 제목</h3>
+    <p class="text-sm text-gray-500 line-clamp-2 mt-1">카드 설명</p>
+    <div class="flex items-center gap-3 mt-2 text-xs text-gray-400">
+      <span>2026.03.28</span>
+      <span>조회 1,234</span>
+    </div>
+  </div>
+</div>
+\`\`\`
 
 ## 목 데이터 작성 규칙 (★ 매우 중요)
 
@@ -277,6 +405,91 @@ function showToast(message, type = 'success') {
 - 태블릿 (768~1024px): \`sm:grid-cols-2\`
 - 데스크톱 (> 1024px): \`lg:grid-cols-3\` 이상, 사이드바 표시
 
+## 접근성 (a11y) 필수 규칙
+
+- 시맨틱 HTML 사용: \`<nav>\`, \`<main>\`, \`<article>\`, \`<section>\`, \`<figure>\`, \`<footer>\`
+- 모든 \`<img>\`에 한국어 \`alt\` 속성 필수 (예: \`alt="서울 강남 브런치 카페 인테리어"\`)
+- 색상 대비: 본문 텍스트는 배경 대비 4.5:1 이상 유지 (다크 모드에서도)
+- 아이콘만 있는 버튼에는 반드시 \`aria-label\` 추가 (예: \`<button aria-label="좋아요"><i class="fas fa-heart"></i></button>\`)
+- 클릭 액션은 \`<button>\` 사용 — \`<div onclick>\` 금지
+- 모달: \`role="dialog"\` + \`aria-modal="true"\` + ESC 키로 닫기
+- 폼 입력: \`<label>\`과 \`<input>\`을 연결 (for/id 또는 감싸기)
+- 키보드 탐색 가능: 탭 순서가 논리적, 포커스 표시 명확 (\`focus:ring-2\`)
+
+## 타이포그래피 체계
+
+일관된 텍스트 크기를 반드시 사용하라:
+- 페이지 타이틀: \`text-3xl sm:text-4xl font-bold tracking-tight\`
+- 섹션 제목: \`text-2xl font-bold\`
+- 카드/항목 제목: \`text-lg font-semibold\`
+- 본문: \`text-sm sm:text-base leading-relaxed\`
+- 캡션/보조: \`text-xs text-gray-500\`
+- 섹션 간 간격: \`space-y-8\` 또는 \`py-12\`
+- 텍스트 줄 간격: \`leading-relaxed\` (본문), \`leading-tight\` (제목)
+
+## 푸터 필수 패턴
+
+모든 페이지에 반드시 푸터를 포함하라:
+\`\`\`html
+<footer class="border-t border-gray-200 mt-16">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 py-8">
+    <div class="flex flex-col sm:flex-row justify-between items-center gap-4">
+      <p class="text-sm text-gray-500">© 2026 서비스이름. All rights reserved.</p>
+      <nav class="flex gap-6 text-sm text-gray-500">
+        <a href="#" class="hover:text-gray-900 transition-colors">이용약관</a>
+        <a href="#" class="hover:text-gray-900 transition-colors">개인정보처리방침</a>
+        <a href="#" class="hover:text-gray-900 transition-colors">고객센터</a>
+      </nav>
+    </div>
+  </div>
+</footer>
+\`\`\`
+다크 테마일 경우 \`border-gray-800\`, \`text-gray-400\`, \`hover:text-gray-100\`으로 조정.
+
+## 마이크로 인터랙션 (필수 적용)
+
+모든 인터랙티브 요소에 세밀한 피드백을 적용하라:
+- 버튼 클릭: \`active:scale-95 transition-transform duration-150\`
+- 카드 호버: \`hover:-translate-y-1 hover:shadow-xl transition-all duration-300\`
+- 폼 포커스: \`focus:ring-2 focus:ring-blue-500/40 focus:border-blue-500 transition-colors\`
+- 좋아요/북마크 토글: 색상 전환 + \`scale\` 애니메이션 (\`transform: scale(1.2)\` → \`scale(1)\`)
+- 링크/텍스트 호버: \`hover:text-blue-600 transition-colors duration-200\`
+- 텍스트 말줄임(\`line-clamp-2\`)에 호버 시 툴팁으로 전체 텍스트 표시
+- 드롭다운/메뉴 열기: \`opacity-0 scale-95\` → \`opacity-100 scale-100\` 트랜지션
+- 삭제 버튼: \`hover:bg-red-50 hover:text-red-600\` 경고 색상
+
+## 로딩 / 에러 / 빈 결과 상태 처리
+
+### API 호출 중 (로딩)
+목 데이터가 이미 렌더링된 상태에서 API 호출. 별도 로딩 스피너 불필요.
+만약 섹션별 업데이트가 필요하면 스켈레톤 UI 사용:
+\`\`\`html
+<div class="animate-pulse space-y-3">
+  <div class="h-4 bg-gray-200 rounded w-3/4"></div>
+  <div class="h-4 bg-gray-200 rounded w-1/2"></div>
+</div>
+\`\`\`
+
+### API 실패 시
+목 데이터를 유지하고, 상단에 비침습적 배너 표시:
+\`\`\`javascript
+function showApiBanner() {
+  const banner = document.createElement('div');
+  banner.className = 'bg-amber-50 border-b border-amber-200 px-4 py-2 text-center text-sm text-amber-700';
+  banner.innerHTML = '<i class="fas fa-info-circle mr-2"></i>실시간 데이터를 불러오지 못했습니다. 샘플 데이터를 표시합니다.';
+  document.body.prepend(banner);
+}
+\`\`\`
+
+### 검색 결과 0건
+\`\`\`html
+<div class="text-center py-16">
+  <i class="fas fa-search text-4xl text-gray-300 mb-4"></i>
+  <p class="text-gray-500 text-lg">"검색어"에 대한 결과가 없습니다</p>
+  <p class="text-gray-400 text-sm mt-2">다른 키워드로 검색해 보세요</p>
+</div>
+\`\`\`
+
 ## API 호출 규칙
 - auth_type이 'api_key'인 API → 서버 프록시:
   \`fetch('/api/v1/proxy?apiId=<ID>&proxyPath=<경로>&파라미터=값')\`
@@ -287,16 +500,31 @@ function showToast(message, type = 'success') {
 
 반환 전에 아래 항목을 하나씩 확인하세요. 하나라도 실패하면 수정 후 반환:
 
+### 콘텐츠 & 데이터
 □ 페이지를 열면 목 데이터가 즉시 보이는가? (빈 화면, "데이터가 없습니다" 없는가?)
+□ 목 데이터가 최소 15개 이상이고 현실적인 한국어인가?
+□ Chart.js에 실제 숫자가 들어있는가? (Chart.js가 불필요하면 포함하지 않았는가?)
+□ 모든 텍스트가 한국어인가? (UI, 목 데이터, placeholder 전부)
+
+### 레이아웃 & 디자인
 □ 헤더/타이틀이 가로로 정상 배치되는가? (세로 깨짐 없는가?)
-□ 카드가 그리드로 보기 좋게 배치되는가? (한 줄에 1개만 있지 않은가?)
-□ Chart.js에 실제 숫자가 들어있는가? (빈 차트가 아닌가?)
+□ 카드가 그리드로 보기 좋게 배치되는가? (데스크톱에서 2열 이상)
+□ 타이포그래피가 일관되는가? (H1 > H2 > H3 > 본문 > 캡션 크기 순서)
+□ 푸터가 포함되어 있는가? (서비스명 + 저작권 + 링크)
+□ 모바일에서도 레이아웃이 정상인가? (반응형 클래스 sm:/md:/lg: 사용)
+
+### 인터랙션 & UX
 □ 탭 클릭, 검색 입력, 카드 클릭 등 인터랙션이 모두 동작하는가?
-□ 모달/상세보기가 풍부한 내용으로 채워져 있는가?
-□ 모바일에서도 레이아웃이 정상인가?
-□ 모든 텍스트가 한국어인가?
+□ 모달/상세보기가 풍부한 내용으로 채워져 있고 ESC로 닫히는가?
 □ 호버 효과, 트랜지션, 애니메이션이 적용되어 있는가?
+□ 버튼 클릭 피드백(active:scale-95), 카드 호버 효과가 있는가?
 □ 화면에 움직이는 요소가 1개 이상 있는가? (카운터, 차트, 피드 등)
+
+### 접근성 & 품질
+□ 시맨틱 HTML을 사용하는가? (<main>, <nav>, <article>, <footer>)
+□ 모든 <img>에 한국어 alt 속성이 있는가?
+□ 아이콘만 있는 버튼에 aria-label이 있는가?
+□ API 호출 실패 시 목 데이터가 유지되는가?
 
 ## 절대 금지
 
@@ -309,10 +537,20 @@ function showToast(message, type = 'success') {
 - 정적이고 움직임이 없는 페이지
 - 영어 UI 텍스트 또는 영어 목 데이터
 - 서비스 타이틀이 세로로 표시되는 깨진 레이아웃
-- 1열로만 나열되는 카드/리스트 (데스크톱에서)`;
+- 1열로만 나열되는 카드/리스트 (데스크톱에서)
+- \`<div onclick>\` — 클릭 액션에는 반드시 \`<button>\` 사용
+- \`alt\` 속성 없는 \`<img>\` 태그
+- 푸터 없이 콘텐츠가 갑자기 끝나는 페이지
+- 불필요한 CDN 로드 (차트 없는 페이지에 Chart.js 등)
+- 일관성 없는 텍스트 크기 (체계 없이 제각각인 font-size)`;
 }
 
-export function buildUserPrompt(apis: ApiCatalogItem[], context: string, projectId?: string): string {
+export function buildUserPrompt(
+  apis: ApiCatalogItem[],
+  context: string,
+  projectId?: string,
+  designPreferences?: DesignPreferences
+): string {
   const apiDescriptions = apis
     .map((api, i) => {
       const endpoints = api.endpoints
@@ -338,12 +576,41 @@ ${endpoints}`;
     })
     .join('\n\n');
 
+  // 카테고리 기반 디자인 추론
+  const categories = [...new Set(apis.map((a) => a.category).filter(Boolean))];
+  const inference = inferDesignFromCategories(categories);
+
+  // 사용자 선호도 + AI 추론 결합
+  const hasUserPrefs = designPreferences && (
+    designPreferences.mood !== 'auto' ||
+    designPreferences.audience !== 'general' ||
+    designPreferences.layoutPreference !== 'auto'
+  );
+
+  const designSection = `
+## 디자인 가이드
+
+### API 분석 기반 추천
+- 감지된 API 카테고리: ${categories.join(', ') || '없음'}
+- 추천 서비스 유형: ${inference.description}
+- 추천 테마: ${inference.theme}
+- 추천 레이아웃: ${inference.layout}
+- 차트 필요: ${inference.useChart ? '예 (Chart.js CDN 포함)' : '아니오 (Chart.js 불필요)'}
+- 지도 필요: ${inference.useMap ? '예 (Leaflet CDN 포함)' : '아니오'}
+${hasUserPrefs ? `
+### 사용자 선호도 (추천보다 우선)
+${designPreferences.mood !== 'auto' ? `- 분위기: ${designPreferences.mood}` : ''}
+${designPreferences.audience !== 'general' ? `- 대상 고객: ${designPreferences.audience}` : ''}
+${designPreferences.layoutPreference !== 'auto' ? `- 레이아웃: ${designPreferences.layoutPreference}` : ''}
+사용자가 명시한 선호도는 위 AI 추천보다 우선 적용하세요.` : '위 추천을 기반으로 디자인하되, 사용자 요청에 더 적합한 대안이 있으면 자율적으로 변경 가능.'}`;
+
   return `## 선택된 API 목록
 
 ${apiDescriptions}
 
 ## 사용자 요청
 ${context}
+${designSection}
 
 ## 구현 지시
 

--- a/src/lib/ai/qualityLoop.test.ts
+++ b/src/lib/ai/qualityLoop.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { shouldRetryGeneration, buildQualityImprovementPrompt } from './qualityLoop';
+import type { QualityMetrics } from '@/lib/ai/codeValidator';
+
+describe('shouldRetryGeneration', () => {
+  it('점수 40 미만이면 true를 반환한다', () => {
+    const metrics: QualityMetrics = {
+      structuralScore: 30,
+      hasSemanticHtml: false,
+      hasMockData: false,
+      hasInteraction: false,
+      hasResponsiveClasses: true,
+      hasFooter: false,
+      hasImgAlt: false,
+      details: ['시맨틱 HTML 부족', '목 데이터 배열이 감지되지 않았습니다'],
+    };
+    expect(shouldRetryGeneration(metrics)).toBe(true);
+  });
+
+  it('점수 40 이상이면 false를 반환한다', () => {
+    const metrics: QualityMetrics = {
+      structuralScore: 70,
+      hasSemanticHtml: true,
+      hasMockData: true,
+      hasInteraction: true,
+      hasResponsiveClasses: true,
+      hasFooter: true,
+      hasImgAlt: true,
+      details: [],
+    };
+    expect(shouldRetryGeneration(metrics)).toBe(false);
+  });
+
+  it('정확히 40이면 false를 반환한다', () => {
+    const metrics: QualityMetrics = {
+      structuralScore: 40,
+      hasSemanticHtml: true,
+      hasMockData: true,
+      hasInteraction: false,
+      hasResponsiveClasses: true,
+      hasFooter: false,
+      hasImgAlt: true,
+      details: [],
+    };
+    expect(shouldRetryGeneration(metrics)).toBe(false);
+  });
+});
+
+describe('buildQualityImprovementPrompt', () => {
+  it('details 목록을 개선 지시에 포함한다', () => {
+    const metrics: QualityMetrics = {
+      structuralScore: 30,
+      hasSemanticHtml: false,
+      hasMockData: false,
+      hasInteraction: true,
+      hasResponsiveClasses: true,
+      hasFooter: false,
+      hasImgAlt: false,
+      details: ['시맨틱 HTML 부족', '<footer> 태그가 없습니다'],
+    };
+    const prompt = buildQualityImprovementPrompt(
+      { html: '<div>test</div>', css: '', js: '' },
+      metrics
+    );
+    expect(prompt).toContain('시맨틱 HTML 부족');
+    expect(prompt).toContain('<footer>');
+    expect(prompt).toContain('이전 생성 코드');
+    expect(prompt).toContain('30/100');
+  });
+
+  it('이전 코드를 코드 블록에 포함한다', () => {
+    const prompt = buildQualityImprovementPrompt(
+      { html: '<div>hello</div>', css: 'body{}', js: 'var x=1' },
+      { structuralScore: 20, hasSemanticHtml: false, hasMockData: false, hasInteraction: false, hasResponsiveClasses: false, hasFooter: false, hasImgAlt: false, details: ['test'] }
+    );
+    expect(prompt).toContain('<div>hello</div>');
+    expect(prompt).toContain('body{}');
+    expect(prompt).toContain('var x=1');
+  });
+});

--- a/src/lib/ai/qualityLoop.ts
+++ b/src/lib/ai/qualityLoop.ts
@@ -1,0 +1,64 @@
+import type { QualityMetrics } from '@/lib/ai/codeValidator';
+
+const QUALITY_THRESHOLD = 40;
+
+export function shouldRetryGeneration(metrics: QualityMetrics): boolean {
+  return metrics.structuralScore < QUALITY_THRESHOLD;
+}
+
+export function buildQualityImprovementPrompt(
+  previousCode: { html: string; css: string; js: string },
+  metrics: QualityMetrics
+): string {
+  const issues = metrics.details.map((d) => `- ${d}`).join('\n');
+
+  return `## 이전 생성 코드
+
+### HTML
+\`\`\`html
+${previousCode.html}
+\`\`\`
+
+### CSS
+\`\`\`css
+${previousCode.css}
+\`\`\`
+
+### JavaScript
+\`\`\`javascript
+${previousCode.js}
+\`\`\`
+
+## 품질 개선 요청
+
+이전 코드의 품질 점수가 ${metrics.structuralScore}/100으로 기준(${QUALITY_THRESHOLD}) 미달입니다.
+아래 문제를 반드시 수정하세요:
+
+${issues}
+
+수정 규칙:
+- 기존 기능과 디자인은 최대한 유지하면서 위 문제만 정확히 수정
+- 시맨틱 HTML 태그(<main>, <nav>, <footer>, <article>) 사용
+- 모든 <img>에 한국어 alt 속성 추가
+- 목 데이터가 없다면 const 배열로 최소 15개 추가
+- <footer> 태그로 서비스명 + 저작권 + 링크 포함
+- 반응형 클래스(sm:/md:/lg:) 사용
+- addEventListener로 인터랙션 추가 (탭, 검색, 모달)
+
+전체 코드를 반환해주세요:
+
+### HTML
+\`\`\`html
+(완전한 HTML 코드)
+\`\`\`
+
+### CSS
+\`\`\`css
+(CSS 코드)
+\`\`\`
+
+### JavaScript
+\`\`\`javascript
+(JavaScript 코드)
+\`\`\``;
+}

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -60,7 +60,9 @@ export class ProjectService {
       deployPlatform: null,
       repoUrl: null,
       previewUrl: null,
-      metadata: {} as ProjectMetadata,
+      metadata: {
+        ...(input.designPreferences ? { designPreferences: input.designPreferences } : {}),
+      } as ProjectMetadata,
       currentVersion: 0,
       apis: [] as ApiCatalogItem[], // stripped by ProjectRepository.toDatabase()
       slug: null,

--- a/src/stores/contextStore.ts
+++ b/src/stores/contextStore.ts
@@ -1,13 +1,21 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { LIMITS } from '@/lib/config/features';
+import type { DesignMood, DesignAudience, DesignLayout, DesignPreferences } from '@/types/project';
 
 interface ContextState {
   context: string;
   selectedTemplate: string | null;
+  mood: DesignMood;
+  audience: DesignAudience;
+  layoutPreference: DesignLayout;
 
   setContext: (context: string) => void;
   setTemplate: (templateId: string | null) => void;
+  setMood: (mood: DesignMood) => void;
+  setAudience: (audience: DesignAudience) => void;
+  setLayoutPreference: (layout: DesignLayout) => void;
+  getDesignPreferences: () => DesignPreferences;
   isValid: () => boolean;
   charCount: () => number;
   reset: () => void;
@@ -18,6 +26,9 @@ export const useContextStore = create<ContextState>()(
     (set, get) => ({
       context: '',
       selectedTemplate: null,
+      mood: 'auto' as DesignMood,
+      audience: 'general' as DesignAudience,
+      layoutPreference: 'auto' as DesignLayout,
 
       setContext: (context) => {
         if (context.length <= LIMITS.contextMaxLength) {
@@ -26,6 +37,14 @@ export const useContextStore = create<ContextState>()(
       },
 
       setTemplate: (selectedTemplate) => set({ selectedTemplate }),
+      setMood: (mood) => set({ mood }),
+      setAudience: (audience) => set({ audience }),
+      setLayoutPreference: (layoutPreference) => set({ layoutPreference }),
+
+      getDesignPreferences: () => {
+        const { mood, audience, layoutPreference } = get();
+        return { mood, audience, layoutPreference };
+      },
 
       isValid: () => {
         const { context } = get();
@@ -36,11 +55,24 @@ export const useContextStore = create<ContextState>()(
 
       charCount: () => get().context.length,
 
-      reset: () => set({ context: '', selectedTemplate: null }),
+      reset: () =>
+        set({
+          context: '',
+          selectedTemplate: null,
+          mood: 'auto' as DesignMood,
+          audience: 'general' as DesignAudience,
+          layoutPreference: 'auto' as DesignLayout,
+        }),
     }),
     {
       name: 'builder-context',
-      partialize: (state) => ({ context: state.context, selectedTemplate: state.selectedTemplate }),
+      partialize: (state) => ({
+        context: state.context,
+        selectedTemplate: state.selectedTemplate,
+        mood: state.mood,
+        audience: state.audience,
+        layoutPreference: state.layoutPreference,
+      }),
     }
   )
 );

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -10,6 +10,16 @@ export type ProjectStatus =
   | 'unpublished' // 게시 취소
   | 'failed';
 
+export type DesignMood = 'auto' | 'light' | 'dark' | 'warm' | 'colorful' | 'minimal';
+export type DesignAudience = 'general' | 'business' | 'youth' | 'premium';
+export type DesignLayout = 'auto' | 'dashboard' | 'gallery' | 'feed' | 'landing' | 'tool';
+
+export interface DesignPreferences {
+  mood: DesignMood;
+  audience: DesignAudience;
+  layoutPreference: DesignLayout;
+}
+
 export interface Project {
   id: string;
   userId: string;
@@ -71,6 +81,20 @@ export interface CodeMetadata {
   externalLibs?: string[];
   userFeedback?: string | null;
   validationErrors?: string[];
+  // evaluateQuality fields (Phase 2)
+  structuralScore?: number;
+  hasSemanticHtml?: boolean;
+  hasMockData?: boolean;
+  hasInteraction?: boolean;
+  hasResponsiveClasses?: boolean;
+  hasFooter?: boolean;
+  hasImgAlt?: boolean;
+  details?: string[];
+  // Phase 6 fields
+  apiCategories?: string[];
+  inferredTheme?: string;
+  inferredLayout?: string;
+  qualityLoopUsed?: boolean;
 }
 
 export interface CreateProjectInput {
@@ -78,4 +102,5 @@ export interface CreateProjectInput {
   context: string;
   apiIds: string[];
   organizationId?: string;
+  designPreferences?: DesignPreferences;
 }


### PR DESCRIPTION
## Summary

AI 코드 생성 파이프라인 전반을 개선하여 생성되는 웹페이지의 디자인 품질, 접근성, 성능, UX를 최고 수준으로 끌어올립니다.

### Phase 1-4: 프롬프트/검증/후처리/디자인 시스템
- 시스템 프롬프트에 접근성(a11y), 타이포그래피 체계, 푸터 패턴, 마이크로인터랙션, 로딩/에러 상태 가이드 추가
- `evaluateQuality()` 10개 품질 지표 스코어링 함수 신규
- `assembleHtml()` 후처리: OG 메타태그, 파비콘, lazy loading, CSS 변수, 프린트 스타일시트 자동 주입
- 테마 3→8개 확장 (오션블루, 포레스트그린, 선셋그래디언트, 파스텔, 모노크롬)
- 히어로 섹션 3변형 + 카드 3변형 코드 예시 추가
- 조건부 CDN (Chart.js는 필요 시에만)

### Phase 5: 사용자 디자인 선호도 입력
- `DesignPreferences` 타입 (mood/audience/layoutPreference) + Zustand 스토어 확장
- 칩 그룹 UI 컴포넌트 (분위기/대상고객/레이아웃 선택)
- 빌더 페이지 양쪽 모드에 통합 + 프로젝트 생성 API 스키마 확장

### Phase 6: 동적 프롬프트 + 품질 보증
- `categoryDesignMap` — API 카테고리→테마/레이아웃/CDN 자동 추론
- `buildUserPrompt`에 "디자인 가이드" 섹션 자동 삽입 (카테고리 추론 + 사용자 선호도)
- 품질 스코어 < 40 시 1회 자동 재생성 루프 (`qualityLoop`)
- 생성 metadata에 카테고리, 추론 테마, 품질 루프 사용 여부 저장

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] 전체 테스트 214개 통과 (19 파일)
- [x] 신규 테스트: categoryDesignMap (7개), qualityLoop (5개), evaluateQuality (5개)
- [ ] 동일 API+컨텍스트로 생성 전/후 비교 (디자인 다양성, 접근성, 푸터 유무)
- [ ] 빌더에서 선호도 선택 → 생성 결과 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)