### PR TITLE
test: 커버리지 대폭 개선 — 32개 테스트 파일 추가 (+459 테스트, ~71% 목표)

### DIFF
--- a/src/__tests__/repositories/drizzleCatalogRepository.test.ts
+++ b/src/__tests__/repositories/drizzleCatalogRepository.test.ts
@@ -1,0 +1,578 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import * as schema from '@/lib/db/schema';
+import { DrizzleCatalogRepository } from '@/repositories/drizzle/DrizzleCatalogRepository';
+
+const NOW = new Date('2026-04-26T00:00:00.000Z');
+
+function makeCatalogRow(overrides: Partial<typeof schema.apiCatalog.$inferSelect> = {}) {
+  return {
+    id: 'api-1',
+    name: '테스트 API',
+    description: '테스트용 API입니다',
+    category: 'weather',
+    base_url: 'https://api.example.com',
+    auth_type: 'none',
+    auth_config: {},
+    rate_limit: null,
+    is_active: true,
+    icon_url: null,
+    docs_url: null,
+    endpoints: [],
+    tags: [],
+    api_version: null,
+    deprecated_at: null,
+    successor_id: null,
+    cors_supported: true,
+    requires_proxy: false,
+    credit_required: null,
+    created_at: NOW,
+    updated_at: NOW,
+    ...overrides,
+  } as typeof schema.apiCatalog.$inferSelect;
+}
+
+function makeMockDb() {
+  return {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    execute: vi.fn(),
+  } as unknown as NodePgDatabase<typeof schema>;
+}
+
+describe('DrizzleCatalogRepository', () => {
+  let mockDb: ReturnType<typeof makeMockDb>;
+  let repo: DrizzleCatalogRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = makeMockDb();
+    repo = new DrizzleCatalogRepository(mockDb);
+  });
+
+  // ─── findById ──────────────────────────────────────────────────────────────
+  describe('findById()', () => {
+    it('ID가 일치하는 API 항목을 반환한다', async () => {
+      const row = makeCatalogRow();
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row]),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.findById('api-1');
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('api-1');
+      expect(result!.name).toBe('테스트 API');
+      expect(result!.baseUrl).toBe('https://api.example.com');
+    });
+
+    it('존재하지 않으면 null을 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.findById('non-existent');
+      expect(result).toBeNull();
+    });
+
+    it('toDomain이 camelCase 필드를 올바르게 매핑한다', async () => {
+      const row = makeCatalogRow({
+        base_url: 'https://api.test.com',
+        auth_type: 'api_key',
+        auth_config: { keyParam: 'apikey' },
+        icon_url: 'https://icon.com/icon.png',
+        docs_url: 'https://docs.example.com',
+        cors_supported: false,
+        requires_proxy: true,
+        credit_required: '5' as never,
+      });
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row]),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.findById('api-1');
+      expect(result!.baseUrl).toBe('https://api.test.com');
+      expect(result!.authType).toBe('api_key');
+      expect(result!.iconUrl).toBe('https://icon.com/icon.png');
+      expect(result!.docsUrl).toBe('https://docs.example.com');
+      expect(result!.corsSupported).toBe(false);
+      expect(result!.requiresProxy).toBe(true);
+      expect(result!.creditRequired).toBe(5);
+    });
+  });
+
+  // ─── findMany ──────────────────────────────────────────────────────────────
+  describe('findMany()', () => {
+    it('항목 목록과 total을 반환한다', async () => {
+      const rows = [makeCatalogRow(), makeCatalogRow({ id: 'api-2', name: '두번째 API' })];
+
+      vi.mocked(mockDb.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ total: 2 }]),
+          }),
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue(rows),
+                }),
+              }),
+            }),
+          }),
+        } as never);
+
+      const result = await repo.findMany();
+      expect(result.total).toBe(2);
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].id).toBe('api-1');
+      expect(result.items[1].id).toBe('api-2');
+    });
+
+    it('결과가 없으면 빈 배열과 total 0을 반환한다', async () => {
+      vi.mocked(mockDb.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ total: 0 }]),
+          }),
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue([]),
+                }),
+              }),
+            }),
+          }),
+        } as never);
+
+      const result = await repo.findMany();
+      expect(result.total).toBe(0);
+      expect(result.items).toEqual([]);
+    });
+  });
+
+  // ─── create ────────────────────────────────────────────────────────────────
+  describe('create()', () => {
+    it('새 API 항목을 삽입하고 반환한다', async () => {
+      const row = makeCatalogRow();
+      const mockReturning = vi.fn().mockResolvedValue([row]);
+      const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+      vi.mocked(mockDb.insert).mockReturnValue({ values: mockValues } as never);
+
+      const input = {
+        name: '테스트 API',
+        description: '설명',
+        category: 'weather',
+        baseUrl: 'https://api.example.com',
+        authType: 'none' as const,
+        authConfig: {},
+        rateLimit: null,
+        isActive: true,
+        iconUrl: null,
+        docsUrl: null,
+        endpoints: [],
+        tags: [],
+        apiVersion: null,
+        deprecatedAt: null,
+        successorId: null,
+        corsSupported: true,
+        requiresProxy: false,
+        creditRequired: null,
+      };
+
+      const result = await repo.create(input);
+      expect(mockDb.insert).toHaveBeenCalled();
+      expect(result.id).toBe('api-1');
+      expect(result.name).toBe('테스트 API');
+    });
+  });
+
+  // ─── update ────────────────────────────────────────────────────────────────
+  describe('update()', () => {
+    it('API 항목을 업데이트하고 반환한다', async () => {
+      const row = makeCatalogRow({ name: '업데이트된 API', is_active: false });
+      vi.mocked(mockDb.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([row]),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.update('api-1', { name: '업데이트된 API', isActive: false });
+      expect(result.name).toBe('업데이트된 API');
+      expect(result.isActive).toBe(false);
+    });
+  });
+
+  // ─── delete ────────────────────────────────────────────────────────────────
+  describe('delete()', () => {
+    it('API 항목을 삭제한다', async () => {
+      const mockWhere = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(mockDb.delete).mockReturnValue({ where: mockWhere } as never);
+
+      await repo.delete('api-1');
+      expect(mockDb.delete).toHaveBeenCalled();
+      expect(mockWhere).toHaveBeenCalled();
+    });
+  });
+
+  // ─── count ─────────────────────────────────────────────────────────────────
+  describe('count()', () => {
+    it('필터 없이 전체 수를 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ total: 42 }]),
+        }),
+      } as never);
+
+      const result = await repo.count();
+      expect(result).toBe(42);
+    });
+
+    it('결과가 없으면 0을 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      } as never);
+
+      const result = await repo.count();
+      expect(result).toBe(0);
+    });
+  });
+
+  // ─── search ────────────────────────────────────────────────────────────────
+  describe('search()', () => {
+    it('카테고리와 검색어로 필터링된 결과를 반환한다', async () => {
+      const rows = [makeCatalogRow()];
+
+      vi.mocked(mockDb.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ total: 1 }]),
+          }),
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue(rows),
+                }),
+              }),
+            }),
+          }),
+        } as never);
+
+      const result = await repo.search({ category: 'weather', search: '테스트', page: 1, limit: 10 });
+      expect(result.total).toBe(1);
+      expect(result.items).toHaveLength(1);
+    });
+
+    it('category가 all이면 카테고리 필터를 적용하지 않는다', async () => {
+      vi.mocked(mockDb.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ total: 5 }]),
+          }),
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue([]),
+                }),
+              }),
+            }),
+          }),
+        } as never);
+
+      const result = await repo.search({ category: 'all' });
+      expect(result.total).toBe(5);
+    });
+
+    it('limit을 100으로 제한한다', async () => {
+      vi.mocked(mockDb.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ total: 0 }]),
+          }),
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue([]),
+                }),
+              }),
+            }),
+          }),
+        } as never);
+
+      const result = await repo.search({ limit: 999 });
+      expect(result.total).toBe(0);
+    });
+  });
+
+  // ─── getCategories ─────────────────────────────────────────────────────────
+  describe('getCategories()', () => {
+    it('카테고리별 집계 결과를 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            { category: 'weather' },
+            { category: 'weather' },
+            { category: 'finance' },
+          ]),
+        }),
+      } as never);
+
+      const result = await repo.getCategories();
+      expect(result.length).toBe(2);
+      const weather = result.find((c) => c.key === 'weather');
+      expect(weather?.count).toBe(2);
+      const finance = result.find((c) => c.key === 'finance');
+      expect(finance?.count).toBe(1);
+    });
+
+    it('category가 null이면 unknown으로 집계한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ category: null }]),
+        }),
+      } as never);
+
+      const result = await repo.getCategories();
+      expect(result[0].key).toBe('unknown');
+      expect(result[0].count).toBe(1);
+    });
+
+    it('결과가 없으면 빈 배열을 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      } as never);
+
+      const result = await repo.getCategories();
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ─── findByIds ─────────────────────────────────────────────────────────────
+  describe('findByIds()', () => {
+    it('ID 목록에 해당하는 항목들을 반환한다', async () => {
+      const rows = [
+        makeCatalogRow({ id: 'api-1' }),
+        makeCatalogRow({ id: 'api-2', name: '두번째 API' }),
+      ];
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(rows),
+        }),
+      } as never);
+
+      const result = await repo.findByIds(['api-1', 'api-2']);
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('api-1');
+      expect(result[1].id).toBe('api-2');
+    });
+
+    it('빈 배열이면 DB를 호출하지 않고 즉시 [] 반환한다', async () => {
+      const result = await repo.findByIds([]);
+      expect(result).toEqual([]);
+      expect(mockDb.select).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── getApiUsageFromProjects ────────────────────────────────────────────────
+  describe('getApiUsageFromProjects()', () => {
+    it('innerJoin으로 API 사용 목록을 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([
+              { api_id: 'api-1', context: '날씨 앱' },
+              { api_id: 'api-2', context: null },
+            ]),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.getApiUsageFromProjects(['published']);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ apiId: 'api-1', context: '날씨 앱' });
+      expect(result[1]).toEqual({ apiId: 'api-2', context: '' }); // null → ''
+    });
+  });
+
+  // ─── getActiveNameToIdMap ──────────────────────────────────────────────────
+  describe('getActiveNameToIdMap()', () => {
+    it('소문자 이름 → ID 매핑 Map을 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            { id: 'api-1', name: 'OpenWeather' },
+            { id: 'api-2', name: 'ExchangeRate' },
+          ]),
+        }),
+      } as never);
+
+      const result = await repo.getActiveNameToIdMap();
+      expect(result.get('openweather')).toBe('api-1');
+      expect(result.get('exchangerate')).toBe('api-2');
+    });
+
+    it('결과가 없으면 빈 Map을 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      } as never);
+
+      const result = await repo.getActiveNameToIdMap();
+      expect(result.size).toBe(0);
+    });
+  });
+
+  // ─── ping ──────────────────────────────────────────────────────────────────
+  describe('ping()', () => {
+    it('DB 조회 성공 시 true를 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ n: 1 }]),
+        }),
+      } as never);
+
+      const result = await repo.ping();
+      expect(result).toBe(true);
+    });
+
+    it('DB 조회 실패 시 false를 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          limit: vi.fn().mockRejectedValue(new Error('연결 실패')),
+        }),
+      } as never);
+
+      const result = await repo.ping();
+      expect(result).toBe(false);
+    });
+  });
+
+  // ─── getUsageCounts ────────────────────────────────────────────────────────
+  describe('getUsageCounts()', () => {
+    it('오늘 생성 수, 전체 프로젝트 수, 전체 사용자 수를 병렬로 조회한다', async () => {
+      vi.mocked(mockDb.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ n: 10 }]),
+          }),
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockResolvedValue([{ n: 50 }]),
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockResolvedValue([{ n: 20 }]),
+        } as never);
+
+      const result = await repo.getUsageCounts(new Date('2026-04-26T00:00:00.000Z'));
+      expect(result.todayGenerations).toBe(10);
+      expect(result.totalProjects).toBe(50);
+      expect(result.totalUsers).toBe(20);
+    });
+
+    it('결과가 없으면 0으로 반환한다', async () => {
+      vi.mocked(mockDb.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([]),
+          }),
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockResolvedValue([]),
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockResolvedValue([]),
+        } as never);
+
+      const result = await repo.getUsageCounts(new Date());
+      expect(result.todayGenerations).toBe(0);
+      expect(result.totalProjects).toBe(0);
+      expect(result.totalUsers).toBe(0);
+    });
+  });
+
+  // ─── 에러 전파 ─────────────────────────────────────────────────────────────
+  describe('에러 전파', () => {
+    it('findById — DB 에러를 그대로 던진다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockRejectedValue(new Error('DB 연결 실패')),
+          }),
+        }),
+      } as never);
+
+      await expect(repo.findById('api-1')).rejects.toThrow('DB 연결 실패');
+    });
+
+    it('create — DB 에러를 그대로 던진다', async () => {
+      const mockReturning = vi.fn().mockRejectedValue(new Error('삽입 실패'));
+      const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+      vi.mocked(mockDb.insert).mockReturnValue({ values: mockValues } as never);
+
+      await expect(
+        repo.create({
+          name: '테스트',
+          description: '설명',
+          category: 'weather',
+          baseUrl: 'https://api.example.com',
+          authType: 'none',
+          authConfig: {},
+          rateLimit: null,
+          isActive: true,
+          iconUrl: null,
+          docsUrl: null,
+          endpoints: [],
+          tags: [],
+          apiVersion: null,
+          deprecatedAt: null,
+          successorId: null,
+          corsSupported: true,
+          requiresProxy: false,
+          creditRequired: null,
+        })
+      ).rejects.toThrow('삽입 실패');
+    });
+
+    it('delete — DB 에러를 그대로 던진다', async () => {
+      vi.mocked(mockDb.delete).mockReturnValue({
+        where: vi.fn().mockRejectedValue(new Error('삭제 실패')),
+      } as never);
+
+      await expect(repo.delete('api-1')).rejects.toThrow('삭제 실패');
+    });
+  });
+});

--- a/src/__tests__/repositories/drizzleEventRepository.test.ts
+++ b/src/__tests__/repositories/drizzleEventRepository.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import * as schema from '@/lib/db/schema';
+import { DrizzleEventRepository } from '@/repositories/drizzle/DrizzleEventRepository';
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+const NOW = new Date('2026-04-26T00:00:00.000Z');
+
+function makeMockDb() {
+  return {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    execute: vi.fn(),
+  } as unknown as NodePgDatabase<typeof schema>;
+}
+
+describe('DrizzleEventRepository', () => {
+  let mockDb: ReturnType<typeof makeMockDb>;
+  let repo: DrizzleEventRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = makeMockDb();
+    repo = new DrizzleEventRepository(mockDb);
+  });
+
+  // ─── persist ───────────────────────────────────────────────────────────────
+  describe('persist()', () => {
+    it('이벤트를 DB에 삽입한다', async () => {
+      const mockValues = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(mockDb.insert).mockReturnValue({ values: mockValues } as never);
+
+      await repo.persist(
+        { type: 'USER_SIGNED_UP', payload: { userId: 'user-1' } },
+        { userId: 'user-1' }
+      );
+
+      expect(mockDb.insert).toHaveBeenCalled();
+      expect(mockValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'USER_SIGNED_UP',
+          user_id: 'user-1',
+        })
+      );
+    });
+
+    it('context가 없으면 payload에서 userId와 projectId를 추출한다', async () => {
+      const mockValues = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(mockDb.insert).mockReturnValue({ values: mockValues } as never);
+
+      await repo.persist({
+        type: 'PROJECT_CREATED',
+        payload: { projectId: 'proj-1', userId: 'user-1', apiCount: 2 },
+      });
+
+      expect(mockValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'PROJECT_CREATED',
+          user_id: 'user-1',
+          project_id: 'proj-1',
+        })
+      );
+    });
+
+    it('DB 에러 발생 시 logger.warn을 호출하고 throw하지 않는다', async () => {
+      const { logger } = await import('@/lib/utils/logger');
+      const mockValues = vi.fn().mockRejectedValue(new Error('DB 오류'));
+      vi.mocked(mockDb.insert).mockReturnValue({ values: mockValues } as never);
+
+      await expect(
+        repo.persist({ type: 'USER_SIGNED_UP', payload: { userId: 'user-1' } })
+      ).resolves.toBeUndefined();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Failed to persist domain event',
+        expect.objectContaining({ eventType: 'USER_SIGNED_UP' })
+      );
+    });
+
+    it('context.correlationId를 warn 로그에 포함한다', async () => {
+      const { logger } = await import('@/lib/utils/logger');
+      const mockValues = vi.fn().mockRejectedValue(new Error('에러'));
+      vi.mocked(mockDb.insert).mockReturnValue({ values: mockValues } as never);
+
+      await repo.persist(
+        { type: 'USER_SIGNED_UP', payload: { userId: 'user-1' } },
+        { correlationId: 'corr-abc' }
+      );
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Failed to persist domain event',
+        expect.objectContaining({ correlationId: 'corr-abc' })
+      );
+    });
+  });
+
+  // ─── persistAsync ──────────────────────────────────────────────────────────
+  describe('persistAsync()', () => {
+    it('fire-and-forget으로 이벤트를 저장한다', async () => {
+      const mockValues = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(mockDb.insert).mockReturnValue({ values: mockValues } as never);
+
+      repo.persistAsync({ type: 'USER_SIGNED_UP', payload: { userId: 'user-1' } });
+
+      // fire-and-forget이므로 insert가 호출되도록 대기
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(mockDb.insert).toHaveBeenCalled();
+    });
+
+    it('내부 에러 발생 시 logger.warn을 호출한다', async () => {
+      const { logger } = await import('@/lib/utils/logger');
+
+      // persist 자체가 에러를 삼키므로 persistAsync도 조용히 처리됨
+      // insert 자체는 에러를 throw하지 않지만 persist 내부에서 catch됨
+      const mockValues = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(mockDb.insert).mockReturnValue({ values: mockValues } as never);
+
+      repo.persistAsync({ type: 'USER_SIGNED_UP', payload: { userId: 'user-1' } });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // 정상 케이스이므로 warn은 호출되지 않아야 함
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── findByUser ────────────────────────────────────────────────────────────
+  describe('findByUser()', () => {
+    it('사용자의 이벤트 목록을 반환한다', async () => {
+      const rows = [
+        {
+          id: 'evt-1',
+          type: 'USER_SIGNED_UP',
+          payload: { userId: 'user-1' },
+          created_at: NOW,
+        },
+        {
+          id: 'evt-2',
+          type: 'PROJECT_CREATED',
+          payload: { projectId: 'proj-1', userId: 'user-1', apiCount: 1 },
+          created_at: NOW,
+        },
+      ];
+
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue(rows),
+            }),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.findByUser('user-1');
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('evt-1');
+      expect(result[0].type).toBe('USER_SIGNED_UP');
+      expect(result[0].createdAt).toBe(String(NOW));
+      expect(result[1].id).toBe('evt-2');
+    });
+
+    it('이벤트가 없으면 빈 배열을 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.findByUser('user-no-events');
+      expect(result).toEqual([]);
+    });
+
+    it('limit을 100으로 제한한다', async () => {
+      const mockLimit = vi.fn().mockResolvedValue([]);
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: mockLimit,
+            }),
+          }),
+        }),
+      } as never);
+
+      await repo.findByUser('user-1', 999);
+      expect(mockLimit).toHaveBeenCalledWith(100);
+    });
+
+    it('기본 limit은 50이다', async () => {
+      const mockLimit = vi.fn().mockResolvedValue([]);
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: mockLimit,
+            }),
+          }),
+        }),
+      } as never);
+
+      await repo.findByUser('user-1');
+      expect(mockLimit).toHaveBeenCalledWith(50);
+    });
+
+    it('DB 에러 발생 시 logger.warn을 호출하고 빈 배열을 반환한다', async () => {
+      const { logger } = await import('@/lib/utils/logger');
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockRejectedValue(new Error('조회 실패')),
+            }),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.findByUser('user-1');
+      expect(result).toEqual([]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Failed to fetch user events',
+        expect.objectContaining({ userId: 'user-1' })
+      );
+    });
+  });
+});

--- a/src/__tests__/repositories/drizzleRateLimitRepository.test.ts
+++ b/src/__tests__/repositories/drizzleRateLimitRepository.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import * as schema from '@/lib/db/schema';
+import { DrizzleRateLimitRepository } from '@/repositories/drizzle/DrizzleRateLimitRepository';
+
+function makeMockDb() {
+  return {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    execute: vi.fn(),
+  } as unknown as NodePgDatabase<typeof schema>;
+}
+
+describe('DrizzleRateLimitRepository', () => {
+  let mockDb: ReturnType<typeof makeMockDb>;
+  let repo: DrizzleRateLimitRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = makeMockDb();
+    repo = new DrizzleRateLimitRepository(mockDb);
+  });
+
+  // ─── checkAndIncrementDailyLimit ──────────────────────────────────────────
+  describe('checkAndIncrementDailyLimit()', () => {
+    it('한도 이내면 true를 반환한다', async () => {
+      vi.mocked(mockDb.execute).mockResolvedValue({ rows: [{ result: true }] } as never);
+
+      const result = await repo.checkAndIncrementDailyLimit('user-1', 10);
+      expect(result).toBe(true);
+      expect(mockDb.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('한도 초과면 false를 반환한다', async () => {
+      vi.mocked(mockDb.execute).mockResolvedValue({ rows: [{ result: false }] } as never);
+
+      const result = await repo.checkAndIncrementDailyLimit('user-1', 10);
+      expect(result).toBe(false);
+    });
+
+    it('rows가 비어있으면 false를 반환한다', async () => {
+      vi.mocked(mockDb.execute).mockResolvedValue({ rows: [] } as never);
+
+      const result = await repo.checkAndIncrementDailyLimit('user-1', 10);
+      expect(result).toBe(false);
+    });
+
+    it('DB 에러를 그대로 던진다', async () => {
+      vi.mocked(mockDb.execute).mockRejectedValue(new Error('DB 오류'));
+
+      await expect(repo.checkAndIncrementDailyLimit('user-1', 10)).rejects.toThrow('DB 오류');
+    });
+  });
+
+  // ─── decrementDailyLimit ──────────────────────────────────────────────────
+  describe('decrementDailyLimit()', () => {
+    it('일일 한도를 감소시킨다', async () => {
+      vi.mocked(mockDb.execute).mockResolvedValue({ rows: [] } as never);
+
+      await repo.decrementDailyLimit('user-1');
+      expect(mockDb.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('DB 에러를 그대로 던진다', async () => {
+      vi.mocked(mockDb.execute).mockRejectedValue(new Error('감소 실패'));
+
+      await expect(repo.decrementDailyLimit('user-1')).rejects.toThrow('감소 실패');
+    });
+  });
+
+  // ─── getCurrentUsage ──────────────────────────────────────────────────────
+  describe('getCurrentUsage()', () => {
+    it('현재 사용량을 반환한다', async () => {
+      vi.mocked(mockDb.execute).mockResolvedValue({ rows: [{ count: 5 }] } as never);
+
+      const result = await repo.getCurrentUsage('user-1');
+      expect(result).toBe(5);
+    });
+
+    it('rows가 비어있으면 0을 반환한다', async () => {
+      vi.mocked(mockDb.execute).mockResolvedValue({ rows: [] } as never);
+
+      const result = await repo.getCurrentUsage('user-1');
+      expect(result).toBe(0);
+    });
+
+    it('count가 0이면 0을 반환한다', async () => {
+      vi.mocked(mockDb.execute).mockResolvedValue({ rows: [{ count: 0 }] } as never);
+
+      const result = await repo.getCurrentUsage('user-1');
+      expect(result).toBe(0);
+    });
+
+    it('DB 에러를 그대로 던진다', async () => {
+      vi.mocked(mockDb.execute).mockRejectedValue(new Error('조회 실패'));
+
+      await expect(repo.getCurrentUsage('user-1')).rejects.toThrow('조회 실패');
+    });
+  });
+
+  // ─── checkAndIncrementDailyDeployLimit ────────────────────────────────────
+  describe('checkAndIncrementDailyDeployLimit()', () => {
+    it('배포 한도 이내면 true를 반환한다', async () => {
+      vi.mocked(mockDb.execute).mockResolvedValue({ rows: [{ result: true }] } as never);
+
+      const result = await repo.checkAndIncrementDailyDeployLimit('user-1', 5);
+      expect(result).toBe(true);
+      expect(mockDb.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('배포 한도 초과면 false를 반환한다', async () => {
+      vi.mocked(mockDb.execute).mockResolvedValue({ rows: [{ result: false }] } as never);
+
+      const result = await repo.checkAndIncrementDailyDeployLimit('user-1', 5);
+      expect(result).toBe(false);
+    });
+
+    it('rows가 비어있으면 false를 반환한다', async () => {
+      vi.mocked(mockDb.execute).mockResolvedValue({ rows: [] } as never);
+
+      const result = await repo.checkAndIncrementDailyDeployLimit('user-1', 5);
+      expect(result).toBe(false);
+    });
+
+    it('DB 에러를 그대로 던진다', async () => {
+      vi.mocked(mockDb.execute).mockRejectedValue(new Error('배포 한도 확인 실패'));
+
+      await expect(repo.checkAndIncrementDailyDeployLimit('user-1', 5)).rejects.toThrow(
+        '배포 한도 확인 실패'
+      );
+    });
+  });
+});

--- a/src/__tests__/repositories/drizzleUserApiKeyRepository.test.ts
+++ b/src/__tests__/repositories/drizzleUserApiKeyRepository.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import * as schema from '@/lib/db/schema';
+import { DrizzleUserApiKeyRepository } from '@/repositories/drizzle/DrizzleUserApiKeyRepository';
+
+const NOW = new Date('2026-04-26T00:00:00.000Z');
+
+function makeApiKeyRow(overrides: Partial<typeof schema.userApiKeys.$inferSelect> = {}) {
+  return {
+    id: 'key-1',
+    user_id: 'user-1',
+    api_id: 'api-1',
+    encrypted_key: 'enc:secret-key',
+    is_verified: false,
+    verified_at: null,
+    created_at: NOW,
+    updated_at: NOW,
+    ...overrides,
+  } as typeof schema.userApiKeys.$inferSelect;
+}
+
+function makeMockDb() {
+  return {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    execute: vi.fn(),
+  } as unknown as NodePgDatabase<typeof schema>;
+}
+
+describe('DrizzleUserApiKeyRepository', () => {
+  let mockDb: ReturnType<typeof makeMockDb>;
+  let repo: DrizzleUserApiKeyRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = makeMockDb();
+    repo = new DrizzleUserApiKeyRepository(mockDb);
+  });
+
+  // ─── upsert ────────────────────────────────────────────────────────────────
+  describe('upsert()', () => {
+    it('API 키를 삽입하고 반환한다', async () => {
+      const row = makeApiKeyRow();
+      const mockReturning = vi.fn().mockResolvedValue([row]);
+      const mockOnConflict = vi.fn().mockReturnValue({ returning: mockReturning });
+      const mockValues = vi.fn().mockReturnValue({ onConflictDoUpdate: mockOnConflict });
+      vi.mocked(mockDb.insert).mockReturnValue({ values: mockValues } as never);
+
+      const result = await repo.upsert('user-1', 'api-1', 'enc:secret-key');
+
+      expect(mockDb.insert).toHaveBeenCalled();
+      expect(result.id).toBe('key-1');
+      expect(result.userId).toBe('user-1');
+      expect(result.apiId).toBe('api-1');
+      expect(result.encryptedKey).toBe('enc:secret-key');
+      expect(result.isVerified).toBe(false);
+      expect(result.verifiedAt).toBeNull();
+    });
+
+    it('이미 존재하는 키도 업데이트하고 반환한다', async () => {
+      const row = makeApiKeyRow({ encrypted_key: 'enc:new-key' });
+      const mockReturning = vi.fn().mockResolvedValue([row]);
+      const mockOnConflict = vi.fn().mockReturnValue({ returning: mockReturning });
+      const mockValues = vi.fn().mockReturnValue({ onConflictDoUpdate: mockOnConflict });
+      vi.mocked(mockDb.insert).mockReturnValue({ values: mockValues } as never);
+
+      const result = await repo.upsert('user-1', 'api-1', 'enc:new-key');
+      expect(result.encryptedKey).toBe('enc:new-key');
+    });
+
+    it('toDomain이 verifiedAt을 String으로 변환한다', async () => {
+      const verifiedAt = new Date('2026-04-26T10:00:00.000Z');
+      const row = makeApiKeyRow({ is_verified: true, verified_at: verifiedAt });
+      const mockReturning = vi.fn().mockResolvedValue([row]);
+      const mockOnConflict = vi.fn().mockReturnValue({ returning: mockReturning });
+      const mockValues = vi.fn().mockReturnValue({ onConflictDoUpdate: mockOnConflict });
+      vi.mocked(mockDb.insert).mockReturnValue({ values: mockValues } as never);
+
+      const result = await repo.upsert('user-1', 'api-1', 'enc:key');
+      expect(result.isVerified).toBe(true);
+      expect(result.verifiedAt).toBe(String(verifiedAt));
+    });
+  });
+
+  // ─── delete ────────────────────────────────────────────────────────────────
+  describe('delete()', () => {
+    it('userId와 apiId로 API 키를 삭제한다', async () => {
+      const mockWhere = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(mockDb.delete).mockReturnValue({ where: mockWhere } as never);
+
+      await repo.delete('user-1', 'api-1');
+      expect(mockDb.delete).toHaveBeenCalled();
+      expect(mockWhere).toHaveBeenCalled();
+    });
+
+    it('DB 에러를 그대로 던진다', async () => {
+      vi.mocked(mockDb.delete).mockReturnValue({
+        where: vi.fn().mockRejectedValue(new Error('삭제 실패')),
+      } as never);
+
+      await expect(repo.delete('user-1', 'api-1')).rejects.toThrow('삭제 실패');
+    });
+  });
+
+  // ─── findByUserAndApi ──────────────────────────────────────────────────────
+  describe('findByUserAndApi()', () => {
+    it('userId와 apiId가 일치하는 키를 반환한다', async () => {
+      const row = makeApiKeyRow();
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row]),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.findByUserAndApi('user-1', 'api-1');
+      expect(result).not.toBeNull();
+      expect(result!.userId).toBe('user-1');
+      expect(result!.apiId).toBe('api-1');
+    });
+
+    it('존재하지 않으면 null을 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.findByUserAndApi('user-1', 'api-999');
+      expect(result).toBeNull();
+    });
+  });
+
+  // ─── findAllByUser ─────────────────────────────────────────────────────────
+  describe('findAllByUser()', () => {
+    it('사용자의 모든 API 키를 반환한다', async () => {
+      const rows = [
+        makeApiKeyRow({ id: 'key-1', api_id: 'api-1' }),
+        makeApiKeyRow({ id: 'key-2', api_id: 'api-2' }),
+      ];
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(rows),
+        }),
+      } as never);
+
+      const result = await repo.findAllByUser('user-1');
+      expect(result).toHaveLength(2);
+      expect(result[0].apiId).toBe('api-1');
+      expect(result[1].apiId).toBe('api-2');
+    });
+
+    it('API 키가 없으면 빈 배열을 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      } as never);
+
+      const result = await repo.findAllByUser('user-no-keys');
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ─── updateVerificationStatus ──────────────────────────────────────────────
+  describe('updateVerificationStatus()', () => {
+    it('인증 상태를 true로 업데이트한다', async () => {
+      const mockWhere = vi.fn().mockResolvedValue(undefined);
+      const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
+      vi.mocked(mockDb.update).mockReturnValue({ set: mockSet } as never);
+
+      await repo.updateVerificationStatus('user-1', 'api-1', true);
+
+      expect(mockDb.update).toHaveBeenCalled();
+      const setArg = mockSet.mock.calls[0][0];
+      expect(setArg.is_verified).toBe(true);
+      expect(setArg.verified_at).toBeInstanceOf(Date);
+      expect(setArg.updated_at).toBeInstanceOf(Date);
+    });
+
+    it('인증 상태를 false로 업데이트하면 verified_at이 null이 된다', async () => {
+      const mockWhere = vi.fn().mockResolvedValue(undefined);
+      const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
+      vi.mocked(mockDb.update).mockReturnValue({ set: mockSet } as never);
+
+      await repo.updateVerificationStatus('user-1', 'api-1', false);
+
+      const setArg = mockSet.mock.calls[0][0];
+      expect(setArg.is_verified).toBe(false);
+      expect(setArg.verified_at).toBeNull();
+    });
+
+    it('DB 에러를 그대로 던진다', async () => {
+      vi.mocked(mockDb.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockRejectedValue(new Error('업데이트 실패')),
+        }),
+      } as never);
+
+      await expect(repo.updateVerificationStatus('user-1', 'api-1', true)).rejects.toThrow(
+        '업데이트 실패'
+      );
+    });
+  });
+});

--- a/src/__tests__/repositories/drizzleUserRepository.test.ts
+++ b/src/__tests__/repositories/drizzleUserRepository.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import * as schema from '@/lib/db/schema';
+import { DrizzleUserRepository } from '@/repositories/drizzle/DrizzleUserRepository';
+
+const NOW = new Date('2026-04-26T00:00:00.000Z');
+
+function makeUserRow(overrides: Partial<typeof schema.users.$inferSelect> = {}) {
+  return {
+    id: 'user-1',
+    email: 'test@example.com',
+    name: null,
+    avatar_url: null,
+    emailVerified: null,
+    image: null,
+    preferences: {},
+    created_at: NOW,
+    updated_at: NOW,
+    ...overrides,
+  } as typeof schema.users.$inferSelect;
+}
+
+function makeMockDb() {
+  return {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    execute: vi.fn(),
+  } as unknown as NodePgDatabase<typeof schema>;
+}
+
+describe('DrizzleUserRepository', () => {
+  let mockDb: ReturnType<typeof makeMockDb>;
+  let repo: DrizzleUserRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = makeMockDb();
+    repo = new DrizzleUserRepository(mockDb);
+  });
+
+  // ─── findById ──────────────────────────────────────────────────────────────
+  describe('findById()', () => {
+    it('ID가 일치하는 사용자를 반환한다', async () => {
+      const row = makeUserRow({ name: '홍길동', email: 'hong@example.com' });
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row]),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.findById('user-1');
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('user-1');
+      expect(result!.email).toBe('hong@example.com');
+      expect(result!.name).toBe('홍길동');
+    });
+
+    it('존재하지 않으면 null을 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.findById('non-existent');
+      expect(result).toBeNull();
+    });
+
+    it('toDomain이 nullable 필드를 기본값으로 매핑한다', async () => {
+      const row = makeUserRow({ name: null, avatar_url: null, preferences: null as never });
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row]),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.findById('user-1');
+      expect(result!.name).toBeNull();
+      expect(result!.avatarUrl).toBeNull();
+      expect(result!.preferences).toEqual({});
+      expect(result!.createdAt).toBe(String(NOW));
+      expect(result!.updatedAt).toBe(String(NOW));
+    });
+  });
+
+  // ─── findMany ──────────────────────────────────────────────────────────────
+  describe('findMany()', () => {
+    it('사용자 목록과 total을 반환한다', async () => {
+      const rows = [
+        makeUserRow({ id: 'user-1' }),
+        makeUserRow({ id: 'user-2', email: 'user2@example.com' }),
+      ];
+
+      vi.mocked(mockDb.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ total: 2 }]),
+          }),
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue(rows),
+                }),
+              }),
+            }),
+          }),
+        } as never);
+
+      const result = await repo.findMany();
+      expect(result.total).toBe(2);
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].id).toBe('user-1');
+      expect(result.items[1].id).toBe('user-2');
+    });
+
+    it('결과가 없으면 빈 배열과 total 0을 반환한다', async () => {
+      vi.mocked(mockDb.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ total: 0 }]),
+          }),
+        } as never)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue([]),
+                }),
+              }),
+            }),
+          }),
+        } as never);
+
+      const result = await repo.findMany();
+      expect(result.total).toBe(0);
+      expect(result.items).toEqual([]);
+    });
+  });
+
+  // ─── create ────────────────────────────────────────────────────────────────
+  describe('create()', () => {
+    it('사용자를 삽입하고 반환한다', async () => {
+      const row = makeUserRow({ email: 'new@example.com' });
+      const mockReturning = vi.fn().mockResolvedValue([row]);
+      const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+      vi.mocked(mockDb.insert).mockReturnValue({ values: mockValues } as never);
+
+      const result = await repo.create({
+        email: 'new@example.com',
+        name: null,
+        avatarUrl: null,
+        preferences: {},
+      });
+
+      expect(mockDb.insert).toHaveBeenCalled();
+      expect(result.email).toBe('new@example.com');
+    });
+  });
+
+  // ─── update ────────────────────────────────────────────────────────────────
+  describe('update()', () => {
+    it('사용자 정보를 업데이트하고 반환한다', async () => {
+      const row = makeUserRow({ name: '수정된이름' });
+      vi.mocked(mockDb.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([row]),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.update('user-1', { name: '수정된이름' });
+      expect(result.name).toBe('수정된이름');
+    });
+  });
+
+  // ─── delete ────────────────────────────────────────────────────────────────
+  describe('delete()', () => {
+    it('사용자를 삭제한다', async () => {
+      const mockWhere = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(mockDb.delete).mockReturnValue({ where: mockWhere } as never);
+
+      await repo.delete('user-1');
+      expect(mockDb.delete).toHaveBeenCalled();
+      expect(mockWhere).toHaveBeenCalled();
+    });
+  });
+
+  // ─── count ─────────────────────────────────────────────────────────────────
+  describe('count()', () => {
+    it('사용자 수를 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ total: 7 }]),
+        }),
+      } as never);
+
+      const result = await repo.count();
+      expect(result).toBe(7);
+    });
+
+    it('결과가 없으면 0을 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      } as never);
+
+      const result = await repo.count();
+      expect(result).toBe(0);
+    });
+  });
+
+  // ─── createWithAuthId ──────────────────────────────────────────────────────
+  describe('createWithAuthId()', () => {
+    it('authId를 id로 사용해 사용자를 생성한다', async () => {
+      const row = makeUserRow({ id: 'auth-uuid-123', email: 'auth@example.com' });
+      const mockReturning = vi.fn().mockResolvedValue([row]);
+      const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+      vi.mocked(mockDb.insert).mockReturnValue({ values: mockValues } as never);
+
+      const result = await repo.createWithAuthId('auth-uuid-123', {
+        email: 'auth@example.com',
+        name: null,
+        avatarUrl: null,
+        preferences: {},
+      });
+
+      expect(mockDb.insert).toHaveBeenCalled();
+      expect(result.id).toBe('auth-uuid-123');
+      expect(result.email).toBe('auth@example.com');
+    });
+  });
+
+  // ─── findByEmail ───────────────────────────────────────────────────────────
+  describe('findByEmail()', () => {
+    it('이메일이 일치하는 사용자를 반환한다', async () => {
+      const row = makeUserRow({ email: 'find@example.com' });
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([row]),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.findByEmail('find@example.com');
+      expect(result).not.toBeNull();
+      expect(result!.email).toBe('find@example.com');
+    });
+
+    it('이메일이 없으면 null을 반환한다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as never);
+
+      const result = await repo.findByEmail('notfound@example.com');
+      expect(result).toBeNull();
+    });
+  });
+
+  // ─── 에러 전파 ─────────────────────────────────────────────────────────────
+  describe('에러 전파', () => {
+    it('findById — DB 에러를 그대로 던진다', async () => {
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockRejectedValue(new Error('DB 연결 실패')),
+          }),
+        }),
+      } as never);
+
+      await expect(repo.findById('user-1')).rejects.toThrow('DB 연결 실패');
+    });
+
+    it('update — DB 에러를 그대로 던진다', async () => {
+      vi.mocked(mockDb.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockRejectedValue(new Error('업데이트 실패')),
+          }),
+        }),
+      } as never);
+
+      await expect(repo.update('user-1', { name: '테스트' })).rejects.toThrow('업데이트 실패');
+    });
+  });
+});

--- a/src/lib/ai/generationPipeline.test.ts
+++ b/src/lib/ai/generationPipeline.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ApiCatalogItem, ApiEndpoint } from '@/types/api';
+
+// evaluateComplexityScore only uses its own pure logic — no imports that need mocking.
+// We still need to stub the heavy transitive deps so the module loads.
+vi.mock('@/providers/ai/AiProviderFactory', () => ({ AiProviderFactory: { createForTask: vi.fn() } }));
+vi.mock('@/lib/ai/codeParser', () => ({ assembleHtml: vi.fn() }));
+vi.mock('@/lib/ai/codeValidator', () => ({ validateAll: vi.fn(), evaluateQuality: vi.fn() }));
+vi.mock('@/lib/ai/qualityLoop', () => ({ runQualityLoop: vi.fn() }));
+vi.mock('@/lib/qc', () => ({ runFastQc: vi.fn(), isQcEnabled: vi.fn().mockReturnValue(false) }));
+vi.mock('@/lib/events/eventBus', () => ({ eventBus: { on: vi.fn(), emit: vi.fn() } }));
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+vi.mock('@/lib/ai/generationTracker', () => ({
+  generationTracker: { start: vi.fn(), fail: vi.fn(), updateProgress: vi.fn() },
+}));
+vi.mock('@/lib/ai/stageRunner', () => ({
+  runStage1: vi.fn(),
+  runStage2Function: vi.fn(),
+  runStage3: vi.fn(),
+}));
+vi.mock('@/lib/ai/generationSaver', () => ({ saveGeneratedCode: vi.fn() }));
+vi.mock('@/lib/ai/featureExtractor', () => ({ extractFeatures: vi.fn() }));
+
+import { evaluateComplexityScore } from '@/lib/ai/generationPipeline';
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function makeApi(overrides: Partial<ApiCatalogItem> = {}): ApiCatalogItem {
+  return {
+    id: 'api-1',
+    name: 'Test API',
+    description: '',
+    category: 'test',
+    baseUrl: 'https://api.example.com',
+    authType: 'none',
+    authConfig: {},
+    rateLimit: null,
+    isActive: true,
+    iconUrl: null,
+    docsUrl: null,
+    endpoints: [],
+    tags: [],
+    apiVersion: null,
+    deprecatedAt: null,
+    successorId: null,
+    corsSupported: true,
+    requiresProxy: false,
+    creditRequired: null,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+  } as ApiCatalogItem;
+}
+
+function makeEndpoint(method: ApiEndpoint['method'] = 'GET'): ApiEndpoint {
+  return {
+    path: '/test',
+    method,
+    description: '',
+    params: [],
+    responseExample: {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('evaluateComplexityScore', () => {
+  it('returns 0 for an empty API list', () => {
+    expect(evaluateComplexityScore([])).toBe(0);
+  });
+
+  it('returns 0 for 1 API with no auth, no endpoints, no context', () => {
+    expect(evaluateComplexityScore([makeApi()])).toBe(0);
+  });
+
+  it('returns 0 for exactly 2 APIs (no API-count bonus, different categories)', () => {
+    // Different categories → no same-category bonus
+    const apis = [makeApi({ category: 'cat-a' }), makeApi({ id: 'api-2', category: 'cat-b' })];
+    expect(evaluateComplexityScore(apis)).toBe(0);
+  });
+
+  it('adds +5 for 3 APIs (1 extra beyond 2), different categories', () => {
+    // Use distinct categories so same-category bonus does not fire
+    const apis = [
+      makeApi({ id: 'api-1', category: 'cat-a' }),
+      makeApi({ id: 'api-2', category: 'cat-b' }),
+      makeApi({ id: 'api-3', category: 'cat-c' }),
+    ];
+    expect(evaluateComplexityScore(apis)).toBe(5);
+  });
+
+  it('caps API-count bonus at 20 for 6 or more APIs (different categories)', () => {
+    // 6 APIs with distinct categories: (6-2)*5 = 20 — capped at 20; no same-category bonus
+    const apis = Array.from({ length: 6 }, (_, i) =>
+      makeApi({ id: `api-${i}`, category: `cat-${i}` }),
+    );
+    expect(evaluateComplexityScore(apis)).toBe(20);
+  });
+
+  it('adds +15 for oauth auth type', () => {
+    expect(evaluateComplexityScore([makeApi({ authType: 'oauth' })])).toBe(15);
+  });
+
+  it('adds +8 for api_key auth type', () => {
+    expect(evaluateComplexityScore([makeApi({ authType: 'api_key' })])).toBe(8);
+  });
+
+  it('uses the highest auth score when mixing oauth and api_key', () => {
+    const apis = [makeApi({ authType: 'oauth' }), makeApi({ id: 'api-2', authType: 'api_key' })];
+    // oauth wins → 15; same category (both 'test') + 2 APIs → +10
+    expect(evaluateComplexityScore(apis)).toBe(15 + 10);
+  });
+
+  it('adds +5 for 2 total endpoints across APIs', () => {
+    const api = makeApi({ endpoints: [makeEndpoint(), makeEndpoint()] });
+    expect(evaluateComplexityScore([api])).toBe(5);
+  });
+
+  it('adds +10 for 4 or more total endpoints', () => {
+    const api = makeApi({
+      endpoints: [makeEndpoint(), makeEndpoint(), makeEndpoint(), makeEndpoint()],
+    });
+    expect(evaluateComplexityScore([api])).toBe(10);
+  });
+
+  it('adds +8 for POST mutation endpoint', () => {
+    const api = makeApi({ endpoints: [makeEndpoint('POST')] });
+    // 1 endpoint < 2 so no endpoint breadth bonus, but +8 for mutation
+    expect(evaluateComplexityScore([api])).toBe(8);
+  });
+
+  it('adds +8 for PUT mutation endpoint', () => {
+    const api = makeApi({ endpoints: [makeEndpoint('PUT')] });
+    expect(evaluateComplexityScore([api])).toBe(8);
+  });
+
+  it('adds +8 for DELETE mutation endpoint', () => {
+    const api = makeApi({ endpoints: [makeEndpoint('DELETE')] });
+    expect(evaluateComplexityScore([api])).toBe(8);
+  });
+
+  it('adds +3 for context with 1–99 characters', () => {
+    expect(evaluateComplexityScore([makeApi()], 'a'.repeat(50))).toBe(3);
+  });
+
+  it('adds +8 for context with exactly 100 characters (boundary)', () => {
+    expect(evaluateComplexityScore([makeApi()], 'a'.repeat(100))).toBe(8);
+  });
+
+  it('adds +15 for context with exactly 500 characters (boundary)', () => {
+    expect(evaluateComplexityScore([makeApi()], 'a'.repeat(500))).toBe(15);
+  });
+
+  it('adds +10 for same category with 2 APIs', () => {
+    // Both have category 'test' by default in makeApi
+    const apis = [makeApi(), makeApi({ id: 'api-2' })];
+    expect(evaluateComplexityScore(apis)).toBe(10);
+  });
+
+  it('does NOT add the same-category bonus when categories differ', () => {
+    const apis = [makeApi({ category: 'cat-a' }), makeApi({ id: 'api-2', category: 'cat-b' })];
+    expect(evaluateComplexityScore(apis)).toBe(0);
+  });
+
+  it('adds +10 for an API name matching the "payment" keyword', () => {
+    expect(evaluateComplexityScore([makeApi({ name: 'Stripe Payment' })])).toBe(10);
+  });
+
+  it('adds +10 for an API name matching "stripe" (case-insensitive)', () => {
+    expect(evaluateComplexityScore([makeApi({ name: 'stripe integration' })])).toBe(10);
+  });
+
+  it('adds +10 for an API name matching "결제" keyword', () => {
+    expect(evaluateComplexityScore([makeApi({ name: '카드 결제 API' })])).toBe(10);
+  });
+
+  it('adds +10 for an API name matching "pay" keyword', () => {
+    expect(evaluateComplexityScore([makeApi({ name: 'PayPal API' })])).toBe(10);
+  });
+
+  it('computes a combined score correctly', () => {
+    // 3 APIs (same category 'test') → API-count +5, same-category +10
+    // api_key auth → +8
+    // 2 endpoints → +5, POST mutation → +8
+    // context 200 chars → +8
+    // Expected: 5 + 10 + 8 + 5 + 8 + 8 = 44
+    const apis = [
+      makeApi({
+        id: 'api-1',
+        authType: 'api_key',
+        endpoints: [makeEndpoint('POST'), makeEndpoint()],
+      }),
+      makeApi({ id: 'api-2' }),
+      makeApi({ id: 'api-3' }),
+    ];
+    const context = 'a'.repeat(200);
+    expect(evaluateComplexityScore(apis, context)).toBe(44);
+  });
+});

--- a/src/lib/ai/generationSaver.test.ts
+++ b/src/lib/ai/generationSaver.test.ts
@@ -1,0 +1,469 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ICodeRepository, IProjectRepository } from '@/repositories/interfaces';
+import type { SseWriter } from '@/lib/ai/sseWriter';
+import type { ApiCatalogItem } from '@/types/api';
+import type { QcReport } from '@/types/qc';
+import type { QualityMetrics, ValidationResult } from '@/lib/ai/codeValidator';
+import type { SaveParams } from './generationSaver';
+
+vi.mock('@/lib/events/eventBus', () => ({
+  eventBus: { emit: vi.fn() },
+}));
+vi.mock('@/lib/config/features', () => ({
+  getLimits: vi.fn().mockReturnValue({ maxCodeVersionsPerProject: 10 }),
+}));
+vi.mock('@/lib/qc', () => ({
+  isQcEnabled: vi.fn().mockReturnValue(false),
+}));
+vi.mock('@/lib/ai/categoryDesignMap', () => ({
+  inferDesignFromCategories: vi.fn().mockReturnValue({ theme: 'light', layout: 'grid' }),
+}));
+vi.mock('@/lib/ai/slugSuggester', () => ({
+  suggestSlugs: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/lib/utils/htmlTitle', () => ({
+  extractTitle: vi.fn().mockReturnValue('Test Title'),
+}));
+vi.mock('@/lib/ai/generationTracker', () => ({
+  generationTracker: { updateProgress: vi.fn(), complete: vi.fn() },
+}));
+vi.mock('@/lib/qc/deepQcRunner', () => ({
+  runDeepQcAndUpdate: vi.fn(),
+}));
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+vi.mock('@/lib/ai/codeValidator', () => ({
+  validateAll: vi.fn().mockReturnValue({ passed: true, errors: [], warnings: [] }),
+  evaluateQuality: vi.fn().mockReturnValue({ structuralScore: 80, mobileScore: 80, details: [], fetchCallCount: 0, placeholderCount: 0 }),
+}));
+vi.mock('@/lib/config/providers', () => ({
+  getDbProvider: vi.fn().mockReturnValue('supabase'),
+}));
+vi.mock('@/lib/db/connection', () => ({
+  getDb: vi.fn(),
+}));
+vi.mock('@/repositories/utils', () => ({
+  toDatabaseRow: vi.fn().mockImplementation((x: unknown) => x),
+}));
+vi.mock('@/repositories/drizzle/DrizzleCodeRepository', () => ({
+  codeRowToDomain: vi.fn().mockImplementation((row: Record<string, unknown>) => ({
+    ...row,
+    id: row.id ?? 'code-1',
+    projectId: row.project_id ?? 'proj-1',
+    version: row.version ?? 1,
+    codeHtml: '',
+    codeCss: '',
+    codeJs: '',
+    createdAt: String(new Date()),
+  })),
+}));
+vi.mock('@/lib/db/schema', () => ({
+  generatedCodes: { $inferInsert: {} },
+  projects: {},
+}));
+vi.mock('@/lib/db/failover', () => ({
+  isInFailover: vi.fn().mockReturnValue(false),
+  reportFailure: vi.fn(),
+}));
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn().mockReturnValue('eq-condition'),
+}));
+
+// ─────────────────────────────────────────────
+// 헬퍼 함수
+// ─────────────────────────────────────────────
+function makeMockCodeRepo() {
+  return {
+    getNextVersion: vi.fn().mockResolvedValue(1),
+    create: vi.fn().mockResolvedValue({
+      id: 'code-1',
+      projectId: 'proj-1',
+      version: 1,
+      codeHtml: '',
+      codeCss: '',
+      codeJs: '',
+      createdAt: '2026-04-26',
+    }),
+    pruneOldVersions: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    findById: vi.fn(),
+    findMany: vi.fn(),
+    update: vi.fn(),
+    count: vi.fn(),
+    findByProject: vi.fn(),
+    countByProject: vi.fn(),
+  } as unknown as ICodeRepository;
+}
+
+function makeMockProjectService(): { updateStatus: (id: string, status: 'generated') => Promise<unknown> } {
+  return {
+    updateStatus: vi.fn().mockResolvedValue(undefined) as unknown as (id: string, status: 'generated') => Promise<unknown>,
+  };
+}
+
+function makeMockSse() {
+  return {
+    send: vi.fn(),
+    isCancelled: vi.fn().mockReturnValue(false),
+  } as unknown as SseWriter & { send: ReturnType<typeof vi.fn>; isCancelled: ReturnType<typeof vi.fn> };
+}
+
+const mockApis: ApiCatalogItem[] = [
+  {
+    id: 'api-1',
+    name: 'Test API',
+    description: 'Test',
+    category: 'utility',
+    baseUrl: 'https://api.example.com',
+    authType: 'none',
+    authConfig: {},
+    rateLimit: null,
+    isActive: true,
+    iconUrl: null,
+    docsUrl: null,
+    endpoints: [],
+    tags: [],
+    apiVersion: null,
+    deprecatedAt: null,
+    successorId: null,
+    corsSupported: true,
+    requiresProxy: false,
+    creditRequired: null,
+    createdAt: '2026-01-01',
+    updatedAt: '2026-01-01',
+  },
+];
+
+const mockQuality: QualityMetrics = {
+  structuralScore: 80,
+  mobileScore: 75,
+  hasSemanticHtml: true,
+  hasMockData: false,
+  hasInteraction: true,
+  hasResponsiveClasses: true,
+  hasAdequateResponsive: true,
+  noFixedOverflow: true,
+  hasImageProtection: true,
+  hasMobileNav: false,
+  hasFooter: true,
+  hasImgAlt: true,
+  fetchCallCount: 0,
+  hasProxyCall: false,
+  hasJsonParse: false,
+  placeholderCount: 0,
+  hardcodedArrayCount: 0,
+  details: [],
+};
+
+const mockValidation: ValidationResult = { passed: true, errors: [], warnings: [] };
+
+function makeBaseParams(overrides?: {
+  codeRepo?: ICodeRepository;
+  projectService?: { updateStatus: (id: string, status: 'generated') => Promise<unknown> };
+  qcReport?: QcReport | null;
+  projectRepo?: IProjectRepository;
+  projectContext?: string;
+}): SaveParams {
+  return {
+    projectId: 'proj-1',
+    userId: 'user-1',
+    correlationId: 'corr-1',
+    parsed: { html: '<html/>', css: 'body{}', js: '' },
+    quality: mockQuality,
+    qcReport: overrides?.qcReport !== undefined ? overrides.qcReport : null,
+    qualityLoopUsed: false,
+    validation: mockValidation,
+    apis: mockApis,
+    stage2Response: {
+      provider: 'anthropic',
+      model: 'claude-opus-4-7',
+      durationMs: 1000,
+      tokensUsed: { input: 100, output: 200 },
+    },
+    userPromptUsed: 'test prompt',
+    codeRepo: overrides?.codeRepo ?? makeMockCodeRepo(),
+    projectService: overrides?.projectService ?? makeMockProjectService(),
+    ...(overrides?.projectRepo && { projectRepo: overrides.projectRepo }),
+    ...(overrides?.projectContext && { projectContext: overrides.projectContext }),
+  } as SaveParams;
+}
+
+describe('saveGeneratedCode() — Supabase 경로', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('codeRepo.getNextVersion을 projectId로 호출한다', async () => {
+    const { saveGeneratedCode } = await import('./generationSaver');
+    const codeRepo = makeMockCodeRepo();
+    const sse = makeMockSse();
+
+    await saveGeneratedCode(makeBaseParams({ codeRepo }), sse);
+
+    expect(codeRepo.getNextVersion).toHaveBeenCalledWith('proj-1');
+  });
+
+  it("sse.send('progress', {step:'saving', progress:95})를 호출한다", async () => {
+    const { saveGeneratedCode } = await import('./generationSaver');
+    const codeRepo = makeMockCodeRepo();
+    const sse = makeMockSse();
+
+    await saveGeneratedCode(makeBaseParams({ codeRepo }), sse);
+
+    expect(sse.send).toHaveBeenCalledWith(
+      'progress',
+      expect.objectContaining({ step: 'saving', progress: 95 })
+    );
+  });
+
+  it('codeRepo.create를 호출한다', async () => {
+    const { saveGeneratedCode } = await import('./generationSaver');
+    const codeRepo = makeMockCodeRepo();
+    const sse = makeMockSse();
+
+    await saveGeneratedCode(makeBaseParams({ codeRepo }), sse);
+
+    expect(codeRepo.create).toHaveBeenCalled();
+  });
+
+  it("projectService.updateStatus('proj-1', 'generated')를 호출한다", async () => {
+    const { saveGeneratedCode } = await import('./generationSaver');
+    const projectService = makeMockProjectService();
+    const sse = makeMockSse();
+
+    await saveGeneratedCode(makeBaseParams({ projectService }), sse);
+
+    expect(projectService.updateStatus).toHaveBeenCalledWith('proj-1', 'generated');
+  });
+
+  it('codeRepo.pruneOldVersions를 호출한다', async () => {
+    const { saveGeneratedCode } = await import('./generationSaver');
+    const codeRepo = makeMockCodeRepo();
+    const sse = makeMockSse();
+
+    await saveGeneratedCode(makeBaseParams({ codeRepo }), sse);
+
+    expect(codeRepo.pruneOldVersions).toHaveBeenCalledWith('proj-1', 10);
+  });
+
+  it('eventBus.emit을 CODE_GENERATED 타입으로 호출한다', async () => {
+    const { saveGeneratedCode } = await import('./generationSaver');
+    const { eventBus } = await import('@/lib/events/eventBus');
+    const sse = makeMockSse();
+
+    await saveGeneratedCode(makeBaseParams(), sse);
+
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'CODE_GENERATED' })
+    );
+  });
+
+  it('generationTracker.complete를 호출한다', async () => {
+    const { saveGeneratedCode } = await import('./generationSaver');
+    const { generationTracker } = await import('@/lib/ai/generationTracker');
+    const sse = makeMockSse();
+
+    await saveGeneratedCode(makeBaseParams(), sse);
+
+    expect(generationTracker.complete).toHaveBeenCalledWith(
+      'proj-1',
+      expect.objectContaining({ projectId: 'proj-1', version: 1 })
+    );
+  });
+
+  it("sse.send('complete', ...)를 호출한다", async () => {
+    const { saveGeneratedCode } = await import('./generationSaver');
+    const sse = makeMockSse();
+
+    await saveGeneratedCode(makeBaseParams(), sse);
+
+    expect(sse.send).toHaveBeenCalledWith(
+      'complete',
+      expect.objectContaining({ projectId: 'proj-1', version: 1 })
+    );
+  });
+
+  it('updateStatus 실패 → codeRepo.delete를 호출하고 에러를 다시 던진다', async () => {
+    const { saveGeneratedCode } = await import('./generationSaver');
+    const codeRepo = makeMockCodeRepo();
+    const updateError = new Error('DB update failed');
+    const projectService: { updateStatus: (id: string, status: 'generated') => Promise<unknown> } = {
+      updateStatus: vi.fn().mockRejectedValue(updateError) as unknown as (id: string, status: 'generated') => Promise<unknown>,
+    };
+    const sse = makeMockSse();
+
+    await expect(
+      saveGeneratedCode(makeBaseParams({ codeRepo, projectService }), sse)
+    ).rejects.toThrow('DB update failed');
+
+    expect(codeRepo.delete).toHaveBeenCalledWith('code-1');
+  });
+
+  it('pruneOldVersions 실패 → 에러를 무시하고 logger.warn을 호출한다', async () => {
+    const { saveGeneratedCode } = await import('./generationSaver');
+    const codeRepo = makeMockCodeRepo();
+    (codeRepo.pruneOldVersions as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('prune failed')
+    );
+    const { logger } = await import('@/lib/utils/logger');
+    const sse = makeMockSse();
+
+    // 에러를 던지지 않아야 함
+    await expect(
+      saveGeneratedCode(makeBaseParams({ codeRepo }), sse)
+    ).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('isQcEnabled=true & qcReport.passed=false → runDeepQcAndUpdate를 호출한다', async () => {
+    const { isQcEnabled } = await import('@/lib/qc');
+    vi.mocked(isQcEnabled).mockReturnValue(true);
+
+    const { saveGeneratedCode } = await import('./generationSaver');
+    const { runDeepQcAndUpdate } = await import('@/lib/qc/deepQcRunner');
+    const sse = makeMockSse();
+
+    const failedQcReport: QcReport = {
+      overallScore: 30,
+      passed: false,
+      checks: [
+        { name: 'render', passed: false, score: 30, details: ['failed'], durationMs: 100 },
+      ],
+      viewportsTested: [1024],
+      durationMs: 200,
+      timestamp: '2026-04-26T00:00:00Z',
+    };
+
+    await saveGeneratedCode(makeBaseParams({ qcReport: failedQcReport }), sse);
+
+    expect(runDeepQcAndUpdate).toHaveBeenCalled();
+
+    // 초기화
+    vi.mocked(isQcEnabled).mockReturnValue(false);
+  });
+
+  it('isQcEnabled=false → runDeepQcAndUpdate를 호출하지 않는다', async () => {
+    const { isQcEnabled } = await import('@/lib/qc');
+    vi.mocked(isQcEnabled).mockReturnValue(false);
+
+    const { saveGeneratedCode } = await import('./generationSaver');
+    const { runDeepQcAndUpdate } = await import('@/lib/qc/deepQcRunner');
+    const sse = makeMockSse();
+
+    await saveGeneratedCode(makeBaseParams(), sse);
+
+    expect(runDeepQcAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('qcReport가 있을 때 sse.send("complete")에 qcResult가 포함된다', async () => {
+    const { saveGeneratedCode } = await import('./generationSaver');
+    const sse = makeMockSse();
+
+    const passedQcReport: QcReport = {
+      overallScore: 85,
+      passed: true,
+      checks: [
+        { name: 'render', passed: true, score: 85, details: [], durationMs: 100 },
+      ],
+      viewportsTested: [1024],
+      durationMs: 150,
+      timestamp: '2026-04-26T00:00:00Z',
+    };
+
+    await saveGeneratedCode(makeBaseParams({ qcReport: passedQcReport }), sse);
+
+    const completeCalls = (sse.send as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => c[0] === 'complete'
+    );
+    expect(completeCalls.length).toBe(1);
+    expect(completeCalls[0][1]).toMatchObject({
+      qcResult: {
+        score: 85,
+        passed: true,
+      },
+    });
+  });
+
+  it('projectRepo + projectContext가 있으면 suggestSlugs가 fire-and-forget으로 호출된다', async () => {
+    const { saveGeneratedCode } = await import('./generationSaver');
+    const { suggestSlugs } = await import('@/lib/ai/slugSuggester');
+    const sse = makeMockSse();
+
+    const projectRepo = {
+      updateSuggestedSlugs: vi.fn().mockResolvedValue(undefined),
+      findById: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+      findByUserId: vi.fn(),
+      countTodayGenerations: vi.fn(),
+      insertProjectApis: vi.fn(),
+      getProjectApiIds: vi.fn(),
+      findBySlug: vi.fn(),
+      updateSlug: vi.fn(),
+    } as unknown as IProjectRepository;
+
+    vi.mocked(suggestSlugs).mockResolvedValue(['my-service', 'test-service']);
+
+    await saveGeneratedCode(
+      makeBaseParams({ projectRepo, projectContext: 'A weather dashboard app' }),
+      sse
+    );
+
+    // fire-and-forget이므로 짧은 대기 필요
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(suggestSlugs).toHaveBeenCalled();
+  });
+});
+
+describe('saveGeneratedCode() — Drizzle/Postgres 경로', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getDbProvider=postgres 시 db.transaction을 호출한다', async () => {
+    const { getDbProvider } = await import('@/lib/config/providers');
+    vi.mocked(getDbProvider).mockReturnValue('postgres');
+
+    const { getDb } = await import('@/lib/db/connection');
+    const mockTx = {
+      insert: vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([
+            { id: 'code-drizzle-1', project_id: 'proj-1', version: 1 },
+          ]),
+        }),
+      }),
+      update: vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(undefined),
+        }),
+      }),
+    };
+    vi.mocked(getDb).mockReturnValue({
+      transaction: vi.fn().mockImplementation(async (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx)),
+    } as never);
+
+    const { saveGeneratedCode } = await import('./generationSaver');
+    const codeRepo = makeMockCodeRepo();
+    const projectService = makeMockProjectService();
+    const sse = makeMockSse();
+
+    await saveGeneratedCode(makeBaseParams({ codeRepo, projectService }), sse);
+
+    expect(getDb).toHaveBeenCalled();
+    const db = vi.mocked(getDb)();
+    expect(db.transaction).toHaveBeenCalled();
+
+    // Supabase 경로의 codeRepo.create는 호출되지 않아야 함
+    expect(codeRepo.create).not.toHaveBeenCalled();
+
+    // 초기화
+    vi.mocked(getDbProvider).mockReturnValue('supabase');
+  });
+});

--- a/src/lib/ai/stageRunner.test.ts
+++ b/src/lib/ai/stageRunner.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runStage1, runStage2Function, runStage3 } from './stageRunner';
+import type { IAiProvider } from '@/providers/ai/IAiProvider';
+import type { SseWriter } from '@/lib/ai/sseWriter';
+import type { ParsedCode } from './stageRunner';
+
+vi.mock('@/lib/ai/codeParser', () => ({
+  parseGeneratedCode: vi.fn().mockReturnValue({ html: '<html/>', css: '', js: '' }),
+}));
+
+function makeMockProvider() {
+  return {
+    generateCodeStream: vi.fn().mockResolvedValue({
+      content: 'some generated code',
+      provider: 'anthropic',
+      model: 'claude-opus-4-7',
+      durationMs: 1000,
+      tokensUsed: { input: 100, output: 200 },
+    }),
+    generateCode: vi.fn(),
+    checkAvailability: vi.fn(),
+    name: 'mock',
+    model: 'mock-model',
+  } as unknown as IAiProvider & {
+    generateCodeStream: ReturnType<typeof vi.fn>;
+    generateCode: ReturnType<typeof vi.fn>;
+    checkAvailability: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeMockSse(cancelled = false) {
+  return {
+    send: vi.fn(),
+    isCancelled: vi.fn().mockReturnValue(cancelled),
+  } as unknown as SseWriter & {
+    send: ReturnType<typeof vi.fn>;
+    isCancelled: ReturnType<typeof vi.fn>;
+  };
+}
+
+const mockParsedCode: ParsedCode = { html: '<html/>', css: 'body{}', js: '' };
+
+describe('runStage1()', () => {
+  let provider: ReturnType<typeof makeMockProvider>;
+  let sse: ReturnType<typeof makeMockSse>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = makeMockProvider();
+    sse = makeMockSse();
+  });
+
+  it('aiProvider.generateCodeStream을 올바른 프롬프트로 호출한다', async () => {
+    await runStage1('sys-prompt', 'user-prompt', provider, sse, false);
+
+    expect(provider.generateCodeStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: 'sys-prompt',
+        user: 'user-prompt',
+        extendedThinking: false,
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('초기 sse.send progress 이벤트를 발행한다 (step=stage1_generating, progress=5)', async () => {
+    await runStage1('sys', 'user', provider, sse, false);
+
+    const progressCalls = (sse.send as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => c[0] === 'progress'
+    );
+    expect(progressCalls.length).toBeGreaterThan(0);
+    expect(progressCalls[0][1]).toMatchObject({ step: 'stage1_generating', progress: 5 });
+  });
+
+  it('useET=true 시 메시지에 "(심층 분석)"이 포함된다', async () => {
+    await runStage1('sys', 'user', provider, sse, true);
+
+    const firstCall = (sse.send as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c: unknown[]) => c[0] === 'progress'
+    );
+    expect((firstCall![1] as { message: string }).message).toContain('(심층 분석)');
+  });
+
+  it('useET=false 시 메시지에 "(심층 분석)"이 포함되지 않는다', async () => {
+    await runStage1('sys', 'user', provider, sse, false);
+
+    const firstCall = (sse.send as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c: unknown[]) => c[0] === 'progress'
+    );
+    expect((firstCall![1] as { message: string }).message).not.toContain('(심층 분석)');
+  });
+
+  it('StageResult를 반환한다: parsed, provider, model, durationMs, tokensUsed, userPrompt', async () => {
+    const result = await runStage1('sys', 'user-prompt', provider, sse, false);
+
+    expect(result).toMatchObject({
+      parsed: { html: '<html/>', css: '', js: '' },
+      provider: 'anthropic',
+      model: 'claude-opus-4-7',
+      durationMs: 1000,
+      tokensUsed: { input: 100, output: 200 },
+      userPrompt: 'user-prompt',
+    });
+  });
+
+  it('extendedThinking=true 시 generateCodeStream에 extendedThinking: true가 전달된다', async () => {
+    await runStage1('sys', 'user', provider, sse, true);
+
+    expect(provider.generateCodeStream).toHaveBeenCalledWith(
+      expect.objectContaining({ extendedThinking: true }),
+      expect.any(Function)
+    );
+  });
+
+  it('sse.isCancelled()=true이면 progress callback에서 sse.send를 추가 호출하지 않는다', async () => {
+    const cancelledSse = makeMockSse(true);
+    let progressCallback: ((chunk: string, accumulated: string) => void) | null = null;
+
+    provider.generateCodeStream.mockImplementation(
+      async (_msgs: unknown, callback: (chunk: string, accumulated: string) => void) => {
+        progressCallback = callback;
+        // callback은 실행되나 cancelled=true라 sse.send는 호출되지 않아야 함
+        callback('chunk', 'accumulated text that is long enough to pass throttle');
+        return {
+          content: 'code',
+          provider: 'anthropic',
+          model: 'claude-opus-4-7',
+          durationMs: 500,
+          tokensUsed: { input: 10, output: 20 },
+        };
+      }
+    );
+
+    await runStage1('sys', 'user', provider, cancelledSse, false);
+
+    // 초기 send 외에 callback으로 인한 추가 send가 없어야 함
+    const progressCallsAfterInit = (cancelledSse.send as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => c[0] === 'progress'
+    );
+    // isCancelled=true이므로 callback 내부에서 send를 호출하지 않아 초기 1회만 있어야 함
+    // (초기 send는 isCancelled 전에 호출됨)
+    expect(progressCallback).not.toBeNull();
+    // callback 호출로 인한 추가 progress sse.send가 없어야 함
+    expect(progressCallsAfterInit.length).toBe(1);
+  });
+});
+
+describe('runStage2Function()', () => {
+  let provider: ReturnType<typeof makeMockProvider>;
+  let sse: ReturnType<typeof makeMockSse>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = makeMockProvider();
+    sse = makeMockSse();
+  });
+
+  it('sse.send가 최소 2번 호출된다 (stage1_complete + stage2_function_generating)', async () => {
+    const buildUserPrompt = vi.fn().mockReturnValue('stage2-user-prompt');
+
+    await runStage2Function(
+      mockParsedCode,
+      'sys-prompt',
+      buildUserPrompt,
+      [],
+      null,
+      provider,
+      sse
+    );
+
+    const steps = (sse.send as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c: unknown[]) => c[0] === 'progress')
+      .map((c: unknown[]) => (c[1] as { step: string }).step);
+
+    expect(steps).toContain('stage1_complete');
+    expect(steps).toContain('stage2_function_generating');
+  });
+
+  it('StageResult를 반환한다', async () => {
+    const buildUserPrompt = vi.fn().mockReturnValue('stage2-user');
+
+    const result = await runStage2Function(
+      mockParsedCode,
+      'sys',
+      buildUserPrompt,
+      ['issue1'],
+      ['fast-issue'],
+      provider,
+      sse
+    );
+
+    expect(result).toMatchObject({
+      parsed: { html: '<html/>', css: '', js: '' },
+      provider: 'anthropic',
+      model: 'claude-opus-4-7',
+      durationMs: 1000,
+      tokensUsed: { input: 100, output: 200 },
+      userPrompt: 'stage2-user',
+    });
+  });
+
+  it('buildUserPrompt를 stage1Code, staticQcIssues, fastQcIssues와 함께 호출한다', async () => {
+    const buildUserPrompt = vi.fn().mockReturnValue('built-prompt');
+
+    await runStage2Function(
+      mockParsedCode,
+      'sys',
+      buildUserPrompt,
+      ['static-issue'],
+      ['fast-issue'],
+      provider,
+      sse
+    );
+
+    expect(buildUserPrompt).toHaveBeenCalledWith(mockParsedCode, ['static-issue'], ['fast-issue']);
+  });
+});
+
+describe('runStage3()', () => {
+  let provider: ReturnType<typeof makeMockProvider>;
+  let sse: ReturnType<typeof makeMockSse>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = makeMockProvider();
+    sse = makeMockSse();
+  });
+
+  it('stage2FunctionCompleteAlreadySent=false → stage2_function_complete sse.send를 호출한다', async () => {
+    const buildUserPrompt = vi.fn().mockReturnValue('stage3-user');
+
+    await runStage3(mockParsedCode, 'sys', buildUserPrompt, provider, sse, false);
+
+    const steps = (sse.send as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c: unknown[]) => c[0] === 'progress')
+      .map((c: unknown[]) => (c[1] as { step: string }).step);
+
+    expect(steps).toContain('stage2_function_complete');
+  });
+
+  it('stage2FunctionCompleteAlreadySent=true → stage2_function_complete를 sse.send하지 않는다', async () => {
+    const buildUserPrompt = vi.fn().mockReturnValue('stage3-user');
+
+    await runStage3(mockParsedCode, 'sys', buildUserPrompt, provider, sse, true);
+
+    const steps = (sse.send as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c: unknown[]) => c[0] === 'progress')
+      .map((c: unknown[]) => (c[1] as { step: string }).step);
+
+    expect(steps).not.toContain('stage2_function_complete');
+  });
+
+  it('항상 stage3_generating sse.send를 호출한다 (AlreadySent=false)', async () => {
+    const buildUserPrompt = vi.fn().mockReturnValue('stage3-user');
+
+    await runStage3(mockParsedCode, 'sys', buildUserPrompt, provider, sse, false);
+
+    const steps = (sse.send as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c: unknown[]) => c[0] === 'progress')
+      .map((c: unknown[]) => (c[1] as { step: string }).step);
+
+    expect(steps).toContain('stage3_generating');
+  });
+
+  it('항상 stage3_generating sse.send를 호출한다 (AlreadySent=true)', async () => {
+    const buildUserPrompt = vi.fn().mockReturnValue('stage3-user');
+
+    await runStage3(mockParsedCode, 'sys', buildUserPrompt, provider, sse, true);
+
+    const steps = (sse.send as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c: unknown[]) => c[0] === 'progress')
+      .map((c: unknown[]) => (c[1] as { step: string }).step);
+
+    expect(steps).toContain('stage3_generating');
+  });
+
+  it('buildUserPrompt를 stage2Code와 함께 호출한다', async () => {
+    const buildUserPrompt = vi.fn().mockReturnValue('built-stage3-prompt');
+
+    await runStage3(mockParsedCode, 'sys', buildUserPrompt, provider, sse, false);
+
+    expect(buildUserPrompt).toHaveBeenCalledWith(mockParsedCode);
+  });
+
+  it('StageResult를 반환한다', async () => {
+    const buildUserPrompt = vi.fn().mockReturnValue('stage3-user-prompt');
+
+    const result = await runStage3(mockParsedCode, 'sys', buildUserPrompt, provider, sse, false);
+
+    expect(result).toMatchObject({
+      parsed: { html: '<html/>', css: '', js: '' },
+      provider: 'anthropic',
+      model: 'claude-opus-4-7',
+      durationMs: 1000,
+      tokensUsed: { input: 100, output: 200 },
+      userPrompt: 'stage3-user-prompt',
+    });
+  });
+});

--- a/src/lib/apiKeyGuides.test.ts
+++ b/src/lib/apiKeyGuides.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { getApiKeyGuide, getDefaultGuide } from './apiKeyGuides';
+
+describe('getApiKeyGuide', () => {
+  it('returns a non-null guide for OpenWeatherMap with required fields', () => {
+    const guide = getApiKeyGuide('OpenWeatherMap');
+    expect(guide).not.toBeNull();
+    expect(guide!.signupUrl).toBeTruthy();
+    expect(Array.isArray(guide!.steps)).toBe(true);
+    expect(guide!.keyLabel).toBeTruthy();
+  });
+
+  it('returns null for an unknown API name', () => {
+    expect(getApiKeyGuide('unknown-api')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(getApiKeyGuide('')).toBeNull();
+  });
+
+  it('returns the same guide (same signupUrl) for all public data portal APIs', () => {
+    const guide1 = getApiKeyGuide('기상청 단기예보');
+    const guide2 = getApiKeyGuide('기상청 중기예보');
+    expect(guide1).not.toBeNull();
+    expect(guide2).not.toBeNull();
+    expect(guide1!.signupUrl).toBe(guide2!.signupUrl);
+  });
+
+  it('public data portal guide has multiple steps', () => {
+    const guide = getApiKeyGuide('기상청 단기예보');
+    expect(guide!.steps.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('every returned guide has estimatedTime and keyLabel strings', () => {
+    const knownApis = ['OpenWeatherMap', 'WeatherAPI.com', 'NewsAPI.org', 'Unsplash', 'NASA 오늘의 천문 사진'];
+    for (const name of knownApis) {
+      const guide = getApiKeyGuide(name);
+      expect(guide).not.toBeNull();
+      expect(typeof guide!.estimatedTime).toBe('string');
+      expect(typeof guide!.keyLabel).toBe('string');
+    }
+  });
+});
+
+describe('getDefaultGuide', () => {
+  it('uses the provided docsUrl as signupUrl', () => {
+    const guide = getDefaultGuide('https://example.com');
+    expect(guide.signupUrl).toBe('https://example.com');
+  });
+
+  it('uses "#" as signupUrl when docsUrl is null', () => {
+    const guide = getDefaultGuide(null);
+    expect(guide.signupUrl).toBe('#');
+  });
+
+  it('has at least one step', () => {
+    const guide = getDefaultGuide('https://example.com');
+    expect(guide.steps.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('has estimatedTime and keyLabel strings', () => {
+    const guide = getDefaultGuide('https://example.com');
+    expect(typeof guide.estimatedTime).toBe('string');
+    expect(typeof guide.keyLabel).toBe('string');
+  });
+});

--- a/src/lib/db/errors.test.ts
+++ b/src/lib/db/errors.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { isUniqueViolation } from './errors';
+
+describe('isUniqueViolation', () => {
+  it('returns false for null', () => {
+    expect(isUniqueViolation(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isUniqueViolation(undefined)).toBe(false);
+  });
+
+  it('returns false for 0', () => {
+    expect(isUniqueViolation(0)).toBe(false);
+  });
+
+  it('returns false for false', () => {
+    expect(isUniqueViolation(false)).toBe(false);
+  });
+
+  it('returns true for supabase-style object with code "23505"', () => {
+    expect(isUniqueViolation({ code: '23505' })).toBe(true);
+  });
+
+  it('returns false for supabase-style object with a different code', () => {
+    expect(isUniqueViolation({ code: '42000' })).toBe(false);
+  });
+
+  it('returns true for plain Error whose message contains "23505"', () => {
+    expect(isUniqueViolation(new Error('duplicate key value violates unique constraint 23505'))).toBe(true);
+  });
+
+  it('returns false for plain Error whose message does NOT contain "23505"', () => {
+    expect(isUniqueViolation(new Error('some other error'))).toBe(false);
+  });
+
+  it('returns true for Error with code property set to "23505"', () => {
+    const err = Object.assign(new Error('duplicate key'), { code: '23505' });
+    expect(isUniqueViolation(err)).toBe(true);
+  });
+
+  it('returns false for a plain string', () => {
+    expect(isUniqueViolation('23505')).toBe(false);
+  });
+
+  it('returns false when code is a number (not a string)', () => {
+    expect(isUniqueViolation({ code: 23505 })).toBe(false);
+  });
+});

--- a/src/lib/db/failover.test.ts
+++ b/src/lib/db/failover.test.ts
@@ -1,0 +1,193 @@
+/**
+ * src/lib/db/failover.ts — co-located 단위 테스트
+ *
+ * 기존 `src/__tests__/lib/db/failover.test.ts` 와 별도로 co-located 위치에 배치.
+ * 두 파일이 동일 모듈 상태를 공유하므로 vi.resetModules()로 격리할 필요가 없음.
+ * (각 describe block에서 beforeEach로 _resetFailoverState 호출)
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  isInFailover,
+  isDbConnectionError,
+  reportFailure,
+  _resetFailoverState,
+  getFailoverStatus,
+} from './failover';
+
+// tripCircuit이 호출하는 resetDbConnection mock
+vi.mock('@/lib/db/connection', () => ({
+  resetDbConnection: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+// ───────────────────────────────────────────────
+// 헬퍼
+// ───────────────────────────────────────────────
+function makeConnError(code: string, message = 'db error'): Error {
+  const err = new Error(message) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+// ───────────────────────────────────────────────
+// isInFailover
+// ───────────────────────────────────────────────
+describe('isInFailover()', () => {
+  beforeEach(() => {
+    _resetFailoverState();
+  });
+
+  it('초기 상태는 false (normal)', () => {
+    expect(isInFailover()).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────
+// isDbConnectionError
+// ───────────────────────────────────────────────
+describe('isDbConnectionError()', () => {
+  it('ECONNREFUSED 코드 → true', () => {
+    expect(isDbConnectionError(makeConnError('ECONNREFUSED'))).toBe(true);
+  });
+
+  it('ETIMEDOUT 코드 → true', () => {
+    expect(isDbConnectionError(makeConnError('ETIMEDOUT'))).toBe(true);
+  });
+
+  it('ENOTFOUND 코드 → true', () => {
+    expect(isDbConnectionError(makeConnError('ENOTFOUND'))).toBe(true);
+  });
+
+  it('"connection terminated" 메시지 → true', () => {
+    expect(isDbConnectionError(new Error('connection terminated unexpectedly'))).toBe(true);
+  });
+
+  it('"connection timeout" 메시지 → true', () => {
+    expect(isDbConnectionError(new Error('connection timeout exceeded'))).toBe(true);
+  });
+
+  it('"too many clients" 메시지 → true', () => {
+    expect(isDbConnectionError(new Error('too many clients already'))).toBe(true);
+  });
+
+  it('"could not connect" 메시지 → true', () => {
+    expect(isDbConnectionError(new Error('could not connect to server'))).toBe(true);
+  });
+
+  it('일반 에러("SyntaxError") → false', () => {
+    expect(isDbConnectionError(new Error('SyntaxError: unexpected token'))).toBe(false);
+  });
+
+  it('Error 아닌 string → false', () => {
+    expect(isDbConnectionError('ECONNREFUSED')).toBe(false);
+  });
+
+  it('Error 아닌 number → false', () => {
+    expect(isDbConnectionError(42)).toBe(false);
+  });
+
+  it('Error 아닌 plain object → false', () => {
+    expect(isDbConnectionError({ message: 'ECONNREFUSED', code: 'ECONNREFUSED' })).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────
+// reportFailure
+// ───────────────────────────────────────────────
+describe('reportFailure()', () => {
+  beforeEach(() => {
+    _resetFailoverState();
+    vi.stubEnv('FAILOVER_ENABLED', 'true');
+    vi.stubEnv('FAILOVER_FAILURE_THRESHOLD', '3');
+    vi.stubEnv('FAILOVER_FAILURE_WINDOW_MS', '30000');
+  });
+
+  afterEach(() => {
+    _resetFailoverState();
+    vi.unstubAllEnvs();
+  });
+
+  it('DB 연결 에러가 아닌 경우 카운터가 증가하지 않는다', () => {
+    reportFailure(new Error('unrelated error'));
+    expect(getFailoverStatus().consecutiveFailures).toBe(0);
+  });
+
+  it('FAILOVER_ENABLED=false → 실패 무시', () => {
+    vi.stubEnv('FAILOVER_ENABLED', 'false');
+    reportFailure(makeConnError('ECONNREFUSED'));
+    reportFailure(makeConnError('ECONNREFUSED'));
+    reportFailure(makeConnError('ECONNREFUSED'));
+    expect(isInFailover()).toBe(false);
+    expect(getFailoverStatus().consecutiveFailures).toBe(0);
+  });
+
+  it('이미 tripped 상태에서 추가 실패 → 무시', () => {
+    const err = makeConnError('ECONNREFUSED');
+    reportFailure(err);
+    reportFailure(err);
+    reportFailure(err); // trip
+    const tripTime = getFailoverStatus().lastTripTime;
+    reportFailure(err);
+    expect(getFailoverStatus().lastTripTime).toBe(tripTime);
+  });
+
+  it('threshold 미만 실패 → 아직 tripped 아님', () => {
+    const err = makeConnError('ECONNREFUSED');
+    reportFailure(err); // 1
+    reportFailure(err); // 2
+    expect(isInFailover()).toBe(false);
+    expect(getFailoverStatus().consecutiveFailures).toBe(2);
+  });
+
+  it('threshold(3) 달성 시 → isInFailover() true', () => {
+    const err = makeConnError('ECONNREFUSED');
+    reportFailure(err); // 1
+    reportFailure(err); // 2
+    reportFailure(err); // 3 → trip
+    expect(isInFailover()).toBe(true);
+    expect(getFailoverStatus().state).toBe('tripped');
+  });
+
+  it('failureWindowMs 초과 후 실패 → 카운터 리셋 후 1로 시작', () => {
+    vi.stubEnv('FAILOVER_FAILURE_WINDOW_MS', '100'); // 100ms 윈도우
+    vi.useFakeTimers();
+    try {
+      const err = makeConnError('ECONNREFUSED');
+      reportFailure(err); // count=1
+
+      // 200ms 경과 → 윈도우 밖
+      vi.advanceTimersByTime(200);
+      reportFailure(err); // 리셋 후 count=1
+
+      expect(getFailoverStatus().consecutiveFailures).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// ───────────────────────────────────────────────
+// getFailoverStatus
+// ───────────────────────────────────────────────
+describe('getFailoverStatus()', () => {
+  beforeEach(() => {
+    _resetFailoverState();
+    vi.stubEnv('FAILOVER_ENABLED', 'true');
+  });
+
+  afterEach(() => {
+    _resetFailoverState();
+    vi.unstubAllEnvs();
+  });
+
+  it('초기 상태를 올바르게 반환한다', () => {
+    const status = getFailoverStatus();
+    expect(status.state).toBe('normal');
+    expect(status.consecutiveFailures).toBe(0);
+    expect(status.lastTripTime).toBeNull();
+    expect(status.enabled).toBe(true);
+  });
+});

--- a/src/lib/deploy/githubService.test.ts
+++ b/src/lib/deploy/githubService.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  vi.stubEnv('GITHUB_TOKEN', 'test-token');
+  vi.stubEnv('GITHUB_ORG', 'test-org');
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+function mockResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  };
+}
+
+// ── createRepository ──────────────────────────────────────────────────────────
+
+describe('createRepository()', () => {
+  it('성공 (200) → repoUrl과 fullName 반환', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ html_url: 'https://github.com/test-org/my-repo', full_name: 'test-org/my-repo' }),
+    );
+
+    const { createRepository } = await import('./githubService');
+    const result = await createRepository('my-repo', 'test description');
+
+    expect(result).toEqual({
+      repoUrl: 'https://github.com/test-org/my-repo',
+      fullName: 'test-org/my-repo',
+    });
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.github.com/orgs/test-org/repos',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('422 "already exists" → 구성된 URL 반환 (fetch 재호출 없음)', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      json: vi.fn().mockResolvedValue({ message: 'Repository creation failed: already exists.' }),
+    });
+
+    const { createRepository } = await import('./githubService');
+    const result = await createRepository('my-repo');
+
+    expect(result).toEqual({
+      repoUrl: 'https://github.com/test-org/my-repo',
+      fullName: 'test-org/my-repo',
+    });
+  });
+
+  it('422이지만 already-exists 아닌 경우 → 에러 throw', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      json: vi.fn().mockResolvedValue({ message: 'Validation failed.' }),
+    });
+
+    const { createRepository } = await import('./githubService');
+    await expect(createRepository('my-repo')).rejects.toThrow('GitHub repo creation failed: 422');
+  });
+
+  it('500 서버 에러 → GitHub repo creation failed: 500 throw', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: vi.fn().mockResolvedValue({ message: 'Internal Server Error' }),
+    });
+
+    const { createRepository } = await import('./githubService');
+    await expect(createRepository('my-repo')).rejects.toThrow('GitHub repo creation failed: 500');
+  });
+
+  it('GITHUB_ORG 미설정 → "GITHUB_ORG is not set" throw', async () => {
+    vi.stubEnv('GITHUB_ORG', '');
+
+    const { createRepository } = await import('./githubService');
+    await expect(createRepository('my-repo')).rejects.toThrow('GITHUB_ORG is not set');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('GITHUB_TOKEN 미설정 → "GITHUB_TOKEN is not set" throw', async () => {
+    vi.stubEnv('GITHUB_ORG', 'test-org');
+    vi.stubEnv('GITHUB_TOKEN', '');
+
+    const { createRepository } = await import('./githubService');
+    await expect(createRepository('my-repo')).rejects.toThrow('GITHUB_TOKEN is not set');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('description 미제공 시 auto-generated 설명 본문 포함', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ html_url: 'https://github.com/test-org/svc', full_name: 'test-org/svc' }),
+    );
+
+    const { createRepository } = await import('./githubService');
+    await createRepository('svc');
+
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(callBody.description).toBe('Auto-generated service: svc');
+  });
+});
+
+// ── pushCode ──────────────────────────────────────────────────────────────────
+
+describe('pushCode()', () => {
+  const files = [{ path: 'index.html', content: '<html/>' }];
+
+  it('전체 성공 → fetch 6회 호출 (ref→commit→blob×1→tree→commit→ref)', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockResponse({ object: { sha: 'abc123' } }))           // GET ref
+      .mockResolvedValueOnce(mockResponse({ tree: { sha: 'tree123' } }))             // GET commit
+      .mockResolvedValueOnce(mockResponse({ sha: 'blob1' }))                         // POST blob
+      .mockResolvedValueOnce(mockResponse({ sha: 'newtree' }))                       // POST tree
+      .mockResolvedValueOnce(mockResponse({ sha: 'newcommit' }))                     // POST commit
+      .mockResolvedValueOnce(mockResponse({}));                                       // PATCH ref
+
+    const { pushCode } = await import('./githubService');
+    await expect(pushCode('test-org/my-repo', files)).resolves.toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledTimes(6);
+  });
+
+  it('파일 2개 → fetch 7회 (blob 2개)', async () => {
+    const twoFiles = [
+      { path: 'index.html', content: '<html/>' },
+      { path: 'style.css', content: 'body {}' },
+    ];
+    mockFetch
+      .mockResolvedValueOnce(mockResponse({ object: { sha: 'abc123' } }))
+      .mockResolvedValueOnce(mockResponse({ tree: { sha: 'tree123' } }))
+      .mockResolvedValueOnce(mockResponse({ sha: 'blob1' }))
+      .mockResolvedValueOnce(mockResponse({ sha: 'blob2' }))
+      .mockResolvedValueOnce(mockResponse({ sha: 'newtree' }))
+      .mockResolvedValueOnce(mockResponse({ sha: 'newcommit' }))
+      .mockResolvedValueOnce(mockResponse({}));
+
+    const { pushCode } = await import('./githubService');
+    await expect(pushCode('test-org/my-repo', twoFiles)).resolves.toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledTimes(7);
+  });
+
+  it('ref 조회 실패 → "Failed to get ref" throw', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, json: vi.fn() });
+
+    const { pushCode } = await import('./githubService');
+    await expect(pushCode('test-org/my-repo', files)).rejects.toThrow('Failed to get ref: 404');
+  });
+
+  it('commit 조회 실패 → "Failed to get commit" throw', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockResponse({ object: { sha: 'abc123' } }))
+      .mockResolvedValueOnce({ ok: false, status: 500, json: vi.fn() });
+
+    const { pushCode } = await import('./githubService');
+    await expect(pushCode('test-org/my-repo', files)).rejects.toThrow('Failed to get commit: 500');
+  });
+
+  it('blob 생성 실패 → "Failed to create blob" throw', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockResponse({ object: { sha: 'abc123' } }))
+      .mockResolvedValueOnce(mockResponse({ tree: { sha: 'tree123' } }))
+      .mockResolvedValueOnce({ ok: false, status: 422, json: vi.fn() });
+
+    const { pushCode } = await import('./githubService');
+    await expect(pushCode('test-org/my-repo', files)).rejects.toThrow('Failed to create blob');
+  });
+
+  it('tree 생성 실패 → "Failed to create tree" throw', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockResponse({ object: { sha: 'abc123' } }))
+      .mockResolvedValueOnce(mockResponse({ tree: { sha: 'tree123' } }))
+      .mockResolvedValueOnce(mockResponse({ sha: 'blob1' }))
+      .mockResolvedValueOnce({ ok: false, status: 500, json: vi.fn() });
+
+    const { pushCode } = await import('./githubService');
+    await expect(pushCode('test-org/my-repo', files)).rejects.toThrow('Failed to create tree: 500');
+  });
+
+  it('commit 생성 실패 → "Failed to create commit" throw', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockResponse({ object: { sha: 'abc123' } }))
+      .mockResolvedValueOnce(mockResponse({ tree: { sha: 'tree123' } }))
+      .mockResolvedValueOnce(mockResponse({ sha: 'blob1' }))
+      .mockResolvedValueOnce(mockResponse({ sha: 'newtree' }))
+      .mockResolvedValueOnce({ ok: false, status: 500, json: vi.fn() });
+
+    const { pushCode } = await import('./githubService');
+    await expect(pushCode('test-org/my-repo', files)).rejects.toThrow('Failed to create commit: 500');
+  });
+
+  it('ref 업데이트 실패 → "Failed to update ref" throw', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockResponse({ object: { sha: 'abc123' } }))
+      .mockResolvedValueOnce(mockResponse({ tree: { sha: 'tree123' } }))
+      .mockResolvedValueOnce(mockResponse({ sha: 'blob1' }))
+      .mockResolvedValueOnce(mockResponse({ sha: 'newtree' }))
+      .mockResolvedValueOnce(mockResponse({ sha: 'newcommit' }))
+      .mockResolvedValueOnce({ ok: false, status: 422, json: vi.fn() });
+
+    const { pushCode } = await import('./githubService');
+    await expect(pushCode('test-org/my-repo', files)).rejects.toThrow('Failed to update ref: 422');
+  });
+});
+
+// ── setSecrets ────────────────────────────────────────────────────────────────
+
+describe('setSecrets()', () => {
+  it('빈 secrets {} → public-key 호출 후 logger.info 호출', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ key: 'base64key==', key_id: 'kid1' }),
+    );
+
+    const { setSecrets } = await import('./githubService');
+    const { logger } = await import('@/lib/utils/logger');
+
+    await expect(setSecrets('test-org/my-repo', {})).resolves.toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(logger.info).toHaveBeenCalledWith('Secrets configured', expect.any(Object));
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('non-empty secrets → logger.warn(libsodium 미구현) + logger.info 호출', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ key: 'base64key==', key_id: 'kid1' }),
+    );
+
+    const { setSecrets } = await import('./githubService');
+    const { logger } = await import('@/lib/utils/logger');
+
+    await setSecrets('test-org/my-repo', { API_KEY: 'secret-value', DB_URL: 'postgres://...' });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('libsodium encryption not yet implemented'),
+      expect.objectContaining({ secretNames: ['API_KEY', 'DB_URL'] }),
+    );
+    expect(logger.info).toHaveBeenCalledWith('Secrets configured', expect.any(Object));
+  });
+
+  it('public-key 조회 실패 → logger.warn 후 early return (에러 throw 없음)', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 403, json: vi.fn() });
+
+    const { setSecrets } = await import('./githubService');
+    const { logger } = await import('@/lib/utils/logger');
+
+    await expect(setSecrets('test-org/my-repo', { KEY: 'val' })).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Failed to get public key for secrets',
+      expect.objectContaining({ status: 403 }),
+    );
+    // info는 호출되지 않음 (early return)
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+});
+
+// ── enableGithubPages ─────────────────────────────────────────────────────────
+
+describe('enableGithubPages()', () => {
+  it('성공 (201) → html_url 반환', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ html_url: 'https://test-org.github.io/my-repo/' }, 201),
+    );
+
+    const { enableGithubPages } = await import('./githubService');
+    const result = await enableGithubPages('test-org/my-repo');
+
+    expect(result).toBe('https://test-org.github.io/my-repo/');
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it('409 충돌 → GET /pages 재조회 후 기존 html_url 반환', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: vi.fn().mockResolvedValue({ message: 'Conflict' }),
+      })
+      .mockResolvedValueOnce(
+        mockResponse({ html_url: 'https://test-org.github.io/my-repo/' }),
+      );
+
+    const { enableGithubPages } = await import('./githubService');
+    const result = await enableGithubPages('test-org/my-repo');
+
+    expect(result).toBe('https://test-org.github.io/my-repo/');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('409 충돌 + GET /pages도 실패 → "Failed to enable GitHub Pages" throw', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: vi.fn().mockResolvedValue({ message: 'Conflict' }),
+      })
+      .mockResolvedValueOnce({ ok: false, status: 500, json: vi.fn() });
+
+    const { enableGithubPages } = await import('./githubService');
+    await expect(enableGithubPages('test-org/my-repo')).rejects.toThrow(
+      'Failed to enable GitHub Pages: 409',
+    );
+  });
+
+  it('500 에러 → "Failed to enable GitHub Pages: 500" throw', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: vi.fn().mockResolvedValue({ message: 'Internal Server Error' }),
+    });
+
+    const { enableGithubPages } = await import('./githubService');
+    await expect(enableGithubPages('test-org/my-repo')).rejects.toThrow(
+      'Failed to enable GitHub Pages: 500',
+    );
+  });
+
+  it('branch/path 기본값 적용 확인 (main, /)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ html_url: 'https://test-org.github.io/repo/' }, 201),
+    );
+
+    const { enableGithubPages } = await import('./githubService');
+    await enableGithubPages('test-org/repo');
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body.source.branch).toBe('main');
+    expect(body.source.path).toBe('/');
+  });
+
+  it('branch/path 커스텀 값 전달', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({ html_url: 'https://test-org.github.io/repo/' }, 201),
+    );
+
+    const { enableGithubPages } = await import('./githubService');
+    await enableGithubPages('test-org/repo', 'gh-pages', '/docs');
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body.source.branch).toBe('gh-pages');
+    expect(body.source.path).toBe('/docs');
+  });
+});

--- a/src/lib/deploy/railwayService.test.ts
+++ b/src/lib/deploy/railwayService.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  vi.stubEnv('RAILWAY_TOKEN', 'test-token');
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+// ── Response helpers ──────────────────────────────────────────────────────────
+
+function gqlResponse(data: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue({ data }),
+  };
+}
+
+function gqlError(message: string) {
+  return {
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue({ errors: [{ message }] }),
+  };
+}
+
+function httpError(status: number) {
+  return { ok: false, status, json: vi.fn() };
+}
+
+// ── graphql() 공통 동작 ───────────────────────────────────────────────────────
+
+describe('graphql() — 공통 에러 처리', () => {
+  it('RAILWAY_TOKEN 미설정 → "RAILWAY_TOKEN is not set" throw', async () => {
+    vi.stubEnv('RAILWAY_TOKEN', '');
+
+    const { createProject } = await import('./railwayService');
+    await expect(createProject('my-app')).rejects.toThrow('RAILWAY_TOKEN is not set');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('HTTP 에러 (500) → "Railway API error: 500" throw', async () => {
+    mockFetch.mockResolvedValueOnce(httpError(500));
+
+    const { createProject } = await import('./railwayService');
+    await expect(createProject('my-app')).rejects.toThrow('Railway API error: 500');
+  });
+
+  it('GraphQL errors 배열 포함 → "Railway GraphQL error: ..." throw', async () => {
+    mockFetch.mockResolvedValueOnce(gqlError('Project limit reached'));
+
+    const { createProject } = await import('./railwayService');
+    await expect(createProject('my-app')).rejects.toThrow(
+      'Railway GraphQL error: Project limit reached',
+    );
+  });
+});
+
+// ── createProject ─────────────────────────────────────────────────────────────
+
+describe('createProject()', () => {
+  it('성공 → RailwayProject 반환', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({ projectCreate: { id: 'rp1', name: 'my-app' } }),
+    );
+
+    const { createProject } = await import('./railwayService');
+    const result = await createProject('my-app');
+
+    expect(result).toEqual({ id: 'rp1', name: 'my-app' });
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://backboard.railway.com/graphql/v2',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('요청 body에 name 변수 포함', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({ projectCreate: { id: 'rp2', name: 'service-x' } }),
+    );
+
+    const { createProject } = await import('./railwayService');
+    await createProject('service-x');
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body.variables).toEqual({ input: { name: 'service-x' } });
+  });
+});
+
+// ── createServiceFromRepo ─────────────────────────────────────────────────────
+
+describe('createServiceFromRepo()', () => {
+  it('성공 → service id 반환', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({ serviceCreate: { id: 'svc1' } }),
+    );
+
+    const { createServiceFromRepo } = await import('./railwayService');
+    const result = await createServiceFromRepo('rp1', 'org/repo');
+
+    expect(result).toBe('svc1');
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it('요청 body에 projectId와 repo 변수 포함', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({ serviceCreate: { id: 'svc2' } }),
+    );
+
+    const { createServiceFromRepo } = await import('./railwayService');
+    await createServiceFromRepo('rp1', 'myorg/myrepo');
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body.variables.input.projectId).toBe('rp1');
+    expect(body.variables.input.source.repo).toBe('myorg/myrepo');
+  });
+});
+
+// ── setEnvironmentVariables ───────────────────────────────────────────────────
+
+describe('setEnvironmentVariables()', () => {
+  it('환경 있음 → 2회 fetch (query + mutation)', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        gqlResponse({
+          environments: { edges: [{ node: { id: 'env1' } }] },
+        }),
+      )
+      .mockResolvedValueOnce(gqlResponse({ variableCollectionUpsert: true }));
+
+    const { setEnvironmentVariables } = await import('./railwayService');
+    await expect(
+      setEnvironmentVariables('rp1', 'svc1', { KEY: 'val', DB: 'postgres://' }),
+    ).resolves.toBeUndefined();
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('mutation body에 environmentId, variables 포함', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        gqlResponse({
+          environments: { edges: [{ node: { id: 'env-abc' } }] },
+        }),
+      )
+      .mockResolvedValueOnce(gqlResponse({ variableCollectionUpsert: true }));
+
+    const { setEnvironmentVariables } = await import('./railwayService');
+    await setEnvironmentVariables('rp1', 'svc1', { SECRET: 'value' });
+
+    const mutationBody = JSON.parse(mockFetch.mock.calls[1][1].body as string);
+    expect(mutationBody.variables.input.environmentId).toBe('env-abc');
+    expect(mutationBody.variables.input.variables).toEqual({ SECRET: 'value' });
+    expect(mutationBody.variables.input.serviceId).toBe('svc1');
+    expect(mutationBody.variables.input.projectId).toBe('rp1');
+  });
+
+  it('환경 없음 → logger.warn 후 early return (fetch 1회만 호출)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({ environments: { edges: [] } }),
+    );
+
+    const { setEnvironmentVariables } = await import('./railwayService');
+    const { logger } = await import('@/lib/utils/logger');
+
+    await expect(
+      setEnvironmentVariables('rp1', 'svc1', { KEY: 'val' }),
+    ).resolves.toBeUndefined();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'No environment found for Railway project',
+      expect.objectContaining({ projectId: 'rp1' }),
+    );
+  });
+});
+
+// ── triggerDeploy ─────────────────────────────────────────────────────────────
+
+describe('triggerDeploy()', () => {
+  it('성공 → deploy id 문자열 반환', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({ serviceInstanceRedeploy: 'deploy-123' }),
+    );
+
+    const { triggerDeploy } = await import('./railwayService');
+    const result = await triggerDeploy('svc1');
+
+    expect(result).toBe('deploy-123');
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it('요청 body에 serviceId 변수 포함', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({ serviceInstanceRedeploy: 'deploy-xyz' }),
+    );
+
+    const { triggerDeploy } = await import('./railwayService');
+    await triggerDeploy('svc-abc');
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body.variables.serviceId).toBe('svc-abc');
+  });
+});
+
+// ── getDeploymentStatus ───────────────────────────────────────────────────────
+
+describe('getDeploymentStatus()', () => {
+  it('배포 있음 + staticUrl 있음 → { id, status, url } 반환', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({
+        deployments: {
+          edges: [{ node: { id: 'dep1', status: 'SUCCESS', staticUrl: 'my-app.up.railway.app' } }],
+        },
+      }),
+    );
+
+    const { getDeploymentStatus } = await import('./railwayService');
+    const result = await getDeploymentStatus('rp1');
+
+    expect(result).toEqual({
+      id: 'dep1',
+      status: 'SUCCESS',
+      url: 'https://my-app.up.railway.app',
+    });
+  });
+
+  it('staticUrl null → url이 undefined', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({
+        deployments: {
+          edges: [{ node: { id: 'dep2', status: 'BUILDING', staticUrl: null } }],
+        },
+      }),
+    );
+
+    const { getDeploymentStatus } = await import('./railwayService');
+    const result = await getDeploymentStatus('rp1');
+
+    expect(result).toEqual({ id: 'dep2', status: 'BUILDING', url: undefined });
+  });
+
+  it('배포 없음 → null 반환', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({ deployments: { edges: [] } }),
+    );
+
+    const { getDeploymentStatus } = await import('./railwayService');
+    const result = await getDeploymentStatus('rp1');
+
+    expect(result).toBeNull();
+  });
+});
+
+// ── getServiceDomain ──────────────────────────────────────────────────────────
+
+describe('getServiceDomain()', () => {
+  it('도메인 있음 → "https://..." 반환', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({
+        serviceDomains: {
+          serviceDomains: [{ domain: 'my-service.up.railway.app' }],
+        },
+      }),
+    );
+
+    const { getServiceDomain } = await import('./railwayService');
+    const result = await getServiceDomain('svc1');
+
+    expect(result).toBe('https://my-service.up.railway.app');
+  });
+
+  it('도메인 없음 → null 반환', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({
+        serviceDomains: { serviceDomains: [] },
+      }),
+    );
+
+    const { getServiceDomain } = await import('./railwayService');
+    const result = await getServiceDomain('svc1');
+
+    expect(result).toBeNull();
+  });
+});
+
+// ── generateServiceDomain ─────────────────────────────────────────────────────
+
+describe('generateServiceDomain()', () => {
+  it('성공 → "https://..." 반환', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({
+        serviceDomainCreate: { domain: 'generated.up.railway.app' },
+      }),
+    );
+
+    const { generateServiceDomain } = await import('./railwayService');
+    const result = await generateServiceDomain('svc1', 'env1');
+
+    expect(result).toBe('https://generated.up.railway.app');
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it('요청 body에 serviceId와 environmentId 포함', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({
+        serviceDomainCreate: { domain: 'new-domain.up.railway.app' },
+      }),
+    );
+
+    const { generateServiceDomain } = await import('./railwayService');
+    await generateServiceDomain('svc-xyz', 'env-abc');
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body.variables.input.serviceId).toBe('svc-xyz');
+    expect(body.variables.input.environmentId).toBe('env-abc');
+  });
+});
+
+// ── deleteProject ─────────────────────────────────────────────────────────────
+
+describe('deleteProject()', () => {
+  it('성공 → fetch 1회 호출, void 반환', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({ projectDelete: true }),
+    );
+
+    const { deleteProject } = await import('./railwayService');
+    await expect(deleteProject('rp1')).resolves.toBeUndefined();
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it('요청 body에 id 변수 포함', async () => {
+    mockFetch.mockResolvedValueOnce(
+      gqlResponse({ projectDelete: true }),
+    );
+
+    const { deleteProject } = await import('./railwayService');
+    await deleteProject('project-123');
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body.variables.id).toBe('project-123');
+  });
+
+  it('GraphQL 에러 → throw', async () => {
+    mockFetch.mockResolvedValueOnce(gqlError('Project not found'));
+
+    const { deleteProject } = await import('./railwayService');
+    await expect(deleteProject('rp-not-exist')).rejects.toThrow(
+      'Railway GraphQL error: Project not found',
+    );
+  });
+});

--- a/src/lib/events/eventBus.test.ts
+++ b/src/lib/events/eventBus.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+// eventBus는 모듈 레벨 싱글톤이므로 각 테스트에서 on/off로 핸들러를 직접 관리
+import { eventBus } from './eventBus';
+import type { DomainEvent } from '@/types/events';
+
+const TEST_EVENT: DomainEvent = {
+  type: 'USER_SIGNED_UP',
+  payload: { userId: 'user-1' },
+};
+
+describe('EventBus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─── on / emit ─────────────────────────────────────────────────────────────
+  describe('on() + emit()', () => {
+    it('등록된 핸들러가 emit 시 호출된다', async () => {
+      const handler = vi.fn();
+      const unsubscribe = eventBus.on(handler);
+
+      eventBus.emit(TEST_EVENT);
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(TEST_EVENT);
+
+      unsubscribe();
+    });
+
+    it('여러 핸들러가 모두 호출된다', async () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const handler3 = vi.fn();
+
+      const unsub1 = eventBus.on(handler1);
+      const unsub2 = eventBus.on(handler2);
+      const unsub3 = eventBus.on(handler3);
+
+      eventBus.emit(TEST_EVENT);
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(handler1).toHaveBeenCalledTimes(1);
+      expect(handler2).toHaveBeenCalledTimes(1);
+      expect(handler3).toHaveBeenCalledTimes(1);
+
+      unsub1();
+      unsub2();
+      unsub3();
+    });
+
+    it('이벤트 페이로드가 핸들러에 그대로 전달된다', async () => {
+      const handler = vi.fn();
+      const unsubscribe = eventBus.on(handler);
+
+      const event: DomainEvent = {
+        type: 'PROJECT_CREATED',
+        payload: { projectId: 'proj-1', userId: 'user-1', apiCount: 3 },
+      };
+      eventBus.emit(event);
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(handler).toHaveBeenCalledWith(event);
+      unsubscribe();
+    });
+  });
+
+  // ─── unsubscribe ───────────────────────────────────────────────────────────
+  describe('unsubscribe()', () => {
+    it('unsubscribe 후 emit해도 핸들러가 호출되지 않는다', async () => {
+      const handler = vi.fn();
+      const unsubscribe = eventBus.on(handler);
+
+      unsubscribe();
+      eventBus.emit(TEST_EVENT);
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('일부 핸들러만 unsubscribe하면 나머지는 계속 호출된다', async () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      const unsub1 = eventBus.on(handler1);
+      const unsub2 = eventBus.on(handler2);
+
+      unsub1(); // handler1만 제거
+
+      eventBus.emit(TEST_EVENT);
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(handler1).not.toHaveBeenCalled();
+      expect(handler2).toHaveBeenCalledTimes(1);
+
+      unsub2();
+    });
+
+    it('동일 핸들러를 두 번 unsubscribe해도 에러가 없다', async () => {
+      const handler = vi.fn();
+      const unsubscribe = eventBus.on(handler);
+
+      unsubscribe();
+      expect(() => unsubscribe()).not.toThrow();
+
+      eventBus.emit(TEST_EVENT);
+      await new Promise((r) => setTimeout(r, 0));
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── 에러 처리 ─────────────────────────────────────────────────────────────
+  describe('에러 처리', () => {
+    it('핸들러 에러가 발생해도 다른 핸들러는 호출된다', async () => {
+      const errorHandler = vi.fn().mockRejectedValue(new Error('핸들러 에러'));
+      const normalHandler = vi.fn();
+
+      const unsub1 = eventBus.on(errorHandler);
+      const unsub2 = eventBus.on(normalHandler);
+
+      eventBus.emit(TEST_EVENT);
+      await new Promise((r) => setTimeout(r, 10)); // Promise.resolve().catch 처리 대기
+
+      expect(normalHandler).toHaveBeenCalledTimes(1);
+
+      unsub1();
+      unsub2();
+    });
+
+    it('핸들러 에러 시 logger.warn이 호출된다', async () => {
+      const { logger } = await import('@/lib/utils/logger');
+      const errorHandler = vi.fn().mockRejectedValue(new Error('핸들러 에러'));
+
+      const unsubscribe = eventBus.on(errorHandler);
+
+      eventBus.emit(TEST_EVENT);
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'EventBus handler error',
+        expect.objectContaining({ type: 'USER_SIGNED_UP' })
+      );
+
+      unsubscribe();
+    });
+
+    it('async 에러 핸들러가 여러 개여도 모두 logger.warn을 호출한다', async () => {
+      const { logger } = await import('@/lib/utils/logger');
+      const errorHandler1 = vi.fn().mockRejectedValue(new Error('에러1'));
+      const errorHandler2 = vi.fn().mockRejectedValue(new Error('에러2'));
+
+      const unsub1 = eventBus.on(errorHandler1);
+      const unsub2 = eventBus.on(errorHandler2);
+
+      eventBus.emit(TEST_EVENT);
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(logger.warn).toHaveBeenCalledTimes(2);
+
+      unsub1();
+      unsub2();
+    });
+  });
+
+  // ─── async 핸들러 ──────────────────────────────────────────────────────────
+  describe('async 핸들러', () => {
+    it('async 핸들러가 올바르게 호출된다', async () => {
+      const results: string[] = [];
+      const asyncHandler = vi.fn().mockImplementation(async (event: DomainEvent) => {
+        await new Promise((r) => setTimeout(r, 5));
+        results.push(event.type);
+      });
+
+      const unsubscribe = eventBus.on(asyncHandler);
+
+      eventBus.emit(TEST_EVENT);
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(asyncHandler).toHaveBeenCalledTimes(1);
+      expect(results).toContain('USER_SIGNED_UP');
+
+      unsubscribe();
+    });
+
+    it('여러 async 핸들러가 모두 호출된다', async () => {
+      const handler1 = vi.fn().mockResolvedValue(undefined);
+      const handler2 = vi.fn().mockResolvedValue(undefined);
+
+      const unsub1 = eventBus.on(handler1);
+      const unsub2 = eventBus.on(handler2);
+
+      eventBus.emit(TEST_EVENT);
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(handler1).toHaveBeenCalledTimes(1);
+      expect(handler2).toHaveBeenCalledTimes(1);
+
+      unsub1();
+      unsub2();
+    });
+  });
+});

--- a/src/lib/events/eventPersister.test.ts
+++ b/src/lib/events/eventPersister.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// All mocks are declared at the top level, but because we use vi.resetModules()
+// in beforeEach we re-import everything dynamically inside each test.
+
+vi.mock('./eventBus', () => ({
+  eventBus: { on: vi.fn(), emit: vi.fn() },
+}));
+vi.mock('@/repositories/factory', () => ({
+  createEventRepository: vi.fn(),
+}));
+vi.mock('@/lib/supabase/server', () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe('registerEventPersister', () => {
+  it('registers a handler on eventBus.on once', async () => {
+    const { registerEventPersister } = await import('./eventPersister');
+    const { eventBus } = await import('./eventBus');
+
+    registerEventPersister();
+
+    expect(eventBus.on).toHaveBeenCalledTimes(1);
+    expect(typeof (eventBus.on as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe('function');
+  });
+
+  it('is idempotent — calling twice only registers one handler', async () => {
+    const { registerEventPersister } = await import('./eventPersister');
+    const { eventBus } = await import('./eventBus');
+
+    registerEventPersister();
+    registerEventPersister();
+
+    expect(eventBus.on).toHaveBeenCalledTimes(1);
+  });
+
+  it('handler calls createServiceClient and eventRepo.persist when invoked', async () => {
+    const { registerEventPersister } = await import('./eventPersister');
+    const { eventBus } = await import('./eventBus');
+    const { createServiceClient } = await import('@/lib/supabase/server');
+    const { createEventRepository } = await import('@/repositories/factory');
+
+    const mockSupabase = { from: vi.fn() };
+    const mockPersist = vi.fn().mockResolvedValue(undefined);
+    const mockEventRepo = { persist: mockPersist };
+
+    (createServiceClient as ReturnType<typeof vi.fn>).mockResolvedValue(mockSupabase);
+    (createEventRepository as ReturnType<typeof vi.fn>).mockReturnValue(mockEventRepo);
+
+    registerEventPersister();
+
+    const handler = (eventBus.on as ReturnType<typeof vi.fn>).mock.calls[0][0] as (
+      event: unknown,
+    ) => Promise<void>;
+
+    const fakeEvent = { type: 'TEST_EVENT', payload: { data: 'value' } };
+    await handler(fakeEvent);
+
+    expect(createServiceClient).toHaveBeenCalledTimes(1);
+    expect(createEventRepository).toHaveBeenCalledWith(mockSupabase);
+    expect(mockPersist).toHaveBeenCalledWith(fakeEvent, {});
+  });
+
+  it('logs a warning and does not throw when createServiceClient rejects', async () => {
+    const { registerEventPersister } = await import('./eventPersister');
+    const { eventBus } = await import('./eventBus');
+    const { createServiceClient } = await import('@/lib/supabase/server');
+    const { logger } = await import('@/lib/utils/logger');
+
+    (createServiceClient as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('DB unavailable'));
+
+    registerEventPersister();
+
+    const handler = (eventBus.on as ReturnType<typeof vi.fn>).mock.calls[0][0] as (
+      event: unknown,
+    ) => Promise<void>;
+
+    const fakeEvent = { type: 'FAIL_EVENT', payload: {} };
+
+    // Should not throw
+    await expect(handler(fakeEvent)).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'EventPersister: failed to persist event',
+      expect.objectContaining({ type: 'FAIL_EVENT', error: 'DB unavailable' }),
+    );
+  });
+
+  it('logs a warning with stringified error for non-Error rejections', async () => {
+    const { registerEventPersister } = await import('./eventPersister');
+    const { eventBus } = await import('./eventBus');
+    const { createServiceClient } = await import('@/lib/supabase/server');
+    const { logger } = await import('@/lib/utils/logger');
+
+    (createServiceClient as ReturnType<typeof vi.fn>).mockRejectedValue('plain string error');
+
+    registerEventPersister();
+
+    const handler = (eventBus.on as ReturnType<typeof vi.fn>).mock.calls[0][0] as (
+      event: unknown,
+    ) => Promise<void>;
+
+    const fakeEvent = { type: 'STRING_ERR_EVENT', payload: {} };
+    await handler(fakeEvent);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'EventPersister: failed to persist event',
+      expect.objectContaining({ error: 'plain string error' }),
+    );
+  });
+});

--- a/src/lib/services/popularServices.test.ts
+++ b/src/lib/services/popularServices.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CURATED_SERVICES,
+  pickTopIds,
+  computePopularServices,
+  resolveCuratedServices,
+} from './popularServices';
+
+describe('CURATED_SERVICES', () => {
+  it('is a non-empty array', () => {
+    expect(Array.isArray(CURATED_SERVICES)).toBe(true);
+    expect(CURATED_SERVICES.length).toBeGreaterThan(0);
+  });
+
+  it('every item has required fields', () => {
+    for (const item of CURATED_SERVICES) {
+      expect(item).toHaveProperty('id');
+      expect(item).toHaveProperty('title');
+      expect(item).toHaveProperty('description');
+      expect(item).toHaveProperty('context');
+      expect(item).toHaveProperty('apiNames');
+      expect(item).toHaveProperty('category');
+    }
+  });
+});
+
+describe('pickTopIds', () => {
+  it('returns [] for empty usage rows', () => {
+    expect(pickTopIds([], 5)).toEqual([]);
+  });
+
+  it('returns the most frequent id when topN is 1', () => {
+    const rows = [
+      { apiId: 'a', context: '' },
+      { apiId: 'b', context: '' },
+      { apiId: 'a', context: '' },
+    ];
+    expect(pickTopIds(rows, 1)).toEqual(['a']);
+  });
+
+  it('returns top 2 ids sorted by frequency descending', () => {
+    const rows = [
+      { apiId: 'a', context: '' },
+      { apiId: 'b', context: '' },
+      { apiId: 'a', context: '' },
+    ];
+    expect(pickTopIds(rows, 2)).toEqual(['a', 'b']);
+  });
+});
+
+describe('computePopularServices', () => {
+  it('returns [] for empty inputs', () => {
+    expect(computePopularServices([], [])).toEqual([]);
+  });
+
+  it('returns one service with correct shape for a single usage row', () => {
+    const rows = [{ apiId: 'api1', context: 'ctx' }];
+    const details = [{ id: 'api1', name: 'Test API', description: 'desc', category: 'cat' }];
+    const result = computePopularServices(rows, details);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('popular-api1');
+    expect(result[0].title).toBe('Test API 활용 서비스');
+    expect(result[0].usageCount).toBe(1);
+  });
+
+  it('filters out APIs that have no usage rows', () => {
+    const rows = [{ apiId: 'api1', context: 'ctx' }];
+    const details = [
+      { id: 'api1', name: 'Test API', description: 'desc', category: 'cat' },
+      { id: 'api2', name: 'Other API', description: null, category: null },
+    ];
+    const result = computePopularServices(rows, details);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('popular-api1');
+  });
+});
+
+describe('resolveCuratedServices', () => {
+  it('returns an array with same length as CURATED_SERVICES', () => {
+    const result = resolveCuratedServices(new Map());
+    expect(result).toHaveLength(CURATED_SERVICES.length);
+  });
+
+  it('returns apiIds: [] when name map is empty', () => {
+    const result = resolveCuratedServices(new Map());
+    for (const service of result) {
+      expect(service.apiIds).toEqual([]);
+    }
+  });
+
+  it('resolves OpenWeatherMap id when provided in the name map', () => {
+    const nameToIdMap = new Map([['openweathermap', 'api-owm']]);
+    const result = resolveCuratedServices(nameToIdMap);
+    const weatherItem = result.find((s) =>
+      CURATED_SERVICES.find(
+        (c) => c.id === s.id && c.apiNames.some((n) => n.toLowerCase() === 'openweathermap')
+      )
+    );
+    expect(weatherItem).toBeDefined();
+    expect(weatherItem!.apiIds).toContain('api-owm');
+  });
+});

--- a/src/lib/templates/siteError.test.ts
+++ b/src/lib/templates/siteError.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { notFoundHtml, preparingHtml } from './siteError';
+
+describe('notFoundHtml', () => {
+  it('contains 404 and the slug', () => {
+    const html = notFoundHtml('my-slug');
+    expect(html).toContain('404');
+    expect(html).toContain('my-slug');
+  });
+
+  it('contains DOCTYPE and html structure', () => {
+    const html = notFoundHtml('test');
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('<html');
+    expect(html).toContain('</html>');
+  });
+
+  it('escapes XSS: <script> tag', () => {
+    const html = notFoundHtml('<script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).not.toContain('<script>');
+  });
+
+  it('escapes XSS: double quotes', () => {
+    const html = notFoundHtml('"hello"');
+    expect(html).toContain('&quot;hello&quot;');
+    expect(html).not.toContain('"hello"');
+  });
+
+  it("escapes XSS: apostrophe in it's", () => {
+    const html = notFoundHtml("it's");
+    expect(html).toContain('&#39;s');
+  });
+});
+
+describe('preparingHtml', () => {
+  it('contains the slug and 준비 중', () => {
+    const html = preparingHtml('my-slug');
+    expect(html).toContain('my-slug');
+    expect(html).toContain('준비 중');
+  });
+
+  it('has meta http-equiv="refresh" for auto-refresh', () => {
+    const html = preparingHtml('test');
+    expect(html).toContain('http-equiv="refresh"');
+  });
+
+  it('escapes XSS: <img src=x>', () => {
+    const html = preparingHtml('<img src=x>');
+    expect(html).toContain('&lt;img src=x&gt;');
+    expect(html).not.toContain('<img src=x>');
+  });
+});

--- a/src/lib/utils/adminAuth.test.ts
+++ b/src/lib/utils/adminAuth.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { withAdminCors, verifyAdminKey, adminCorsHeaders } from './adminAuth';
+import { ForbiddenError } from './errors';
+
+// logger는 사용되지 않지만 errors.ts가 import하므로 mock
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+// errors.ts → failover.ts → connection.ts 체인 mock
+vi.mock('@/lib/db/failover', () => ({
+  isDbConnectionError: vi.fn().mockReturnValue(false),
+  reportFailure: vi.fn(),
+}));
+
+// i18n mock
+vi.mock('@/lib/i18n', () => ({
+  t: (key: string) => key,
+}));
+
+// ───────────────────────────────────────────────
+// withAdminCors
+// ───────────────────────────────────────────────
+describe('withAdminCors()', () => {
+  it('원본 응답에 CORS 헤더를 추가한다', () => {
+    const original = new Response('{"ok":true}', { status: 200 });
+    const result = withAdminCors(original);
+
+    for (const [key, value] of Object.entries(adminCorsHeaders)) {
+      expect(result.headers.get(key)).toBe(value);
+    }
+  });
+
+  it('원본 status / statusText를 유지한다', () => {
+    const original = new Response(null, { status: 204, statusText: 'No Content' });
+    const result = withAdminCors(original);
+    expect(result.status).toBe(204);
+    expect(result.statusText).toBe('No Content');
+  });
+
+  it('기존 헤더에 CORS 헤더를 추가(덮어쓰기)한다', () => {
+    const original = new Response(null, {
+      headers: { 'X-Custom': 'hello', 'Access-Control-Allow-Origin': 'https://old.example.com' },
+    });
+    const result = withAdminCors(original);
+    // 기존 커스텀 헤더는 유지
+    expect(result.headers.get('X-Custom')).toBe('hello');
+    // CORS 헤더는 adminCorsHeaders 값으로 덮어씌워짐
+    expect(result.headers.get('Access-Control-Allow-Origin')).toBe(
+      adminCorsHeaders['Access-Control-Allow-Origin']
+    );
+  });
+});
+
+// ───────────────────────────────────────────────
+// verifyAdminKey
+// ───────────────────────────────────────────────
+describe('verifyAdminKey()', () => {
+  // 각 테스트에서 다른 IP를 사용해 rate-limit 카운터 오염 방지
+  let ipCounter = 0;
+  function makeRequest(headers: Record<string, string> = {}, ip?: string): Request {
+    const resolvedIp = ip ?? `10.0.0.${ipCounter++}`;
+    return new Request('http://test.com/admin', {
+      headers: {
+        'x-forwarded-for': resolvedIp,
+        ...headers,
+      },
+    });
+  }
+
+  beforeEach(() => {
+    vi.stubEnv('ADMIN_API_KEY', 'secret-admin-key');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('Authorization 헤더 없으면 ForbiddenError를 던진다', () => {
+    expect(() => verifyAdminKey(makeRequest())).toThrow(ForbiddenError);
+  });
+
+  it("'Bearer'로 시작하지 않으면 ForbiddenError를 던진다", () => {
+    expect(() =>
+      verifyAdminKey(makeRequest({ Authorization: 'Token secret-admin-key' }))
+    ).toThrow(ForbiddenError);
+  });
+
+  it('ADMIN_API_KEY 환경변수가 없으면 ForbiddenError를 던진다', () => {
+    vi.stubEnv('ADMIN_API_KEY', '');
+    // 빈 문자열은 falsy이므로 에러 발생
+    expect(() =>
+      verifyAdminKey(makeRequest({ Authorization: 'Bearer secret-admin-key' }))
+    ).toThrow(ForbiddenError);
+  });
+
+  it('잘못된 키이면 ForbiddenError를 던진다', () => {
+    expect(() =>
+      verifyAdminKey(makeRequest({ Authorization: 'Bearer wrong-key' }))
+    ).toThrow(ForbiddenError);
+  });
+
+  it('올바른 키이면 에러 없이 통과한다', () => {
+    expect(() =>
+      verifyAdminKey(makeRequest({ Authorization: 'Bearer secret-admin-key' }))
+    ).not.toThrow();
+  });
+
+  it('x-real-ip 헤더만 있어도 레이트 리밋 IP를 식별한다', () => {
+    const req = new Request('http://test.com/admin', {
+      headers: {
+        'x-real-ip': '192.168.1.100',
+        Authorization: 'Bearer secret-admin-key',
+      },
+    });
+    expect(() => verifyAdminKey(req)).not.toThrow();
+  });
+
+  it('헤더 없이 요청하면 IP가 unknown으로 처리된다 (에러 종류만 확인)', () => {
+    // Authorization 없으므로 ForbiddenError 발생 (IP unknown 처리는 내부)
+    const req = new Request('http://test.com/admin');
+    expect(() => verifyAdminKey(req)).toThrow(ForbiddenError);
+  });
+
+  describe('레이트 리밋', () => {
+    it('같은 IP로 61회 이상 호출하면 ForbiddenError(레이트 리밋)를 던진다', () => {
+      const rateIp = `rate-test-ip-${Date.now()}`;
+      // 올바른 키로 60회 통과
+      for (let i = 0; i < 60; i++) {
+        expect(() =>
+          verifyAdminKey(
+            new Request('http://test.com/admin', {
+              headers: {
+                'x-forwarded-for': rateIp,
+                Authorization: 'Bearer secret-admin-key',
+              },
+            })
+          )
+        ).not.toThrow();
+      }
+      // 61번째 요청 → 레이트 리밋 초과
+      expect(() =>
+        verifyAdminKey(
+          new Request('http://test.com/admin', {
+            headers: {
+              'x-forwarded-for': rateIp,
+              Authorization: 'Bearer secret-admin-key',
+            },
+          })
+        )
+      ).toThrow(ForbiddenError);
+    });
+  });
+});

--- a/src/lib/utils/htmlTitle.test.ts
+++ b/src/lib/utils/htmlTitle.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { extractTitle } from './htmlTitle';
+
+describe('extractTitle()', () => {
+  it('title 태그의 내용을 추출한다', () => {
+    const html = '<html><head><title>My App</title></head><body></body></html>';
+    expect(extractTitle(html)).toBe('My App');
+  });
+
+  it('title 태그가 없으면 undefined를 반환한다', () => {
+    const html = '<html><head></head><body>내용</body></html>';
+    expect(extractTitle(html)).toBeUndefined();
+  });
+
+  it('title 내용의 앞뒤 공백을 제거한다', () => {
+    const html = '<title>  공백 있는 제목  </title>';
+    expect(extractTitle(html)).toBe('공백 있는 제목');
+  });
+
+  it('대소문자 혼합 TITLE 태그도 인식한다', () => {
+    const html = '<TITLE>대문자 제목</TITLE>';
+    expect(extractTitle(html)).toBe('대문자 제목');
+  });
+
+  it('혼합 대소문자 Title 태그도 인식한다', () => {
+    const html = '<Title>혼합 제목</Title>';
+    expect(extractTitle(html)).toBe('혼합 제목');
+  });
+
+  it('빈 문자열이면 undefined를 반환한다', () => {
+    expect(extractTitle('')).toBeUndefined();
+  });
+
+  it('한국어 제목을 올바르게 추출한다', () => {
+    const html = '<title>날씨 앱</title>';
+    expect(extractTitle(html)).toBe('날씨 앱');
+  });
+
+  it('title 속성이 있는 태그도 처리한다', () => {
+    const html = '<title lang="ko">속성 있는 제목</title>';
+    expect(extractTitle(html)).toBe('속성 있는 제목');
+  });
+});

--- a/src/lib/utils/publishUrl.test.ts
+++ b/src/lib/utils/publishUrl.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { buildPublishUrl } from './publishUrl';
+
+describe('buildPublishUrl()', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_ROOT_DOMAIN;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_ROOT_DOMAIN;
+    } else {
+      process.env.NEXT_PUBLIC_ROOT_DOMAIN = originalEnv;
+    }
+  });
+
+  it('NEXT_PUBLIC_ROOT_DOMAIN이 없으면 /site/{slug}를 반환한다', () => {
+    delete process.env.NEXT_PUBLIC_ROOT_DOMAIN;
+
+    const result = buildPublishUrl('my-app');
+    expect(result).toBe('/site/my-app');
+  });
+
+  it('rootDomain이 localhost이면 /site/{slug}를 반환한다', () => {
+    process.env.NEXT_PUBLIC_ROOT_DOMAIN = 'localhost:3000';
+
+    const result = buildPublishUrl('my-app');
+    expect(result).toBe('/site/my-app');
+  });
+
+  it('rootDomain이 127.0.0.1이면 /site/{slug}를 반환한다', () => {
+    process.env.NEXT_PUBLIC_ROOT_DOMAIN = '127.0.0.1:3000';
+
+    const result = buildPublishUrl('my-app');
+    expect(result).toBe('/site/my-app');
+  });
+
+  it('프로덕션 도메인이면 https://{slug}.{rootDomain}을 반환한다', () => {
+    process.env.NEXT_PUBLIC_ROOT_DOMAIN = 'xzawed.xyz';
+
+    const result = buildPublishUrl('my-app');
+    expect(result).toBe('https://my-app.xzawed.xyz');
+  });
+
+  it('프로덕션 도메인에서 slug가 그대로 서브도메인에 포함된다', () => {
+    process.env.NEXT_PUBLIC_ROOT_DOMAIN = 'example.com';
+
+    const result = buildPublishUrl('cool-project-abc123');
+    expect(result).toBe('https://cool-project-abc123.example.com');
+  });
+});

--- a/src/lib/utils/slugify.test.ts
+++ b/src/lib/utils/slugify.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { toSlug, generateSlug, isValidSlug, RESERVED_SLUGS } from './slugify';
+
+describe('toSlug()', () => {
+  it('영문 소문자로 변환한다', () => {
+    expect(toSlug('Hello World')).toBe('hello-world');
+  });
+
+  it('발음 기호(액센트)를 제거한다', () => {
+    expect(toSlug('café')).toBe('cafe');
+    expect(toSlug('résumé')).toBe('resume');
+    expect(toSlug('naïve')).toBe('naive');
+  });
+
+  it('특수문자를 제거한다', () => {
+    expect(toSlug('hello!@#$%^&*()')).toBe('hello');
+    expect(toSlug('my.app.name')).toBe('myappname');
+  });
+
+  it('공백을 하이픈으로 변환한다', () => {
+    expect(toSlug('my project name')).toBe('my-project-name');
+  });
+
+  it('언더스코어는 특수문자로 제거된다 (하이픈 변환 전에 삭제)', () => {
+    // toSlug: [^a-z0-9\s-] 제거 → 언더스코어가 먼저 제거됨
+    expect(toSlug('my_project_name')).toBe('myprojectname');
+  });
+
+  it('연속된 하이픈을 단일 하이픈으로 변환한다', () => {
+    expect(toSlug('hello---world')).toBe('hello-world');
+    expect(toSlug('hello   world')).toBe('hello-world');
+  });
+
+  it('앞뒤 하이픈을 제거한다', () => {
+    expect(toSlug('-hello-')).toBe('hello');
+    expect(toSlug('  hello  ')).toBe('hello');
+  });
+
+  it('한국어는 빈 문자열이 된다', () => {
+    expect(toSlug('안녕하세요')).toBe('');
+  });
+
+  it('숫자는 유지한다', () => {
+    expect(toSlug('project123')).toBe('project123');
+    expect(toSlug('123 test')).toBe('123-test');
+  });
+});
+
+describe('generateSlug()', () => {
+  it('영문 프로젝트 이름으로 slug를 생성한다', () => {
+    const result = generateSlug('My Weather App', 'abc123-def456');
+    // idSuffix: 'abc123def456'.slice(0,6) = 'abc123'
+    expect(result).toBe('my-weather-app-abc123');
+  });
+
+  it('한글/특수문자 이름이면 project-{idSuffix} 형식을 사용한다', () => {
+    const result = generateSlug('한국어 앱', 'xyz789-uvw012');
+    // toSlug('한국어 앱') = '' (길이 0)
+    expect(result).toMatch(/^project-/);
+  });
+
+  it('1글자 이름이면 project-{idSuffix} 형식을 사용한다', () => {
+    const result = generateSlug('a', 'abc123-def456');
+    // toSlug('a').length = 1 < 2
+    expect(result).toMatch(/^project-/);
+  });
+
+  it('id의 하이픈을 제거하고 앞 6자리만 사용한다', () => {
+    const result = generateSlug('test-app', 'abcdef-ghijkl');
+    // idSuffix = 'abcdefghijkl'.slice(0,6) = 'abcdef'
+    expect(result).toBe('test-app-abcdef');
+  });
+
+  it('긴 프로젝트 이름은 43자로 잘린다', () => {
+    const longName = 'a'.repeat(50);
+    const result = generateSlug(longName, 'abc123-def456');
+    // base = 'a'.repeat(43), idSuffix = 'abc123'
+    expect(result).toBe('a'.repeat(43) + '-abc123');
+    expect(result.length).toBeLessThanOrEqual(50);
+  });
+});
+
+describe('isValidSlug()', () => {
+  it('유효한 slug를 허용한다', () => {
+    expect(isValidSlug('my-app')).toBe(true);
+    expect(isValidSlug('project-abc123')).toBe(true);
+    expect(isValidSlug('hello-world-test')).toBe(true);
+  });
+
+  it('예약된 slug를 거부한다', () => {
+    expect(isValidSlug('www')).toBe(false);
+    expect(isValidSlug('api')).toBe(false);
+    expect(isValidSlug('admin')).toBe(false);
+    expect(isValidSlug('dashboard')).toBe(false);
+    expect(isValidSlug('login')).toBe(false);
+    expect(isValidSlug('logout')).toBe(false);
+    expect(isValidSlug('signup')).toBe(false);
+    expect(isValidSlug('auth')).toBe(false);
+    expect(isValidSlug('site')).toBe(false);
+    expect(isValidSlug('app')).toBe(false);
+    expect(isValidSlug('settings')).toBe(false);
+    expect(isValidSlug('builder')).toBe(false);
+    expect(isValidSlug('docs')).toBe(false);
+    expect(isValidSlug('status')).toBe(false);
+    expect(isValidSlug('health')).toBe(false);
+  });
+
+  it('대문자가 포함된 slug를 거부한다', () => {
+    expect(isValidSlug('MyApp')).toBe(false);
+    expect(isValidSlug('MY-APP')).toBe(false);
+  });
+
+  it('앞/뒤 하이픈이 있는 slug를 거부한다', () => {
+    expect(isValidSlug('-myapp')).toBe(false);
+    expect(isValidSlug('myapp-')).toBe(false);
+  });
+
+  it('너무 짧은 slug를 거부한다 (2자 미만)', () => {
+    expect(isValidSlug('a')).toBe(false);
+    expect(isValidSlug('ab')).toBe(false); // 2자: ^[a-z0-9][a-z0-9-]{1,48}[a-z0-9]$ — 최소 3자
+  });
+
+  it('특수문자가 포함된 slug를 거부한다', () => {
+    expect(isValidSlug('my_app')).toBe(false);
+    expect(isValidSlug('my.app')).toBe(false);
+    expect(isValidSlug('my app')).toBe(false);
+  });
+
+  it('숫자로 시작하는 slug를 허용한다', () => {
+    expect(isValidSlug('123abc')).toBe(true);
+  });
+
+  it('RESERVED_SLUGS Set에 포함된 항목들이 모두 거부된다', () => {
+    for (const reserved of RESERVED_SLUGS) {
+      expect(isValidSlug(reserved)).toBe(false);
+    }
+  });
+});

--- a/src/providers/deploy/DeployProviderFactory.test.ts
+++ b/src/providers/deploy/DeployProviderFactory.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DeployProviderFactory } from './DeployProviderFactory';
+import { RailwayDeployer } from './RailwayDeployer';
+import { GithubPagesDeployer } from './GithubPagesDeployer';
+
+vi.mock('./RailwayDeployer', () => {
+  const MockRailwayDeployer = vi.fn(function (this: Record<string, unknown>) {
+    this.name = 'railway';
+    this.supportedFeatures = ['env_vars', 'custom_domain', 'serverless'];
+  });
+  return { RailwayDeployer: MockRailwayDeployer };
+});
+
+vi.mock('./GithubPagesDeployer', () => {
+  const MockGithubPagesDeployer = vi.fn(function (this: Record<string, unknown>) {
+    this.name = 'github_pages';
+    this.supportedFeatures = ['static_only'];
+  });
+  return { GithubPagesDeployer: MockGithubPagesDeployer };
+});
+
+describe('DeployProviderFactory', () => {
+  beforeEach(() => {
+    // static 캐시 초기화 (private이지만 인덱스 접근으로 우회)
+    (DeployProviderFactory as unknown as { providers: Map<string, unknown> })['providers'] = new Map();
+    vi.clearAllMocks();
+  });
+
+  describe('create()', () => {
+    it("'railway' 플랫폼 → RailwayDeployer 인스턴스를 반환한다", () => {
+      const provider = DeployProviderFactory.create('railway');
+      expect(provider.name).toBe('railway');
+      expect(RailwayDeployer).toHaveBeenCalledTimes(1);
+    });
+
+    it("'github_pages' 플랫폼 → GithubPagesDeployer 인스턴스를 반환한다", () => {
+      const provider = DeployProviderFactory.create('github_pages');
+      expect(provider.name).toBe('github_pages');
+      expect(GithubPagesDeployer).toHaveBeenCalledTimes(1);
+    });
+
+    it('기본값(인수 없음)은 railway를 사용한다', () => {
+      const provider = DeployProviderFactory.create();
+      expect(provider.name).toBe('railway');
+    });
+
+    it('같은 플랫폼을 두 번 create()하면 캐싱된 동일 인스턴스를 반환한다', () => {
+      const p1 = DeployProviderFactory.create('railway');
+      const p2 = DeployProviderFactory.create('railway');
+      expect(p1).toBe(p2);
+      // 생성자는 한 번만 호출되어야 함
+      expect(RailwayDeployer).toHaveBeenCalledTimes(1);
+    });
+
+    it('서로 다른 플랫폼은 서로 다른 인스턴스를 반환한다', () => {
+      const p1 = DeployProviderFactory.create('railway');
+      const p2 = DeployProviderFactory.create('github_pages');
+      expect(p1).not.toBe(p2);
+    });
+
+    it('알 수 없는 플랫폼은 Error를 던진다', () => {
+      expect(() =>
+        DeployProviderFactory.create('unknown' as never)
+      ).toThrow('Unknown deploy platform: unknown');
+    });
+  });
+
+  describe('getSupportedPlatforms()', () => {
+    it("['railway', 'github_pages']를 반환한다", () => {
+      expect(DeployProviderFactory.getSupportedPlatforms()).toEqual(['railway', 'github_pages']);
+    });
+  });
+});

--- a/src/providers/deploy/GithubPagesDeployer.test.ts
+++ b/src/providers/deploy/GithubPagesDeployer.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GithubPagesDeployer } from './GithubPagesDeployer';
+import * as github from '@/lib/deploy/githubService';
+import type { FileEntry } from './IDeployProvider';
+
+vi.mock('@/lib/deploy/githubService', () => ({
+  createRepository: vi.fn(),
+  pushCode: vi.fn(),
+  setSecrets: vi.fn(),
+  enableGithubPages: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+const mockGithub = vi.mocked(github);
+
+describe('GithubPagesDeployer', () => {
+  let deployer: GithubPagesDeployer;
+
+  beforeEach(() => {
+    deployer = new GithubPagesDeployer();
+    vi.clearAllMocks();
+  });
+
+  // ─────────────────────────────────────────────
+  // createProject
+  // ─────────────────────────────────────────────
+  describe('createProject()', () => {
+    it("이름 앞에 'svc-'를 붙여 createRepository를 호출한다", async () => {
+      mockGithub.createRepository.mockResolvedValue({
+        repoUrl: 'https://github.com/org/svc-my-app',
+        fullName: 'org/svc-my-app',
+      });
+
+      const result = await deployer.createProject('my-app');
+
+      expect(mockGithub.createRepository).toHaveBeenCalledWith('svc-my-app');
+      expect(result.projectId).toBe('org/svc-my-app');
+      expect(result.repoUrl).toBe('https://github.com/org/svc-my-app');
+    });
+
+    it('projectId가 fullName으로 설정된다', async () => {
+      mockGithub.createRepository.mockResolvedValue({
+        repoUrl: 'https://github.com/myorg/svc-demo',
+        fullName: 'myorg/svc-demo',
+      });
+
+      const result = await deployer.createProject('demo');
+      expect(result.projectId).toBe('myorg/svc-demo');
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // pushFiles
+  // ─────────────────────────────────────────────
+  describe('pushFiles()', () => {
+    const files: FileEntry[] = [{ path: 'index.html', content: '<h1>Hello</h1>' }];
+
+    it('projectId가 "/" 포함 → 그대로 repoFullName으로 사용한다', async () => {
+      mockGithub.pushCode.mockResolvedValue(undefined);
+
+      await deployer.pushFiles('org/repo', files);
+
+      expect(mockGithub.pushCode).toHaveBeenCalledWith('org/repo', files);
+    });
+
+    it('projectId가 "/" 미포함이고 repoMap에 없으면 Error를 던진다', async () => {
+      await expect(deployer.pushFiles('unknown-project', files)).rejects.toThrow(
+        'Repo not found for project: unknown-project'
+      );
+    });
+
+    it('createProject 후 반환된 name 키로 pushFiles가 동작한다', async () => {
+      mockGithub.createRepository.mockResolvedValue({
+        repoUrl: 'https://github.com/org/svc-myapp',
+        fullName: 'org/svc-myapp',
+      });
+      mockGithub.pushCode.mockResolvedValue(undefined);
+
+      // createProject는 name을 키로 repoMap에 저장
+      await deployer.createProject('myapp');
+      await deployer.pushFiles('myapp', files);
+
+      expect(mockGithub.pushCode).toHaveBeenCalledWith('org/svc-myapp', files);
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // setEnvironment
+  // ─────────────────────────────────────────────
+  describe('setEnvironment()', () => {
+    it('github.setSecrets를 올바른 인수로 호출한다', async () => {
+      mockGithub.setSecrets.mockResolvedValue(undefined);
+      const env = { DB_URL: 'postgres://...' };
+
+      await deployer.setEnvironment('org/repo', env);
+
+      expect(mockGithub.setSecrets).toHaveBeenCalledWith('org/repo', env);
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // deploy
+  // ─────────────────────────────────────────────
+  describe('deploy()', () => {
+    it('github.enableGithubPages를 호출하고 DeployResult를 반환한다', async () => {
+      mockGithub.enableGithubPages.mockResolvedValue('https://org.github.io/repo');
+
+      const result = await deployer.deploy('org/repo');
+
+      expect(mockGithub.enableGithubPages).toHaveBeenCalledWith('org/repo', 'main', '/');
+      expect(result).toEqual({
+        deploymentId: 'org/repo',
+        url: 'https://org.github.io/repo',
+        platform: 'github_pages',
+        status: 'ready',
+      });
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // getStatus
+  // ─────────────────────────────────────────────
+  describe('getStatus()', () => {
+    it("유효한 'org/repo' 형식 → URL을 계산해서 반환한다", async () => {
+      const result = await deployer.getStatus('myorg/myrepo');
+
+      expect(result).toEqual({
+        deploymentId: 'myorg/myrepo',
+        url: 'https://myorg.github.io/myrepo',
+        platform: 'github_pages',
+        status: 'ready',
+      });
+    });
+
+    it("잘못된 형식('just-repo') → Error를 던진다", async () => {
+      await expect(deployer.getStatus('just-repo')).rejects.toThrow('잘못된 deploymentId 형식');
+    });
+
+    it('빈 문자열 → Error를 던진다', async () => {
+      await expect(deployer.getStatus('')).rejects.toThrow('잘못된 deploymentId 형식');
+    });
+
+    it("슬래시만 있는 문자열('org/') → Error를 던진다", async () => {
+      await expect(deployer.getStatus('org/')).rejects.toThrow('잘못된 deploymentId 형식');
+    });
+
+    it("'/repo' 형식 → Error를 던진다", async () => {
+      await expect(deployer.getStatus('/repo')).rejects.toThrow('잘못된 deploymentId 형식');
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // rollback
+  // ─────────────────────────────────────────────
+  describe('rollback()', () => {
+    it('logger.warn을 호출하고 getStatus 결과를 반환한다', async () => {
+      const { logger } = await import('@/lib/utils/logger');
+
+      const result = await deployer.rollback('org/repo', 1);
+
+      expect(logger.warn).toHaveBeenCalled();
+      expect(result).toEqual({
+        deploymentId: 'org/repo',
+        url: 'https://org.github.io/repo',
+        platform: 'github_pages',
+        status: 'ready',
+      });
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // deleteProject
+  // ─────────────────────────────────────────────
+  describe('deleteProject()', () => {
+    it('logger.warn을 호출하고 void를 반환한다', async () => {
+      const { logger } = await import('@/lib/utils/logger');
+
+      await deployer.deleteProject('org/repo');
+
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // resolveRepo (private — pushFiles/deploy를 통해 간접 테스트)
+  // ─────────────────────────────────────────────
+  describe('resolveRepo() (간접 테스트)', () => {
+    it('"/" 포함 projectId → 그대로 사용', async () => {
+      mockGithub.pushCode.mockResolvedValue(undefined);
+      await deployer.pushFiles('some-org/some-repo', []);
+      expect(mockGithub.pushCode).toHaveBeenCalledWith('some-org/some-repo', []);
+    });
+
+    it('"/" 미포함이고 repoMap 없으면 Error', async () => {
+      await expect(deployer.pushFiles('no-slash-id', [])).rejects.toThrow(
+        'Repo not found for project: no-slash-id'
+      );
+    });
+
+    it('createProject 후 반환된 fullName을 repoMap에서 조회한다', async () => {
+      mockGithub.createRepository.mockResolvedValue({
+        repoUrl: 'https://github.com/testorg/svc-bar',
+        fullName: 'testorg/svc-bar',
+      });
+      mockGithub.pushCode.mockResolvedValue(undefined);
+
+      await deployer.createProject('bar');
+      await deployer.pushFiles('bar', []);
+
+      expect(mockGithub.pushCode).toHaveBeenCalledWith('testorg/svc-bar', []);
+    });
+  });
+});

--- a/src/providers/deploy/RailwayDeployer.test.ts
+++ b/src/providers/deploy/RailwayDeployer.test.ts
@@ -1,0 +1,426 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RailwayDeployer } from './RailwayDeployer';
+import * as github from '@/lib/deploy/githubService';
+import * as railway from '@/lib/deploy/railwayService';
+import { DeployError } from '@/lib/utils/errors';
+import type { FileEntry } from './IDeployProvider';
+
+vi.mock('@/lib/deploy/githubService', () => ({
+  createRepository: vi.fn(),
+  pushCode: vi.fn(),
+  setSecrets: vi.fn(),
+}));
+
+vi.mock('@/lib/deploy/railwayService', () => ({
+  createProject: vi.fn(),
+  createServiceFromRepo: vi.fn(),
+  setEnvironmentVariables: vi.fn(),
+  triggerDeploy: vi.fn(),
+  getDeploymentStatus: vi.fn(),
+  getServiceDomain: vi.fn(),
+  deleteProject: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+const mockGithub = vi.mocked(github);
+const mockRailway = vi.mocked(railway);
+
+describe('RailwayDeployer', () => {
+  let deployer: RailwayDeployer;
+
+  beforeEach(() => {
+    deployer = new RailwayDeployer();
+    vi.clearAllMocks();
+  });
+
+  // ─────────────────────────────────────────────
+  // createProject
+  // ─────────────────────────────────────────────
+  describe('createProject()', () => {
+    it("이름 앞에 'svc-'를 붙여 createRepository와 railway.createProject를 호출한다", async () => {
+      mockGithub.createRepository.mockResolvedValue({
+        repoUrl: 'https://github.com/org/svc-my-app',
+        fullName: 'org/svc-my-app',
+      });
+      mockRailway.createProject.mockResolvedValue({ id: 'rail-proj-1', name: 'svc-my-app' });
+
+      const result = await deployer.createProject('my-app');
+
+      expect(mockGithub.createRepository).toHaveBeenCalledWith('svc-my-app');
+      expect(mockRailway.createProject).toHaveBeenCalledWith('svc-my-app');
+      expect(result.projectId).toBe('rail-proj-1');
+      expect(result.repoUrl).toBe('https://github.com/org/svc-my-app');
+    });
+
+    it('railway.createProject가 반환한 id를 projectId로 반환한다', async () => {
+      mockGithub.createRepository.mockResolvedValue({
+        repoUrl: 'https://github.com/org/svc-demo',
+        fullName: 'org/svc-demo',
+      });
+      mockRailway.createProject.mockResolvedValue({ id: 'unique-rail-id', name: 'svc-demo' });
+
+      const result = await deployer.createProject('demo');
+
+      expect(result.projectId).toBe('unique-rail-id');
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // pushFiles
+  // ─────────────────────────────────────────────
+  describe('pushFiles()', () => {
+    const files: FileEntry[] = [{ path: 'index.html', content: '<h1>Hello</h1>' }];
+
+    it('컨텍스트가 없으면 Error를 던진다', async () => {
+      await expect(deployer.pushFiles('unknown-project-id', files)).rejects.toThrow(
+        'Project context not found: unknown-project-id'
+      );
+    });
+
+    it('createProject 후 railwayProjectId로 github.pushCode를 호출한다', async () => {
+      mockGithub.createRepository.mockResolvedValue({
+        repoUrl: 'https://github.com/org/svc-myapp',
+        fullName: 'org/svc-myapp',
+      });
+      mockRailway.createProject.mockResolvedValue({ id: 'rail-id-1', name: 'svc-myapp' });
+      mockGithub.pushCode.mockResolvedValue(undefined);
+
+      await deployer.createProject('myapp');
+      await deployer.pushFiles('rail-id-1', files);
+
+      expect(mockGithub.pushCode).toHaveBeenCalledWith('org/svc-myapp', files);
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // setEnvironment
+  // ─────────────────────────────────────────────
+  describe('setEnvironment()', () => {
+    const setupProject = async (name = 'testapp') => {
+      mockGithub.createRepository.mockResolvedValue({
+        repoUrl: 'https://github.com/org/svc-testapp',
+        fullName: 'org/svc-testapp',
+      });
+      mockRailway.createProject.mockResolvedValue({ id: 'rail-proj-env', name: 'svc-testapp' });
+      await deployer.createProject(name);
+    };
+
+    it('컨텍스트가 없으면 Error를 던진다', async () => {
+      await expect(
+        deployer.setEnvironment('nonexistent', { KEY: 'val' })
+      ).rejects.toThrow('Project context not found: nonexistent');
+    });
+
+    it('serviceId가 없으면 createServiceFromRepo를 호출하고 serviceId를 저장한다', async () => {
+      await setupProject();
+      mockGithub.setSecrets.mockResolvedValue(undefined);
+      mockRailway.createServiceFromRepo.mockResolvedValue('service-id-1');
+      mockRailway.setEnvironmentVariables.mockResolvedValue(undefined);
+
+      await deployer.setEnvironment('rail-proj-env', { KEY: 'value' });
+
+      expect(mockRailway.createServiceFromRepo).toHaveBeenCalledWith(
+        'rail-proj-env',
+        'org/svc-testapp'
+      );
+      expect(mockRailway.setEnvironmentVariables).toHaveBeenCalledWith(
+        'rail-proj-env',
+        'service-id-1',
+        { KEY: 'value' }
+      );
+    });
+
+    it('serviceId가 이미 있으면 createServiceFromRepo를 재호출하지 않는다', async () => {
+      await setupProject();
+      mockGithub.setSecrets.mockResolvedValue(undefined);
+      mockRailway.createServiceFromRepo.mockResolvedValue('service-id-1');
+      mockRailway.setEnvironmentVariables.mockResolvedValue(undefined);
+      mockRailway.triggerDeploy.mockResolvedValue('deployment-id');
+      mockRailway.getDeploymentStatus.mockResolvedValue({ id: 'd-1', status: 'SUCCESS', url: 'https://app.railway.app' });
+
+      // 첫 번째 호출로 serviceId 초기화
+      await deployer.setEnvironment('rail-proj-env', { KEY: 'value' });
+      vi.clearAllMocks();
+      mockGithub.setSecrets.mockResolvedValue(undefined);
+      mockRailway.setEnvironmentVariables.mockResolvedValue(undefined);
+
+      // 두 번째 호출 — createServiceFromRepo 재호출 없어야 함
+      await deployer.setEnvironment('rail-proj-env', { KEY2: 'value2' });
+
+      expect(mockRailway.createServiceFromRepo).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // deploy
+  // ─────────────────────────────────────────────
+  describe('deploy()', () => {
+    const setupProjectWithService = async () => {
+      mockGithub.createRepository.mockResolvedValue({
+        repoUrl: 'https://github.com/org/svc-deploy',
+        fullName: 'org/svc-deploy',
+      });
+      mockRailway.createProject.mockResolvedValue({ id: 'rail-deploy-id', name: 'svc-deploy' });
+      mockRailway.createServiceFromRepo.mockResolvedValue('service-deploy-id');
+      await deployer.createProject('deploy');
+    };
+
+    it('컨텍스트가 없으면 Error를 던진다', async () => {
+      await expect(deployer.deploy('nonexistent-id')).rejects.toThrow(
+        'Project context not found: nonexistent-id'
+      );
+    });
+
+    it('SUCCESS 상태 즉시 반환 → DeployResult를 반환한다', async () => {
+      await setupProjectWithService();
+      mockGithub.setSecrets.mockResolvedValue(undefined);
+      mockRailway.setEnvironmentVariables.mockResolvedValue(undefined);
+      mockRailway.triggerDeploy.mockResolvedValue('depl-id-1');
+      mockRailway.getDeploymentStatus.mockResolvedValue({
+        id: 'depl-id-1',
+        status: 'SUCCESS',
+        url: 'https://my-service.railway.app',
+      });
+
+      const result = await deployer.deploy('rail-deploy-id');
+
+      expect(mockRailway.triggerDeploy).toHaveBeenCalledWith('service-deploy-id');
+      expect(result).toEqual({
+        deploymentId: 'rail-deploy-id',
+        url: 'https://my-service.railway.app',
+        platform: 'railway',
+        status: 'ready',
+      });
+    });
+
+    it('READY 상태도 DeployResult를 반환한다', async () => {
+      await setupProjectWithService();
+      mockRailway.triggerDeploy.mockResolvedValue('depl-id-2');
+      mockRailway.getDeploymentStatus.mockResolvedValue({
+        id: 'depl-id-2',
+        status: 'READY',
+        url: 'https://ready-service.railway.app',
+      });
+
+      const result = await deployer.deploy('rail-deploy-id');
+
+      expect(result.status).toBe('ready');
+      expect(result.url).toBe('https://ready-service.railway.app');
+    });
+
+    it('url이 없으면 getServiceDomain으로 URL을 가져온다', async () => {
+      await setupProjectWithService();
+      mockRailway.triggerDeploy.mockResolvedValue('depl-id-3');
+      mockRailway.getDeploymentStatus.mockResolvedValue({
+        id: 'depl-id-3',
+        status: 'SUCCESS',
+        url: undefined,
+      });
+      mockRailway.getServiceDomain.mockResolvedValue('https://domain-service.railway.app');
+
+      const result = await deployer.deploy('rail-deploy-id');
+
+      expect(mockRailway.getServiceDomain).toHaveBeenCalledWith('service-deploy-id');
+      expect(result.url).toBe('https://domain-service.railway.app');
+    });
+
+    it('FAILED 상태 → DeployError를 던진다', async () => {
+      await setupProjectWithService();
+      mockRailway.triggerDeploy.mockResolvedValue('depl-id-4');
+      mockRailway.getDeploymentStatus.mockResolvedValue({
+        id: 'depl-id-4',
+        status: 'FAILED',
+        url: undefined,
+      });
+
+      await expect(deployer.deploy('rail-deploy-id')).rejects.toThrow(DeployError);
+    });
+
+    it('CRASHED 상태 → DeployError를 던진다', async () => {
+      await setupProjectWithService();
+      mockRailway.triggerDeploy.mockResolvedValue('depl-id-5');
+      mockRailway.getDeploymentStatus.mockResolvedValue({
+        id: 'depl-id-5',
+        status: 'CRASHED',
+        url: undefined,
+      });
+
+      await expect(deployer.deploy('rail-deploy-id')).rejects.toThrow(DeployError);
+    });
+
+    it('serviceId가 없으면 createServiceFromRepo를 호출한다', async () => {
+      // 서비스 ID 없이 새 deployer 인스턴스에서 createProject만 수행
+      mockGithub.createRepository.mockResolvedValue({
+        repoUrl: 'https://github.com/org/svc-noservice',
+        fullName: 'org/svc-noservice',
+      });
+      mockRailway.createProject.mockResolvedValue({ id: 'rail-noservice-id', name: 'svc-noservice' });
+      await deployer.createProject('noservice');
+
+      mockRailway.createServiceFromRepo.mockResolvedValue('new-service-id');
+      mockRailway.triggerDeploy.mockResolvedValue('depl-id-6');
+      mockRailway.getDeploymentStatus.mockResolvedValue({
+        id: 'depl-id-6',
+        status: 'SUCCESS',
+        url: 'https://new.railway.app',
+      });
+
+      await deployer.deploy('rail-noservice-id');
+
+      expect(mockRailway.createServiceFromRepo).toHaveBeenCalledWith(
+        'rail-noservice-id',
+        'org/svc-noservice'
+      );
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // getStatus
+  // ─────────────────────────────────────────────
+  describe('getStatus()', () => {
+    it('SUCCESS → ready 상태를 반환한다', async () => {
+      mockRailway.getDeploymentStatus.mockResolvedValue({
+        id: 'd-1',
+        status: 'SUCCESS',
+        url: 'https://app.railway.app',
+      });
+
+      const result = await deployer.getStatus('proj-1');
+
+      expect(result).toEqual({
+        deploymentId: 'proj-1',
+        url: 'https://app.railway.app',
+        platform: 'railway',
+        status: 'ready',
+      });
+    });
+
+    it('READY → ready 상태를 반환한다', async () => {
+      mockRailway.getDeploymentStatus.mockResolvedValue({ id: 'd-2', status: 'READY', url: 'https://r.app' });
+
+      const result = await deployer.getStatus('proj-2');
+
+      expect(result.status).toBe('ready');
+    });
+
+    it('BUILDING → building 상태를 반환한다', async () => {
+      mockRailway.getDeploymentStatus.mockResolvedValue({ id: 'd-3', status: 'BUILDING', url: undefined });
+
+      const result = await deployer.getStatus('proj-3');
+
+      expect(result.status).toBe('building');
+    });
+
+    it('DEPLOYING → building 상태를 반환한다', async () => {
+      mockRailway.getDeploymentStatus.mockResolvedValue({ id: 'd-4', status: 'DEPLOYING', url: undefined });
+
+      const result = await deployer.getStatus('proj-4');
+
+      expect(result.status).toBe('building');
+    });
+
+    it('FAILED → error 상태를 반환한다', async () => {
+      mockRailway.getDeploymentStatus.mockResolvedValue({ id: 'd-5', status: 'FAILED', url: undefined });
+
+      const result = await deployer.getStatus('proj-5');
+
+      expect(result.status).toBe('error');
+    });
+
+    it('CRASHED → error 상태를 반환한다', async () => {
+      mockRailway.getDeploymentStatus.mockResolvedValue({ id: 'd-6', status: 'CRASHED', url: undefined });
+
+      const result = await deployer.getStatus('proj-6');
+
+      expect(result.status).toBe('error');
+    });
+
+    it('알 수 없는 상태 → pending을 반환한다', async () => {
+      mockRailway.getDeploymentStatus.mockResolvedValue({ id: 'd-7', status: 'UNKNOWN_STATUS', url: undefined });
+
+      const result = await deployer.getStatus('proj-7');
+
+      expect(result.status).toBe('pending');
+    });
+
+    it('null 반환 → url은 빈 문자열, status는 pending', async () => {
+      mockRailway.getDeploymentStatus.mockResolvedValue(null);
+
+      const result = await deployer.getStatus('proj-8');
+
+      expect(result.url).toBe('');
+      expect(result.status).toBe('pending');
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // rollback
+  // ─────────────────────────────────────────────
+  describe('rollback()', () => {
+    it('serviceId가 없으면 Error를 던진다', async () => {
+      await expect(deployer.rollback('nonexistent', 1)).rejects.toThrow(
+        'Service not found for rollback'
+      );
+    });
+
+    it('serviceId가 있으면 triggerDeploy를 호출하고 getStatus 결과를 반환한다', async () => {
+      // 프로젝트 생성 + 서비스 설정
+      mockGithub.createRepository.mockResolvedValue({
+        repoUrl: 'https://github.com/org/svc-rollback',
+        fullName: 'org/svc-rollback',
+      });
+      mockRailway.createProject.mockResolvedValue({ id: 'rail-rollback-id', name: 'svc-rollback' });
+      await deployer.createProject('rollback');
+
+      mockGithub.setSecrets.mockResolvedValue(undefined);
+      mockRailway.createServiceFromRepo.mockResolvedValue('service-rollback-id');
+      mockRailway.setEnvironmentVariables.mockResolvedValue(undefined);
+      await deployer.setEnvironment('rail-rollback-id', {});
+
+      mockRailway.triggerDeploy.mockResolvedValue('depl-rb-1');
+      mockRailway.getDeploymentStatus.mockResolvedValue({
+        id: 'depl-rb-1',
+        status: 'READY',
+        url: 'https://rollback.railway.app',
+      });
+
+      const result = await deployer.rollback('rail-rollback-id', 1);
+
+      expect(mockRailway.triggerDeploy).toHaveBeenCalledWith('service-rollback-id');
+      expect(result.status).toBe('ready');
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // deleteProject
+  // ─────────────────────────────────────────────
+  describe('deleteProject()', () => {
+    it('railway.deleteProject를 호출한다', async () => {
+      mockRailway.deleteProject.mockResolvedValue(undefined);
+
+      await deployer.deleteProject('proj-to-delete');
+
+      expect(mockRailway.deleteProject).toHaveBeenCalledWith('proj-to-delete');
+    });
+
+    it('createProject로 등록된 프로젝트를 삭제한 후 projectMap에서도 제거된다', async () => {
+      mockGithub.createRepository.mockResolvedValue({
+        repoUrl: 'https://github.com/org/svc-delete-me',
+        fullName: 'org/svc-delete-me',
+      });
+      mockRailway.createProject.mockResolvedValue({ id: 'rail-del-id', name: 'svc-delete-me' });
+      await deployer.createProject('delete-me');
+
+      mockRailway.deleteProject.mockResolvedValue(undefined);
+      await deployer.deleteProject('rail-del-id');
+
+      // 삭제 후 pushFiles 시 컨텍스트 없음
+      await expect(
+        deployer.pushFiles('rail-del-id', [])
+      ).rejects.toThrow('Project context not found: rail-del-id');
+    });
+  });
+});

--- a/src/repositories/base/BaseRepository.test.ts
+++ b/src/repositories/base/BaseRepository.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { BaseRepository } from './BaseRepository';
+
+// --- Concrete test subclass ---
+
+interface TestItem {
+  id: string;
+  name: string;
+  createdAt: string;
+}
+
+class TestRepo extends BaseRepository<TestItem> {
+  protected toDomain(row: Record<string, unknown>): TestItem {
+    return {
+      id: row.id as string,
+      name: row.name as string,
+      createdAt: row.created_at as string,
+    };
+  }
+}
+
+// --- Mock helpers ---
+
+/**
+ * Builds a chainable mock that returns `this` for every listed method,
+ * and resolves a given result when the chain is awaited.
+ * The result is exposed on the chain object itself so that
+ * `await chain` (via `.then`) resolves to it.
+ */
+function makeChain(result: Record<string, unknown>) {
+  const chain: Record<string, unknown> = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    range: vi.fn().mockReturnThis(),
+    single: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    upsert: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    // Make the chain itself awaitable by providing a `.then` method
+    then: (resolve: (v: unknown) => void) => Promise.resolve(result).then(resolve),
+  };
+  return chain;
+}
+
+function makeRepoWithChain(result: Record<string, unknown>): {
+  repo: TestRepo;
+  chain: ReturnType<typeof makeChain>;
+  fromMock: ReturnType<typeof vi.fn>;
+} {
+  const chain = makeChain(result);
+  const fromMock = vi.fn().mockReturnValue(chain);
+  const supabase = { from: fromMock } as unknown as SupabaseClient;
+  const repo = new TestRepo(supabase, 'test_table');
+  return { repo, chain, fromMock };
+}
+
+// For single() – needs a separate resolution via single()
+function makeSingleChain(result: Record<string, unknown>) {
+  const chain: Record<string, unknown> = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    range: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    upsert: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(result),
+  };
+  // Also make the chain itself awaitable (for delete / count)
+  Object.assign(chain, {
+    then: (resolve: (v: unknown) => void) => Promise.resolve(result).then(resolve),
+  });
+  return chain;
+}
+
+function makeRepoWithSingleChain(result: Record<string, unknown>): {
+  repo: TestRepo;
+  chain: ReturnType<typeof makeSingleChain>;
+  fromMock: ReturnType<typeof vi.fn>;
+} {
+  const chain = makeSingleChain(result);
+  const fromMock = vi.fn().mockReturnValue(chain);
+  const supabase = { from: fromMock } as unknown as SupabaseClient;
+  const repo = new TestRepo(supabase, 'test_table');
+  return { repo, chain, fromMock };
+}
+
+// ---------------------------------------------------------------------------
+
+describe('BaseRepository', () => {
+  // ---------- findById ----------
+
+  describe('findById()', () => {
+    it('행을 찾으면 도메인 객체를 반환한다', async () => {
+      const dbRow = { id: '1', name: 'Alice', created_at: '2024-01-01' };
+      const { repo, chain, fromMock } = makeRepoWithSingleChain({ data: dbRow, error: null });
+
+      const result = await repo.findById('1');
+
+      expect(fromMock).toHaveBeenCalledWith('test_table');
+      expect(chain.select).toHaveBeenCalledWith('*');
+      expect(chain.eq).toHaveBeenCalledWith('id', '1');
+      expect(chain.single).toHaveBeenCalled();
+      expect(result).toEqual({ id: '1', name: 'Alice', createdAt: '2024-01-01' });
+    });
+
+    it('PGRST116 에러면 null을 반환한다', async () => {
+      const { repo } = makeRepoWithSingleChain({
+        data: null,
+        error: { code: 'PGRST116', message: 'Row not found' },
+      });
+
+      const result = await repo.findById('missing');
+      expect(result).toBeNull();
+    });
+
+    it('PGRST116 이외 에러는 throw한다', async () => {
+      const dbError = { code: '42P01', message: 'Table does not exist' };
+      const { repo } = makeRepoWithSingleChain({ data: null, error: dbError });
+
+      await expect(repo.findById('1')).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- findMany ----------
+
+  describe('findMany()', () => {
+    it('필터 없이 호출하면 올바른 체인을 거쳐 items와 total을 반환한다', async () => {
+      const dbRow = { id: '1', name: 'Alice', created_at: '2024-01-01' };
+      const { repo, chain, fromMock } = makeRepoWithChain({
+        data: [dbRow],
+        error: null,
+        count: 1,
+      });
+
+      const result = await repo.findMany();
+
+      expect(fromMock).toHaveBeenCalledWith('test_table');
+      expect(chain.select).toHaveBeenCalledWith('*', { count: 'exact' });
+      expect(chain.order).toHaveBeenCalledWith('created_at', { ascending: false });
+      expect(chain.range).toHaveBeenCalledWith(0, 19); // page=1, limit=20
+      expect(result).toEqual({
+        items: [{ id: '1', name: 'Alice', createdAt: '2024-01-01' }],
+        total: 1,
+      });
+    });
+
+    it('camelCase 필터 키를 snake_case로 변환해서 .eq()를 호출한다', async () => {
+      const dbRow = { id: '2', name: 'Bob', created_at: '2024-02-01' };
+      const { repo, chain } = makeRepoWithChain({ data: [dbRow], error: null, count: 1 });
+
+      await repo.findMany({ userId: 'u1' });
+
+      expect(chain.eq).toHaveBeenCalledWith('user_id', 'u1');
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: '42P01', message: 'Table not found' };
+      const { repo } = makeRepoWithChain({ data: null, error: dbError, count: null });
+
+      await expect(repo.findMany()).rejects.toEqual(dbError);
+    });
+
+    it('count가 null이면 total: 0을 반환한다', async () => {
+      const { repo } = makeRepoWithChain({ data: [], error: null, count: null });
+      const result = await repo.findMany();
+      expect(result.total).toBe(0);
+    });
+
+    it('undefined/null 필터 값은 .eq() 호출을 건너뛴다', async () => {
+      const { repo, chain } = makeRepoWithChain({ data: [], error: null, count: 0 });
+
+      await repo.findMany({ userId: undefined, name: null });
+
+      // eq should only have been called as part of order/range setup, not with user filters
+      const eqCalls = (chain.eq as ReturnType<typeof vi.fn>).mock.calls;
+      const filterEqCalls = eqCalls.filter(
+        (call) => call[0] === 'user_id' || call[0] === 'name',
+      );
+      expect(filterEqCalls).toHaveLength(0);
+    });
+  });
+
+  // ---------- create ----------
+
+  describe('create()', () => {
+    it('insert().select().single()을 호출하고 도메인 객체를 반환한다', async () => {
+      const dbRow = { id: 'new-id', name: 'Charlie', created_at: '2024-03-01' };
+      const { repo, chain, fromMock } = makeRepoWithSingleChain({ data: dbRow, error: null });
+
+      const result = await repo.create({ name: 'Charlie' } as Omit<
+        TestItem,
+        'id' | 'createdAt' | 'updatedAt'
+      >);
+
+      expect(fromMock).toHaveBeenCalledWith('test_table');
+      expect(chain.insert).toHaveBeenCalled();
+      expect(chain.select).toHaveBeenCalled();
+      expect(chain.single).toHaveBeenCalled();
+      expect(result).toEqual({ id: 'new-id', name: 'Charlie', createdAt: '2024-03-01' });
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: '23505', message: 'duplicate key' };
+      const { repo } = makeRepoWithSingleChain({ data: null, error: dbError });
+
+      await expect(
+        repo.create({ name: 'Alice' } as Omit<TestItem, 'id' | 'createdAt' | 'updatedAt'>),
+      ).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- update ----------
+
+  describe('update()', () => {
+    it('update({...patch, updated_at}).eq(id).select().single()을 호출하고 도메인 객체를 반환한다', async () => {
+      const dbRow = { id: '1', name: 'Updated', created_at: '2024-01-01' };
+      const { repo, chain, fromMock } = makeRepoWithSingleChain({ data: dbRow, error: null });
+
+      const result = await repo.update('1', { name: 'Updated' });
+
+      expect(fromMock).toHaveBeenCalledWith('test_table');
+      expect(chain.update).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Updated', updated_at: expect.any(String) }),
+      );
+      expect(chain.eq).toHaveBeenCalledWith('id', '1');
+      expect(chain.select).toHaveBeenCalled();
+      expect(chain.single).toHaveBeenCalled();
+      expect(result).toEqual({ id: '1', name: 'Updated', createdAt: '2024-01-01' });
+    });
+
+    it('updated_at에 ISO 형식 날짜를 설정한다', async () => {
+      const dbRow = { id: '1', name: 'Updated', created_at: '2024-01-01' };
+      const { repo, chain } = makeRepoWithSingleChain({ data: dbRow, error: null });
+
+      await repo.update('1', { name: 'Updated' });
+
+      const updateArg = (chain.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(updateArg.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: '42P01', message: 'table not found' };
+      const { repo } = makeRepoWithSingleChain({ data: null, error: dbError });
+
+      await expect(repo.update('1', { name: 'X' })).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- delete ----------
+
+  describe('delete()', () => {
+    it('delete().eq(id)를 호출하고 void를 반환한다', async () => {
+      const { repo, chain, fromMock } = makeRepoWithChain({ error: null });
+
+      await repo.delete('1');
+
+      expect(fromMock).toHaveBeenCalledWith('test_table');
+      expect(chain.delete).toHaveBeenCalled();
+      expect(chain.eq).toHaveBeenCalledWith('id', '1');
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: '42P01', message: 'table not found' };
+      const { repo } = makeRepoWithChain({ error: dbError });
+
+      await expect(repo.delete('1')).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- count ----------
+
+  describe('count()', () => {
+    it('select(*,{count:exact,head:true})를 호출하고 count를 반환한다', async () => {
+      const { repo, chain, fromMock } = makeRepoWithChain({ count: 42, error: null });
+
+      const result = await repo.count();
+
+      expect(fromMock).toHaveBeenCalledWith('test_table');
+      expect(chain.select).toHaveBeenCalledWith('*', { count: 'exact', head: true });
+      expect(result).toBe(42);
+    });
+
+    it('count가 null이면 0을 반환한다', async () => {
+      const { repo } = makeRepoWithChain({ count: null, error: null });
+      const result = await repo.count();
+      expect(result).toBe(0);
+    });
+
+    it('필터가 있으면 snake_case로 변환해서 .eq()를 호출한다', async () => {
+      const { repo, chain } = makeRepoWithChain({ count: 3, error: null });
+
+      await repo.count({ userId: 'u1' });
+
+      expect(chain.eq).toHaveBeenCalledWith('user_id', 'u1');
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: '42P01', message: 'table not found' };
+      const { repo } = makeRepoWithChain({ count: null, error: dbError });
+
+      await expect(repo.count()).rejects.toEqual(dbError);
+    });
+  });
+});

--- a/src/repositories/factory.test.ts
+++ b/src/repositories/factory.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+vi.mock('@/lib/config/providers', () => ({ getDbProvider: vi.fn() }));
+vi.mock('@/lib/db/connection', () => ({ getDb: vi.fn().mockReturnValue({}) }));
+vi.mock('@/repositories/projectRepository', () => ({
+  ProjectRepository: vi.fn(function (this: { _type: string }) {
+    this._type = 'supabase-project';
+  }),
+}));
+vi.mock('@/repositories/userRepository', () => ({
+  UserRepository: vi.fn(function (this: { _type: string }) {
+    this._type = 'supabase-user';
+  }),
+}));
+vi.mock('@/repositories/codeRepository', () => ({
+  CodeRepository: vi.fn(function (this: { _type: string }) {
+    this._type = 'supabase-code';
+  }),
+}));
+vi.mock('@/repositories/catalogRepository', () => ({
+  CatalogRepository: vi.fn(function (this: { _type: string }) {
+    this._type = 'supabase-catalog';
+  }),
+}));
+vi.mock('@/repositories/eventRepository', () => ({
+  EventRepository: vi.fn(function (this: { _type: string }) {
+    this._type = 'supabase-event';
+  }),
+}));
+vi.mock('@/repositories/supabaseRateLimitRepository', () => ({
+  SupabaseRateLimitRepository: vi.fn(function (this: { _type: string }) {
+    this._type = 'supabase-ratelimit';
+  }),
+}));
+vi.mock('@/repositories/supabaseUserApiKeyRepository', () => ({
+  SupabaseUserApiKeyRepository: vi.fn(function (this: { _type: string }) {
+    this._type = 'supabase-apikey';
+  }),
+}));
+vi.mock('@/repositories/drizzle', () => ({
+  DrizzleProjectRepository: vi.fn(function (this: { _type: string }) {
+    this._type = 'drizzle-project';
+  }),
+  DrizzleUserRepository: vi.fn(function (this: { _type: string }) {
+    this._type = 'drizzle-user';
+  }),
+  DrizzleCodeRepository: vi.fn(function (this: { _type: string }) {
+    this._type = 'drizzle-code';
+  }),
+  DrizzleCatalogRepository: vi.fn(function (this: { _type: string }) {
+    this._type = 'drizzle-catalog';
+  }),
+  DrizzleEventRepository: vi.fn(function (this: { _type: string }) {
+    this._type = 'drizzle-event';
+  }),
+  DrizzleRateLimitRepository: vi.fn(function (this: { _type: string }) {
+    this._type = 'drizzle-ratelimit';
+  }),
+  DrizzleUserApiKeyRepository: vi.fn(function (this: { _type: string }) {
+    this._type = 'drizzle-apikey';
+  }),
+}));
+
+import { getDbProvider } from '@/lib/config/providers';
+import {
+  createProjectRepository,
+  createUserRepository,
+  createCodeRepository,
+  createCatalogRepository,
+  createEventRepository,
+  createRateLimitRepository,
+  createUserApiKeyRepository,
+} from '@/repositories/factory';
+
+const mockGetDbProvider = getDbProvider as ReturnType<typeof vi.fn>;
+const mockClient = {} as unknown as SupabaseClient;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createProjectRepository', () => {
+  it('returns a Drizzle instance when provider is postgres', () => {
+    mockGetDbProvider.mockReturnValue('postgres');
+    const repo = createProjectRepository() as unknown as { _type: string };
+    expect(repo._type).toContain('drizzle-');
+  });
+
+  it('returns a Supabase instance when provider is supabase with client', () => {
+    mockGetDbProvider.mockReturnValue('supabase');
+    const repo = createProjectRepository(mockClient) as unknown as { _type: string };
+    expect(repo._type).toContain('supabase-');
+  });
+
+  it('throws when provider is supabase and no client is passed', () => {
+    mockGetDbProvider.mockReturnValue('supabase');
+    expect(() => createProjectRepository()).toThrow('Supabase 모드에서는 SupabaseClient가 필요합니다.');
+  });
+});
+
+describe('createUserRepository', () => {
+  it('returns a Drizzle instance when provider is postgres', () => {
+    mockGetDbProvider.mockReturnValue('postgres');
+    const repo = createUserRepository() as unknown as { _type: string };
+    expect(repo._type).toContain('drizzle-');
+  });
+
+  it('returns a Supabase instance when provider is supabase with client', () => {
+    mockGetDbProvider.mockReturnValue('supabase');
+    const repo = createUserRepository(mockClient) as unknown as { _type: string };
+    expect(repo._type).toContain('supabase-');
+  });
+
+  it('throws when provider is supabase and no client is passed', () => {
+    mockGetDbProvider.mockReturnValue('supabase');
+    expect(() => createUserRepository()).toThrow('Supabase 모드에서는 SupabaseClient가 필요합니다.');
+  });
+});
+
+describe('createCodeRepository', () => {
+  it('returns a Drizzle instance when provider is postgres', () => {
+    mockGetDbProvider.mockReturnValue('postgres');
+    const repo = createCodeRepository() as unknown as { _type: string };
+    expect(repo._type).toContain('drizzle-');
+  });
+
+  it('returns a Supabase instance when provider is supabase with client', () => {
+    mockGetDbProvider.mockReturnValue('supabase');
+    const repo = createCodeRepository(mockClient) as unknown as { _type: string };
+    expect(repo._type).toContain('supabase-');
+  });
+
+  it('throws when provider is supabase and no client is passed', () => {
+    mockGetDbProvider.mockReturnValue('supabase');
+    expect(() => createCodeRepository()).toThrow('Supabase 모드에서는 SupabaseClient가 필요합니다.');
+  });
+});
+
+describe('createCatalogRepository', () => {
+  it('returns a Drizzle instance when provider is postgres', () => {
+    mockGetDbProvider.mockReturnValue('postgres');
+    const repo = createCatalogRepository() as unknown as { _type: string };
+    expect(repo._type).toContain('drizzle-');
+  });
+
+  it('returns a Supabase instance when provider is supabase with client', () => {
+    mockGetDbProvider.mockReturnValue('supabase');
+    const repo = createCatalogRepository(mockClient) as unknown as { _type: string };
+    expect(repo._type).toContain('supabase-');
+  });
+
+  it('throws when provider is supabase and no client is passed', () => {
+    mockGetDbProvider.mockReturnValue('supabase');
+    expect(() => createCatalogRepository()).toThrow('Supabase 모드에서는 SupabaseClient가 필요합니다.');
+  });
+});
+
+describe('createEventRepository', () => {
+  it('returns a Drizzle instance when provider is postgres', () => {
+    mockGetDbProvider.mockReturnValue('postgres');
+    const repo = createEventRepository() as unknown as { _type: string };
+    expect(repo._type).toContain('drizzle-');
+  });
+
+  it('returns a Supabase instance when provider is supabase with client', () => {
+    mockGetDbProvider.mockReturnValue('supabase');
+    const repo = createEventRepository(mockClient) as unknown as { _type: string };
+    expect(repo._type).toContain('supabase-');
+  });
+
+  it('throws when provider is supabase and no client is passed', () => {
+    mockGetDbProvider.mockReturnValue('supabase');
+    expect(() => createEventRepository()).toThrow('Supabase 모드에서는 SupabaseClient가 필요합니다.');
+  });
+});
+
+describe('createRateLimitRepository', () => {
+  it('returns a Drizzle instance when provider is postgres', () => {
+    mockGetDbProvider.mockReturnValue('postgres');
+    const repo = createRateLimitRepository() as unknown as { _type: string };
+    expect(repo._type).toContain('drizzle-');
+  });
+
+  it('returns a Supabase instance when provider is supabase with client', () => {
+    mockGetDbProvider.mockReturnValue('supabase');
+    const repo = createRateLimitRepository(mockClient) as unknown as { _type: string };
+    expect(repo._type).toContain('supabase-');
+  });
+
+  it('throws when provider is supabase and no client is passed', () => {
+    mockGetDbProvider.mockReturnValue('supabase');
+    expect(() => createRateLimitRepository()).toThrow('Supabase 모드에서는 SupabaseClient가 필요합니다.');
+  });
+});
+
+describe('createUserApiKeyRepository', () => {
+  it('returns a Drizzle instance when provider is postgres', () => {
+    mockGetDbProvider.mockReturnValue('postgres');
+    const repo = createUserApiKeyRepository() as unknown as { _type: string };
+    expect(repo._type).toContain('drizzle-');
+  });
+
+  it('returns a Supabase instance when provider is supabase with client', () => {
+    mockGetDbProvider.mockReturnValue('supabase');
+    const repo = createUserApiKeyRepository(mockClient) as unknown as { _type: string };
+    expect(repo._type).toContain('supabase-');
+  });
+
+  it('throws when provider is supabase and no client is passed', () => {
+    mockGetDbProvider.mockReturnValue('supabase');
+    expect(() => createUserApiKeyRepository()).toThrow('Supabase 모드에서는 SupabaseClient가 필요합니다.');
+  });
+});

--- a/src/repositories/projectRepository.test.ts
+++ b/src/repositories/projectRepository.test.ts
@@ -1,0 +1,451 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { ProjectRepository } from './projectRepository';
+import type { Project } from '@/types/project';
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+/** Chain that resolves via .order() — used for findByUserId */
+function makeOrderChain(result: { data: unknown[]; error: unknown }) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockResolvedValue(result),
+  };
+}
+
+/** Chain that resolves via .single() — used for findBySlug, updateSlug */
+function makeSingleChain(result: { data: unknown; error: unknown }) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(result),
+  };
+}
+
+/** Chain that resolves via .eq() — used for getProjectApiIds */
+function makeEqChain(result: { data: unknown; error: unknown }) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockResolvedValue(result),
+  };
+}
+
+// Typical DB row for a Project
+const dbRow = {
+  id: 'proj-1',
+  user_id: 'user-1',
+  organization_id: null,
+  name: 'My Project',
+  context: 'ctx',
+  status: 'draft',
+  deploy_url: null,
+  deploy_platform: null,
+  repo_url: null,
+  preview_url: null,
+  metadata: {},
+  current_version: 1,
+  slug: null,
+  suggested_slugs: undefined,
+  published_at: null,
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+};
+
+const expectedProject: Project = {
+  id: 'proj-1',
+  userId: 'user-1',
+  organizationId: null,
+  name: 'My Project',
+  context: 'ctx',
+  status: 'draft',
+  deployUrl: null,
+  deployPlatform: null,
+  repoUrl: null,
+  previewUrl: null,
+  metadata: {},
+  currentVersion: 1,
+  apis: [],
+  slug: null,
+  suggestedSlugs: undefined,
+  publishedAt: null,
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ProjectRepository', () => {
+  // ---------- findByUserId ----------
+
+  describe('findByUserId()', () => {
+    it('select(*).eq(user_id).order(created_at)를 호출하고 Project 배열을 반환한다', async () => {
+      const chain = makeOrderChain({ data: [dbRow], error: null });
+      const supabase = {
+        from: vi.fn().mockReturnValue(chain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      const result = await repo.findByUserId('user-1');
+
+      expect((supabase as unknown as { from: ReturnType<typeof vi.fn> }).from).toHaveBeenCalledWith('projects');
+      expect(chain.select).toHaveBeenCalledWith('*');
+      expect(chain.eq).toHaveBeenCalledWith('user_id', 'user-1');
+      expect(chain.order).toHaveBeenCalledWith('created_at', { ascending: false });
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(expectedProject);
+    });
+
+    it('결과가 없으면 빈 배열을 반환한다', async () => {
+      const chain = makeOrderChain({ data: [], error: null });
+      const supabase = {
+        from: vi.fn().mockReturnValue(chain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      const result = await repo.findByUserId('user-1');
+      expect(result).toEqual([]);
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: '42P01', message: 'table not found' };
+      const chain = makeOrderChain({ data: [], error: dbError });
+      const supabase = {
+        from: vi.fn().mockReturnValue(chain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      await expect(repo.findByUserId('user-1')).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- countTodayGenerations ----------
+
+  describe('countTodayGenerations()', () => {
+    it('rpc("count_today_generations", { p_user_id })를 호출하고 숫자를 반환한다', async () => {
+      const supabase = {
+        from: vi.fn(),
+        rpc: vi.fn().mockResolvedValue({ data: 5, error: null }),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      const result = await repo.countTodayGenerations('u1');
+
+      expect((supabase as unknown as { rpc: ReturnType<typeof vi.fn> }).rpc).toHaveBeenCalledWith(
+        'count_today_generations',
+        { p_user_id: 'u1' },
+      );
+      expect(result).toBe(5);
+    });
+
+    it('data가 null이면 0을 반환한다', async () => {
+      const supabase = {
+        from: vi.fn(),
+        rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      const result = await repo.countTodayGenerations('u1');
+      expect(result).toBe(0);
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: 'PGRST200', message: 'rpc error' };
+      const supabase = {
+        from: vi.fn(),
+        rpc: vi.fn().mockResolvedValue({ data: null, error: dbError }),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      await expect(repo.countTodayGenerations('u1')).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- insertProjectApis ----------
+
+  describe('insertProjectApis()', () => {
+    it('project_apis 테이블에 올바른 매핑 배열로 insert를 호출한다', async () => {
+      const insertMock = vi.fn().mockResolvedValue({ error: null });
+      const projectApisChain = { insert: insertMock };
+      const supabase = {
+        from: vi.fn().mockImplementation((table: string) => {
+          if (table === 'project_apis') return projectApisChain;
+          return {};
+        }),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      await repo.insertProjectApis('proj1', ['api1', 'api2']);
+
+      expect((supabase as unknown as { from: ReturnType<typeof vi.fn> }).from).toHaveBeenCalledWith('project_apis');
+      expect(insertMock).toHaveBeenCalledWith([
+        { project_id: 'proj1', api_id: 'api1' },
+        { project_id: 'proj1', api_id: 'api2' },
+      ]);
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: '23503', message: 'foreign key violation' };
+      const insertMock = vi.fn().mockResolvedValue({ error: dbError });
+      const projectApisChain = { insert: insertMock };
+      const supabase = {
+        from: vi.fn().mockReturnValue(projectApisChain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      await expect(repo.insertProjectApis('proj1', ['api1'])).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- getProjectApiIds ----------
+
+  describe('getProjectApiIds()', () => {
+    it('project_apis 테이블에서 api_id 배열을 반환한다', async () => {
+      const rows = [{ api_id: 'api1' }, { api_id: 'api2' }];
+      const chain = makeEqChain({ data: rows, error: null });
+      const supabase = {
+        from: vi.fn().mockReturnValue(chain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      const result = await repo.getProjectApiIds('proj1');
+
+      expect((supabase as unknown as { from: ReturnType<typeof vi.fn> }).from).toHaveBeenCalledWith('project_apis');
+      expect(chain.select).toHaveBeenCalledWith('api_id');
+      expect(chain.eq).toHaveBeenCalledWith('project_id', 'proj1');
+      expect(result).toEqual(['api1', 'api2']);
+    });
+
+    it('결과가 없으면 빈 배열을 반환한다', async () => {
+      const chain = makeEqChain({ data: null, error: null });
+      const supabase = {
+        from: vi.fn().mockReturnValue(chain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      const result = await repo.getProjectApiIds('proj1');
+      expect(result).toEqual([]);
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: '42P01', message: 'table not found' };
+      const chain = makeEqChain({ data: null, error: dbError });
+      const supabase = {
+        from: vi.fn().mockReturnValue(chain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      await expect(repo.getProjectApiIds('proj1')).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- findBySlug ----------
+
+  describe('findBySlug()', () => {
+    it('select(*).eq(slug).single()을 호출하고 Project를 반환한다', async () => {
+      const slugRow = { ...dbRow, slug: 'my-slug', status: 'published' };
+      const chain = makeSingleChain({ data: slugRow, error: null });
+      const supabase = {
+        from: vi.fn().mockReturnValue(chain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      const result = await repo.findBySlug('my-slug');
+
+      expect((supabase as unknown as { from: ReturnType<typeof vi.fn> }).from).toHaveBeenCalledWith('projects');
+      expect(chain.select).toHaveBeenCalledWith('*');
+      expect(chain.eq).toHaveBeenCalledWith('slug', 'my-slug');
+      expect(chain.single).toHaveBeenCalled();
+      expect(result).not.toBeNull();
+      expect(result?.slug).toBe('my-slug');
+    });
+
+    it('PGRST116 에러면 null을 반환한다', async () => {
+      const chain = makeSingleChain({
+        data: null,
+        error: { code: 'PGRST116', message: 'Row not found' },
+      });
+      const supabase = {
+        from: vi.fn().mockReturnValue(chain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      const result = await repo.findBySlug('nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('data가 null이면 null을 반환한다', async () => {
+      const chain = makeSingleChain({ data: null, error: null });
+      const supabase = {
+        from: vi.fn().mockReturnValue(chain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      const result = await repo.findBySlug('my-slug');
+      expect(result).toBeNull();
+    });
+
+    it('PGRST116 이외 에러는 throw한다', async () => {
+      const dbError = { code: '42P01', message: 'table not found' };
+      const chain = makeSingleChain({ data: null, error: dbError });
+      const supabase = {
+        from: vi.fn().mockReturnValue(chain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      await expect(repo.findBySlug('my-slug')).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- updateSuggestedSlugs ----------
+
+  describe('updateSuggestedSlugs()', () => {
+    it('projects 테이블에 suggested_slugs로 update().eq()를 호출한다', async () => {
+      const eqMock = vi.fn().mockResolvedValue({ error: null });
+      const updateMock = vi.fn().mockReturnValue({ eq: eqMock });
+      const projectsChain = { update: updateMock };
+      const supabase = {
+        from: vi.fn().mockReturnValue(projectsChain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      await repo.updateSuggestedSlugs('proj-1', ['slug-a', 'slug-b']);
+
+      expect((supabase as unknown as { from: ReturnType<typeof vi.fn> }).from).toHaveBeenCalledWith('projects');
+      expect(updateMock).toHaveBeenCalledWith({ suggested_slugs: ['slug-a', 'slug-b'] });
+      expect(eqMock).toHaveBeenCalledWith('id', 'proj-1');
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: '42P01', message: 'table not found' };
+      const eqMock = vi.fn().mockResolvedValue({ error: dbError });
+      const updateMock = vi.fn().mockReturnValue({ eq: eqMock });
+      const projectsChain = { update: updateMock };
+      const supabase = {
+        from: vi.fn().mockReturnValue(projectsChain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      await expect(repo.updateSuggestedSlugs('proj-1', ['slug-a'])).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- updateSlug ----------
+
+  describe('updateSlug()', () => {
+    it('update({ slug, published_at, status:"published", updated_at }).eq(id).select().single()을 호출하고 Project를 반환한다', async () => {
+      const publishedRow = {
+        ...dbRow,
+        slug: 'new-slug',
+        status: 'published',
+        published_at: '2024-06-01T00:00:00.000Z',
+      };
+      const chain = makeSingleChain({ data: publishedRow, error: null });
+      const supabase = {
+        from: vi.fn().mockReturnValue(chain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+      const publishedAt = new Date('2024-06-01T00:00:00.000Z');
+
+      const result = await repo.updateSlug('proj-1', 'new-slug', publishedAt);
+
+      expect((supabase as unknown as { from: ReturnType<typeof vi.fn> }).from).toHaveBeenCalledWith('projects');
+      expect(chain.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          slug: 'new-slug',
+          published_at: publishedAt.toISOString(),
+          status: 'published',
+          updated_at: expect.any(String),
+        }),
+      );
+      expect(chain.eq).toHaveBeenCalledWith('id', 'proj-1');
+      expect(chain.select).toHaveBeenCalled();
+      expect(chain.single).toHaveBeenCalled();
+      expect(result.status).toBe('published');
+      expect(result.slug).toBe('new-slug');
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: '42P01', message: 'table not found' };
+      const chain = makeSingleChain({ data: null, error: dbError });
+      const supabase = {
+        from: vi.fn().mockReturnValue(chain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      await expect(
+        repo.updateSlug('proj-1', 'new-slug', new Date()),
+      ).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- toDomain mapping ----------
+
+  describe('toDomain() mapping', () => {
+    it('모든 nullable 필드의 기본값이 올바르게 매핑된다', async () => {
+      const chain = makeSingleChain({ data: dbRow, error: null });
+      const supabase = {
+        from: vi.fn().mockReturnValue(chain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      const result = await repo.findBySlug('any');
+      expect(result).toEqual(expectedProject);
+      expect(result?.apis).toEqual([]);
+      expect(result?.organizationId).toBeNull();
+      expect(result?.deployUrl).toBeNull();
+      expect(result?.slug).toBeNull();
+      expect(result?.publishedAt).toBeNull();
+    });
+
+    it('currentVersion이 없으면 0으로 기본값이 설정된다', async () => {
+      const rowNoVersion = { ...dbRow, current_version: null };
+      const chain = makeSingleChain({ data: rowNoVersion, error: null });
+      const supabase = {
+        from: vi.fn().mockReturnValue(chain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      const result = await repo.findBySlug('any');
+      expect(result?.currentVersion).toBe(0);
+    });
+
+    it('metadata가 없으면 빈 객체 {}로 기본값이 설정된다', async () => {
+      const rowNoMeta = { ...dbRow, metadata: null };
+      const chain = makeSingleChain({ data: rowNoMeta, error: null });
+      const supabase = {
+        from: vi.fn().mockReturnValue(chain),
+        rpc: vi.fn(),
+      } as unknown as SupabaseClient;
+      const repo = new ProjectRepository(supabase);
+
+      const result = await repo.findBySlug('any');
+      expect(result?.metadata).toEqual({});
+    });
+  });
+});

--- a/src/repositories/supabaseRateLimitRepository.test.ts
+++ b/src/repositories/supabaseRateLimitRepository.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { SupabaseRateLimitRepository } from './supabaseRateLimitRepository';
+
+function makeSupabase() {
+  const rpc = vi.fn();
+  return { supabase: { rpc } as unknown as SupabaseClient, rpc };
+}
+
+describe('SupabaseRateLimitRepository', () => {
+  // ---------- checkAndIncrementDailyLimit ----------
+
+  describe('checkAndIncrementDailyLimit()', () => {
+    it('try_increment_daily_generation RPC를 호출하고 true를 반환한다', async () => {
+      const { supabase, rpc } = makeSupabase();
+      rpc.mockResolvedValueOnce({ data: true, error: null });
+
+      const repo = new SupabaseRateLimitRepository(supabase);
+      const result = await repo.checkAndIncrementDailyLimit('u1', 10);
+
+      expect(rpc).toHaveBeenCalledWith('try_increment_daily_generation', {
+        p_user_id: 'u1',
+        p_limit: 10,
+      });
+      expect(result).toBe(true);
+    });
+
+    it('한도 초과 시 false를 반환한다', async () => {
+      const { supabase, rpc } = makeSupabase();
+      rpc.mockResolvedValueOnce({ data: false, error: null });
+
+      const repo = new SupabaseRateLimitRepository(supabase);
+      const result = await repo.checkAndIncrementDailyLimit('u1', 10);
+
+      expect(result).toBe(false);
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const { supabase, rpc } = makeSupabase();
+      const dbError = { code: 'P0001', message: 'DB error' };
+      rpc.mockResolvedValueOnce({ data: null, error: dbError });
+
+      const repo = new SupabaseRateLimitRepository(supabase);
+      await expect(repo.checkAndIncrementDailyLimit('u1', 10)).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- decrementDailyLimit ----------
+
+  describe('decrementDailyLimit()', () => {
+    it('decrement_daily_generation RPC를 호출하고 void를 반환한다', async () => {
+      const { supabase, rpc } = makeSupabase();
+      rpc.mockResolvedValueOnce({ error: null });
+
+      const repo = new SupabaseRateLimitRepository(supabase);
+      await repo.decrementDailyLimit('u1');
+
+      expect(rpc).toHaveBeenCalledWith('decrement_daily_generation', { p_user_id: 'u1' });
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const { supabase, rpc } = makeSupabase();
+      const dbError = { code: 'P0001', message: 'DB error' };
+      rpc.mockResolvedValueOnce({ error: dbError });
+
+      const repo = new SupabaseRateLimitRepository(supabase);
+      await expect(repo.decrementDailyLimit('u1')).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- getCurrentUsage ----------
+
+  describe('getCurrentUsage()', () => {
+    it('get_daily_generation_count RPC를 호출하고 숫자를 반환한다', async () => {
+      const { supabase, rpc } = makeSupabase();
+      rpc.mockResolvedValueOnce({ data: 5, error: null });
+
+      const repo = new SupabaseRateLimitRepository(supabase);
+      const result = await repo.getCurrentUsage('u1');
+
+      expect(rpc).toHaveBeenCalledWith('get_daily_generation_count', { p_user_id: 'u1' });
+      expect(result).toBe(5);
+    });
+
+    it('data가 null이면 0을 반환한다', async () => {
+      const { supabase, rpc } = makeSupabase();
+      rpc.mockResolvedValueOnce({ data: null, error: null });
+
+      const repo = new SupabaseRateLimitRepository(supabase);
+      const result = await repo.getCurrentUsage('u1');
+
+      expect(result).toBe(0);
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const { supabase, rpc } = makeSupabase();
+      const dbError = { code: 'P0001', message: 'DB error' };
+      rpc.mockResolvedValueOnce({ data: null, error: dbError });
+
+      const repo = new SupabaseRateLimitRepository(supabase);
+      await expect(repo.getCurrentUsage('u1')).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- checkAndIncrementDailyDeployLimit ----------
+
+  describe('checkAndIncrementDailyDeployLimit()', () => {
+    it('try_increment_daily_deploy RPC를 호출하고 true를 반환한다', async () => {
+      const { supabase, rpc } = makeSupabase();
+      rpc.mockResolvedValueOnce({ data: true, error: null });
+
+      const repo = new SupabaseRateLimitRepository(supabase);
+      const result = await repo.checkAndIncrementDailyDeployLimit('u1', 5);
+
+      expect(rpc).toHaveBeenCalledWith('try_increment_daily_deploy', {
+        p_user_id: 'u1',
+        p_limit: 5,
+      });
+      expect(result).toBe(true);
+    });
+
+    it('한도 초과 시 false를 반환한다', async () => {
+      const { supabase, rpc } = makeSupabase();
+      rpc.mockResolvedValueOnce({ data: false, error: null });
+
+      const repo = new SupabaseRateLimitRepository(supabase);
+      const result = await repo.checkAndIncrementDailyDeployLimit('u1', 5);
+
+      expect(result).toBe(false);
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const { supabase, rpc } = makeSupabase();
+      const dbError = { code: 'P0001', message: 'deploy limit error' };
+      rpc.mockResolvedValueOnce({ data: null, error: dbError });
+
+      const repo = new SupabaseRateLimitRepository(supabase);
+      await expect(repo.checkAndIncrementDailyDeployLimit('u1', 5)).rejects.toEqual(dbError);
+    });
+  });
+});

--- a/src/repositories/supabaseUserApiKeyRepository.test.ts
+++ b/src/repositories/supabaseUserApiKeyRepository.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { SupabaseUserApiKeyRepository } from './supabaseUserApiKeyRepository';
+import type { UserApiKey } from './interfaces';
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a fully chainable mock for the normal case where the chain ends with .single().
+ * The chain itself is also awaitable (for delete / updateVerificationStatus).
+ */
+function makeChain(result: Record<string, unknown>) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    upsert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(result),
+    // Make chain itself awaitable so delete/update chains resolve too
+    then: (resolve: (v: unknown) => void) => Promise.resolve(result).then(resolve),
+  };
+  return chain;
+}
+
+function makeSupabase(chain: ReturnType<typeof makeChain>) {
+  return { from: vi.fn().mockReturnValue(chain) } as unknown as SupabaseClient;
+}
+
+/** Convenience: create repo + supabase around a single chain */
+function makeRepo(result: Record<string, unknown>): {
+  repo: SupabaseUserApiKeyRepository;
+  chain: ReturnType<typeof makeChain>;
+  from: ReturnType<typeof vi.fn>;
+} {
+  const chain = makeChain(result);
+  const supabase = makeSupabase(chain);
+  const repo = new SupabaseUserApiKeyRepository(supabase);
+  return { repo, chain, from: (supabase as unknown as { from: ReturnType<typeof vi.fn> }).from };
+}
+
+// Typical DB row that maps to a UserApiKey
+const dbRow = {
+  id: 'key-1',
+  user_id: 'u1',
+  api_id: 'api1',
+  encrypted_key: 'enc-abc',
+  is_verified: true,
+  verified_at: '2024-06-01T00:00:00Z',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-02T00:00:00Z',
+};
+
+const expectedDomain: UserApiKey = {
+  id: 'key-1',
+  userId: 'u1',
+  apiId: 'api1',
+  encryptedKey: 'enc-abc',
+  isVerified: true,
+  verifiedAt: '2024-06-01T00:00:00Z',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-02T00:00:00Z',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SupabaseUserApiKeyRepository', () => {
+  // ---------- upsert ----------
+
+  describe('upsert()', () => {
+    it('upsert().select().single()을 호출하고 UserApiKey를 반환한다', async () => {
+      const { repo, chain, from } = makeRepo({ data: dbRow, error: null });
+
+      const result = await repo.upsert('u1', 'api1', 'enc-abc');
+
+      expect(from).toHaveBeenCalledWith('user_api_keys');
+      expect(chain.upsert).toHaveBeenCalledWith(
+        { user_id: 'u1', api_id: 'api1', encrypted_key: 'enc-abc' },
+        { onConflict: 'user_id,api_id' },
+      );
+      expect(chain.select).toHaveBeenCalled();
+      expect(chain.single).toHaveBeenCalled();
+      expect(result).toEqual(expectedDomain);
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: '23505', message: 'duplicate key' };
+      const { repo } = makeRepo({ data: null, error: dbError });
+
+      await expect(repo.upsert('u1', 'api1', 'enc-abc')).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- delete ----------
+
+  describe('delete()', () => {
+    it('delete().eq(user_id).eq(api_id)를 호출한다', async () => {
+      const { repo, chain, from } = makeRepo({ error: null });
+
+      await repo.delete('u1', 'api1');
+
+      expect(from).toHaveBeenCalledWith('user_api_keys');
+      expect(chain.delete).toHaveBeenCalled();
+      expect(chain.eq).toHaveBeenCalledWith('user_id', 'u1');
+      expect(chain.eq).toHaveBeenCalledWith('api_id', 'api1');
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: '42P01', message: 'table not found' };
+      const { repo } = makeRepo({ error: dbError });
+
+      await expect(repo.delete('u1', 'api1')).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- findByUserAndApi ----------
+
+  describe('findByUserAndApi()', () => {
+    it('select().eq().eq().single()을 호출하고 UserApiKey를 반환한다', async () => {
+      const { repo, chain, from } = makeRepo({ data: dbRow, error: null });
+
+      const result = await repo.findByUserAndApi('u1', 'api1');
+
+      expect(from).toHaveBeenCalledWith('user_api_keys');
+      expect(chain.select).toHaveBeenCalledWith('*');
+      expect(chain.eq).toHaveBeenCalledWith('user_id', 'u1');
+      expect(chain.eq).toHaveBeenCalledWith('api_id', 'api1');
+      expect(chain.single).toHaveBeenCalled();
+      expect(result).toEqual(expectedDomain);
+    });
+
+    it('PGRST116 에러면 null을 반환한다', async () => {
+      const { repo } = makeRepo({
+        data: null,
+        error: { code: 'PGRST116', message: 'Row not found' },
+      });
+
+      const result = await repo.findByUserAndApi('u1', 'api1');
+      expect(result).toBeNull();
+    });
+
+    it('PGRST116 이외 에러는 throw한다', async () => {
+      const dbError = { code: '42P01', message: 'table error' };
+      const { repo } = makeRepo({ data: null, error: dbError });
+
+      await expect(repo.findByUserAndApi('u1', 'api1')).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- findAllByUser ----------
+
+  describe('findAllByUser()', () => {
+    it('select().eq()를 호출하고 UserApiKey 배열을 반환한다', async () => {
+      const row2 = {
+        ...dbRow,
+        id: 'key-2',
+        api_id: 'api2',
+        is_verified: false,
+        verified_at: null,
+      };
+      // For findAllByUser the last call is .eq() which resolves directly (no .single())
+      const arrayChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ data: [dbRow, row2], error: null }),
+      };
+      const supabase = {
+        from: vi.fn().mockReturnValue(arrayChain),
+      } as unknown as SupabaseClient;
+      const repo = new SupabaseUserApiKeyRepository(supabase);
+
+      const result = await repo.findAllByUser('u1');
+
+      expect(arrayChain.select).toHaveBeenCalledWith('*');
+      expect(arrayChain.eq).toHaveBeenCalledWith('user_id', 'u1');
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual(expectedDomain);
+      expect(result[1].id).toBe('key-2');
+      expect(result[1].isVerified).toBe(false);
+      expect(result[1].verifiedAt).toBeNull();
+    });
+
+    it('결과가 없으면 빈 배열을 반환한다', async () => {
+      const arrayChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+      const supabase = { from: vi.fn().mockReturnValue(arrayChain) } as unknown as SupabaseClient;
+      const repo = new SupabaseUserApiKeyRepository(supabase);
+
+      const result = await repo.findAllByUser('u1');
+      expect(result).toEqual([]);
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: '42P01', message: 'table not found' };
+      const arrayChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ data: null, error: dbError }),
+      };
+      const supabase = { from: vi.fn().mockReturnValue(arrayChain) } as unknown as SupabaseClient;
+      const repo = new SupabaseUserApiKeyRepository(supabase);
+
+      await expect(repo.findAllByUser('u1')).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- updateVerificationStatus ----------
+
+  describe('updateVerificationStatus()', () => {
+    it('isVerified=true → is_verified:true, verified_at: non-null ISO string', async () => {
+      const { repo, chain, from } = makeRepo({ error: null });
+
+      await repo.updateVerificationStatus('u1', 'api1', true);
+
+      expect(from).toHaveBeenCalledWith('user_api_keys');
+      const updateArg = (chain.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(updateArg.is_verified).toBe(true);
+      expect(updateArg.verified_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(chain.eq).toHaveBeenCalledWith('user_id', 'u1');
+      expect(chain.eq).toHaveBeenCalledWith('api_id', 'api1');
+    });
+
+    it('isVerified=false → is_verified:false, verified_at: null', async () => {
+      const { repo, chain } = makeRepo({ error: null });
+
+      await repo.updateVerificationStatus('u1', 'api1', false);
+
+      const updateArg = (chain.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(updateArg.is_verified).toBe(false);
+      expect(updateArg.verified_at).toBeNull();
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: '42P01', message: 'table not found' };
+      const { repo } = makeRepo({ error: dbError });
+
+      await expect(repo.updateVerificationStatus('u1', 'api1', true)).rejects.toEqual(dbError);
+    });
+  });
+});

--- a/src/repositories/userRepository.test.ts
+++ b/src/repositories/userRepository.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { UserRepository } from './userRepository';
+import type { User } from '@/types/user';
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+function makeSingleChain(result: { data: unknown; error: unknown }) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(result),
+  };
+}
+
+function makeSupabase(chain: ReturnType<typeof makeSingleChain>) {
+  return { from: vi.fn().mockReturnValue(chain), rpc: vi.fn() } as unknown as SupabaseClient;
+}
+
+// Typical DB row
+const dbRow = {
+  id: 'user-1',
+  email: 'test@test.com',
+  name: 'Test',
+  avatar_url: null,
+  preferences: {},
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+};
+
+const expectedUser: User = {
+  id: 'user-1',
+  email: 'test@test.com',
+  name: 'Test',
+  avatarUrl: null,
+  preferences: {},
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('UserRepository', () => {
+  // ---------- createWithAuthId ----------
+
+  describe('createWithAuthId()', () => {
+    it('insert({ ...dbData, id: authId }).select().single()을 호출하고 User를 반환한다', async () => {
+      const chain = makeSingleChain({ data: dbRow, error: null });
+      const supabase = makeSupabase(chain);
+      const repo = new UserRepository(supabase);
+
+      const input = {
+        email: 'test@test.com',
+        name: 'Test',
+        avatarUrl: null,
+        preferences: {},
+      };
+      const result = await repo.createWithAuthId('auth-123', input);
+
+      expect((supabase as unknown as { from: ReturnType<typeof vi.fn> }).from).toHaveBeenCalledWith('users');
+      expect(chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'auth-123', email: 'test@test.com' }),
+      );
+      expect(chain.select).toHaveBeenCalled();
+      expect(chain.single).toHaveBeenCalled();
+      expect(result).toEqual(expectedUser);
+    });
+
+    it('에러 발생 시 throw한다', async () => {
+      const dbError = { code: '23505', message: 'duplicate key' };
+      const chain = makeSingleChain({ data: null, error: dbError });
+      const supabase = makeSupabase(chain);
+      const repo = new UserRepository(supabase);
+
+      await expect(
+        repo.createWithAuthId('auth-123', {
+          email: 'test@test.com',
+          name: 'Test',
+          avatarUrl: null,
+          preferences: {},
+        }),
+      ).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- findByEmail ----------
+
+  describe('findByEmail()', () => {
+    it('select(*).eq(email).single()을 호출하고 User를 반환한다', async () => {
+      const chain = makeSingleChain({ data: dbRow, error: null });
+      const supabase = makeSupabase(chain);
+      const repo = new UserRepository(supabase);
+
+      const result = await repo.findByEmail('test@test.com');
+
+      expect((supabase as unknown as { from: ReturnType<typeof vi.fn> }).from).toHaveBeenCalledWith('users');
+      expect(chain.select).toHaveBeenCalledWith('*');
+      expect(chain.eq).toHaveBeenCalledWith('email', 'test@test.com');
+      expect(chain.single).toHaveBeenCalled();
+      expect(result).toEqual(expectedUser);
+      expect(result?.email).toBe('test@test.com');
+    });
+
+    it('PGRST116 에러면 null을 반환한다', async () => {
+      const chain = makeSingleChain({
+        data: null,
+        error: { code: 'PGRST116', message: 'Row not found' },
+      });
+      const supabase = makeSupabase(chain);
+      const repo = new UserRepository(supabase);
+
+      const result = await repo.findByEmail('notfound@test.com');
+      expect(result).toBeNull();
+    });
+
+    it('PGRST116 이외 에러는 throw한다', async () => {
+      const dbError = { code: '42P01', message: 'Table does not exist' };
+      const chain = makeSingleChain({ data: null, error: dbError });
+      const supabase = makeSupabase(chain);
+      const repo = new UserRepository(supabase);
+
+      await expect(repo.findByEmail('test@test.com')).rejects.toEqual(dbError);
+    });
+  });
+
+  // ---------- toDomain mapping ----------
+
+  describe('toDomain() mapping', () => {
+    it('null name은 null로 매핑된다', async () => {
+      const rowWithNullName = { ...dbRow, name: null };
+      const chain = makeSingleChain({ data: rowWithNullName, error: null });
+      const supabase = makeSupabase(chain);
+      const repo = new UserRepository(supabase);
+
+      const result = await repo.findByEmail('test@test.com');
+      expect(result?.name).toBeNull();
+    });
+
+    it('null avatar_url은 avatarUrl: null로 매핑된다', async () => {
+      const rowWithNullAvatar = { ...dbRow, avatar_url: null };
+      const chain = makeSingleChain({ data: rowWithNullAvatar, error: null });
+      const supabase = makeSupabase(chain);
+      const repo = new UserRepository(supabase);
+
+      const result = await repo.findByEmail('test@test.com');
+      expect(result?.avatarUrl).toBeNull();
+    });
+
+    it('preferences가 없으면 빈 객체 {}로 기본값이 설정된다', async () => {
+      const rowWithNullPrefs = { ...dbRow, preferences: null };
+      const chain = makeSingleChain({ data: rowWithNullPrefs, error: null });
+      const supabase = makeSupabase(chain);
+      const repo = new UserRepository(supabase);
+
+      const result = await repo.findByEmail('test@test.com');
+      expect(result?.preferences).toEqual({});
+    });
+
+    it('모든 필드가 올바르게 camelCase로 매핑된다', async () => {
+      const fullRow = {
+        id: 'u-99',
+        email: 'full@test.com',
+        name: 'Full User',
+        avatar_url: 'https://example.com/avatar.png',
+        preferences: { language: 'ko', theme: 'dark' },
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-06-01T00:00:00Z',
+      };
+      const chain = makeSingleChain({ data: fullRow, error: null });
+      const supabase = makeSupabase(chain);
+      const repo = new UserRepository(supabase);
+
+      const result = await repo.findByEmail('full@test.com');
+      expect(result).toEqual({
+        id: 'u-99',
+        email: 'full@test.com',
+        name: 'Full User',
+        avatarUrl: 'https://example.com/avatar.png',
+        preferences: { language: 'ko', theme: 'dark' },
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-06-01T00:00:00Z',
+      });
+    });
+  });
+});

--- a/src/repositories/utils/conditionBuilder.test.ts
+++ b/src/repositories/utils/conditionBuilder.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { buildConditions } from './conditionBuilder';
+
+describe('buildConditions', () => {
+  it('returns undefined when no filter is provided', () => {
+    expect(buildConditions(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty filter object', () => {
+    expect(buildConditions({})).toBeUndefined();
+  });
+
+  it('returns undefined when all values are undefined or null', () => {
+    expect(buildConditions({ userId: undefined, name: null })).toBeUndefined();
+  });
+
+  it('returns a truthy value for a single-field filter', () => {
+    expect(buildConditions({ userId: 'abc' })).toBeTruthy();
+  });
+
+  it('returns a truthy value for a multi-field filter', () => {
+    expect(buildConditions({ userId: 'abc', name: 'test' })).toBeTruthy();
+  });
+});

--- a/src/services/factory.test.ts
+++ b/src/services/factory.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+vi.mock('@/repositories/factory', () => ({
+  createProjectRepository: vi.fn().mockReturnValue({ _type: 'project-repo' }),
+  createCatalogRepository: vi.fn().mockReturnValue({ _type: 'catalog-repo' }),
+  createCodeRepository: vi.fn().mockReturnValue({ _type: 'code-repo' }),
+  createRateLimitRepository: vi.fn().mockReturnValue({ _type: 'ratelimit-repo' }),
+}));
+vi.mock('@/services/projectService', () => ({
+  ProjectService: vi.fn(function (this: { _type: string }) {
+    this._type = 'ProjectService';
+  }),
+}));
+vi.mock('@/services/catalogService', () => ({
+  CatalogService: vi.fn(function (this: { _type: string }) {
+    this._type = 'CatalogService';
+  }),
+}));
+vi.mock('@/services/deployService', () => ({
+  DeployService: vi.fn(function (this: { _type: string }) {
+    this._type = 'DeployService';
+  }),
+}));
+vi.mock('@/services/rateLimitService', () => ({
+  RateLimitService: vi.fn(function (this: { _type: string }) {
+    this._type = 'RateLimitService';
+  }),
+}));
+
+import {
+  createProjectService,
+  createCatalogService,
+  createDeployService,
+  createRateLimitService,
+} from '@/services/factory';
+import {
+  createProjectRepository,
+  createCatalogRepository,
+  createCodeRepository,
+  createRateLimitRepository,
+} from '@/repositories/factory';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createProjectService', () => {
+  it('returns a ProjectService instance', () => {
+    const svc = createProjectService() as unknown as { _type: string };
+    expect(svc._type).toBe('ProjectService');
+  });
+
+  it('passes the supabase client to repository factory calls', () => {
+    const mockClient = {} as unknown as SupabaseClient;
+    createProjectService(mockClient);
+    expect(createProjectRepository).toHaveBeenCalledWith(mockClient);
+    expect(createCatalogRepository).toHaveBeenCalledWith(mockClient);
+  });
+});
+
+describe('createCatalogService', () => {
+  it('returns a CatalogService instance', () => {
+    const svc = createCatalogService() as unknown as { _type: string };
+    expect(svc._type).toBe('CatalogService');
+  });
+
+  it('passes the supabase client to createCatalogRepository', () => {
+    const mockClient = {} as unknown as SupabaseClient;
+    createCatalogService(mockClient);
+    expect(createCatalogRepository).toHaveBeenCalledWith(mockClient);
+  });
+});
+
+describe('createDeployService', () => {
+  it('returns a DeployService instance', () => {
+    const svc = createDeployService() as unknown as { _type: string };
+    expect(svc._type).toBe('DeployService');
+  });
+
+  it('passes the supabase client to repository factory calls', () => {
+    const mockClient = {} as unknown as SupabaseClient;
+    createDeployService(mockClient);
+    expect(createProjectRepository).toHaveBeenCalledWith(mockClient);
+    expect(createCodeRepository).toHaveBeenCalledWith(mockClient);
+  });
+});
+
+describe('createRateLimitService', () => {
+  it('returns a RateLimitService instance', () => {
+    const svc = createRateLimitService() as unknown as { _type: string };
+    expect(svc._type).toBe('RateLimitService');
+  });
+
+  it('passes the supabase client to createRateLimitRepository', () => {
+    const mockClient = {} as unknown as SupabaseClient;
+    createRateLimitService(mockClient);
+    expect(createRateLimitRepository).toHaveBeenCalledWith(mockClient);
+  });
+});


### PR DESCRIPTION
## Summary

PR #45 머지 이후 누락된 커버리지 개선 커밋 2개를 포함합니다.

**2차 개선 (+237 테스트, 16파일):**
- DrizzleCatalog/User/UserApiKey/Event/RateLimitRepository 테스트
- eventBus, adminAuth, failover, slugify, publishUrl, htmlTitle 유틸 테스트
- DeployProviderFactory, GithubPagesDeployer, RailwayDeployer 테스트
- stageRunner, generationSaver AI 파이프라인 테스트

**3차 개선 (+222 테스트, 16파일):**
- generationPipeline.evaluateComplexityScore 테스트 (23개)
- githubService, railwayService fetch 기반 API 클라이언트 테스트 (46개)
- BaseRepository, ProjectRepository, UserRepository, SupabaseRateLimitRepository 등 (74개)
- repositories/factory, services/factory 팩토리 함수 테스트 (29개)
- siteError, db/errors, conditionBuilder, popularServices, apiKeyGuides 유틸 테스트 (50개)

## Test plan

- [ ] CI 전체 테스트 통과 (1078개 테스트)
- [ ] Codecov 커버리지 상승 확인 (로컬 기준 59.52% → 71.77%)
- [ ] SonarCloud 커버리지 개선 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)