### PR TITLE
fix: 회고 반영 + 프로덕션 버그 수정 (suggest-context rate limit, temperature deprecated)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ pnpm test:coverage    # 커버리지 리포트
 | 3단계 생성 파이프라인 설계 | [docs/superpowers/specs/2026-04-14-two-stage-generation-design.md](docs/superpowers/specs/2026-04-14-two-stage-generation-design.md) |
 | Repository 유틸리티 추출 ADR | [docs/decisions/2026-04-26-repository-utils-extraction.md](docs/decisions/2026-04-26-repository-utils-extraction.md) |
 | CI ESLint 마이그레이션 ADR | [docs/decisions/2026-04-26-ci-eslint-migration.md](docs/decisions/2026-04-26-ci-eslint-migration.md) |
+| 커버리지 개선 회고 (PR #45·#46) | [docs/decisions/2026-04-26-coverage-improvement-retrospective.md](docs/decisions/2026-04-26-coverage-improvement-retrospective.md) |
 
 - [README.md](README.md) — 프로젝트 전체 개요
 - [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) — PR 템플릿

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,7 @@ pnpm test:coverage    # 커버리지 리포트
 - **브랜치 네이밍**: `feat/`, `fix/`, `refactor/`, `chore/`, `docs/` 접두사 사용
 - **"커밋 푸쉬 병합"** = feature 브랜치 커밋 → push → PR 생성 → main 병합
 - 대규모 변경 시 Phase 단위로 나누어 각 Phase를 하나의 커밋으로 묶는 것을 선호
+- **PR 병합 타이밍**: 여러 커밋이 예정된 작업은 모든 커밋이 완료된 후에 병합한다. 중간에 병합하면 cherry-pick 등 복구 작업이 필요해짐
 
 ## 커밋 메시지 규칙
 
@@ -189,6 +190,8 @@ pnpm test:coverage    # 커버리지 리포트
 - **Playwright 병렬 체크 주의**: 단일 `page` 인스턴스에서 `Promise.allSettled` 사용 시 viewport를 변경하는 체크는 반드시 다른 체크 완료 후 순차 실행 (`renderingQc.ts` 참고)
 - **slug 충돌 처리**: `assignUniqueSlug()` in `projectService.ts` — base → base-2 → … → base-10 → timestamp fallback; 23505 unique 위반 시 1회 재시도
 - **generationTracker 단일 인스턴스**: `src/lib/ai/generationTracker.ts`의 `generationTracker`는 모듈 레벨 싱글톤. TTL 차등: `generating` 30분, `completed`/`failed` 10분. Railway 단일 인스턴스 환경에서만 동작 — 멀티 인스턴스 배포 시 Redis 등 외부 저장소로 교체 필요
+- **모듈 레벨 상태가 있는 파일 테스트**: `let registered = false` 같은 모듈 레벨 플래그가 있는 파일은 테스트 간 상태 누출이 발생한다. `vi.resetModules()` + 매 테스트마다 `await import(...)` 동적 임포트로 격리한다 (`eventPersister.ts` 참고)
+- **SonarCloud vs Codecov 지표 불일치**: Codecov는 `vitest.config.ts`의 `coverage.include` 범위(lib/services/providers/repositories, ~10,601 lines)만 측정. SonarCloud는 전체 TypeScript(~21,980 lines) 측정. 두 숫자는 구조적으로 차이가 날 수밖에 없으며, 이는 설정 문제가 아님
 - **ExtendedThinking + temperature**: `extendedThinking: true` 설정 시 `temperature`는 반드시 `1` (Anthropic API 강제 요구사항). ClaudeProvider 내부에서 자동 처리됨
 - **인메모리 rate limit 한계**: proxy의 Map 기반 리밋은 서버 재시작 시 초기화됨 (분당 카운터라 보안 영향 낮음). Railway 단일 인스턴스 전제 — 멀티 인스턴스 전환 시 Redis 등 외부 저장소 필요 (generationTracker와 동일 제약)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ pnpm test:coverage    # 커버리지 리포트
 - **generationTracker 단일 인스턴스**: `src/lib/ai/generationTracker.ts`의 `generationTracker`는 모듈 레벨 싱글톤. TTL 차등: `generating` 30분, `completed`/`failed` 10분. Railway 단일 인스턴스 환경에서만 동작 — 멀티 인스턴스 배포 시 Redis 등 외부 저장소로 교체 필요
 - **모듈 레벨 상태가 있는 파일 테스트**: `let registered = false` 같은 모듈 레벨 플래그가 있는 파일은 테스트 간 상태 누출이 발생한다. `vi.resetModules()` + 매 테스트마다 `await import(...)` 동적 임포트로 격리한다 (`eventPersister.ts` 참고)
 - **SonarCloud vs Codecov 지표 불일치**: Codecov는 `vitest.config.ts`의 `coverage.include` 범위(lib/services/providers/repositories, ~10,601 lines)만 측정. SonarCloud는 전체 TypeScript(~21,980 lines) 측정. 두 숫자는 구조적으로 차이가 날 수밖에 없으며, 이는 설정 문제가 아님
-- **ExtendedThinking + temperature**: `extendedThinking: true` 설정 시 `temperature`는 반드시 `1` (Anthropic API 강제 요구사항). ClaudeProvider 내부에서 자동 처리됨
+- **temperature deprecated (Claude 4.x)**: Claude 4.x 모델(`claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-opus-4-7`)은 `temperature` 파라미터를 지원하지 않음. ClaudeProvider에서 완전히 제거됨 (Extended Thinking 포함). `IAiPrompt.temperature` 필드는 legacy 호환용으로 유지하나 실제 API 호출에 사용하지 않음
 - **인메모리 rate limit 한계**: proxy의 Map 기반 리밋은 서버 재시작 시 초기화됨 (분당 카운터라 보안 영향 낮음). Railway 단일 인스턴스 전제 — 멀티 인스턴스 전환 시 Redis 등 외부 저장소 필요 (generationTracker와 동일 제약)
 
 ## Claude 도움 요청 원칙

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![status](https://img.shields.io/badge/status-v1.0.0%20Live-brightgreen?style=flat-square)](https://xzawed.xyz)
 [![Next.js](https://img.shields.io/badge/Next.js-16+-black?style=flat-square&logo=next.js)](https://nextjs.org)
 [![AI](https://img.shields.io/badge/AI-Claude%20Opus%204.7-blueviolet?style=flat-square)](https://anthropic.com)
-[![Tests](https://img.shields.io/badge/Tests-581%20passed-success?style=flat-square)](./docs/guides/testing.md)
+[![Tests](https://img.shields.io/badge/Tests-1078%20passed-success?style=flat-square)](./docs/guides/testing.md)
+[![Coverage](https://img.shields.io/badge/Coverage-71%25-yellow?style=flat-square)](./docs/guides/testing.md)
 [![Deploy](https://img.shields.io/badge/Deploy-Railway-8A2BE2?style=flat-square&logo=railway)](https://railway.app)
 
 **🌐 서비스 URL**: [xzawed.xyz](https://xzawed.xyz) &nbsp;|&nbsp; 🇺🇸 [English](./README.en.md)
@@ -137,11 +138,11 @@ src/
 
 | 항목 | 내용 |
 |------|------|
-| ✅ 총 테스트 수 | **581개** (단위 · 통합 · 컴포넌트 · E2E) |
-| 🔬 단위 테스트 | Vitest + happy-dom — AI 파이프라인, 보안 검증, 레이트리밋, Circuit Breaker 등 |
+| ✅ 총 테스트 수 | **1,078개** (단위 · 통합 · 컴포넌트 · E2E) |
+| 🔬 단위 테스트 | Vitest + happy-dom — AI 파이프라인, 보안 검증, 레이트리밋, Circuit Breaker, 배포 서비스 등 |
 | 🔗 통합 테스트 | Vitest + MSW — API 라우트 인증·입력·권한·비즈니스 로직 전 경로 |
 | 🌐 E2E 테스트 | Playwright — 3종 디바이스 (모바일 · 태블릿 · 데스크톱) |
-| 📊 커버리지 임계값 | branches 50% · functions/lines/statements 60% |
+| 📊 커버리지 | **71% lines** (lib/services/providers/repositories 대상) · Codecov + SonarCloud 연동 |
 
 ```bash
 pnpm test              # 전체 테스트

--- a/docs/decisions/2026-04-26-coverage-improvement-retrospective.md
+++ b/docs/decisions/2026-04-26-coverage-improvement-retrospective.md
@@ -1,0 +1,116 @@
+# 커버리지 개선 회고 (2026-04-26)
+
+> PR #45 + PR #46 — 테스트 커버리지 대규모 개선 작업 전체 회고
+
+## 최종 성과
+
+| 항목 | 이전 | 이후 | 변화 |
+|------|------|------|------|
+| 테스트 수 | 856개 | 1,078개 | +222개 |
+| 로컬 커버리지 (lines) | 59.52% | 71.77% | +12.25pp |
+| Codecov | ~49% (CI 기준) | 71%+ (예상) | +22pp |
+| SonarCloud | 32.6% | 대폭 상승 예상 | — |
+| 신규 테스트 파일 | — | 32개 | — |
+
+---
+
+## 문제의 시작 — "개선이 미미하다"
+
+첫 라운드에서 237개 테스트를 추가했음에도 Codecov가 49.16%에서 거의 움직이지 않았다. 처음에는 테스트 전략이 잘못된 것으로 의심했지만, 조사 결과 원인은 두 가지였다.
+
+### 1. CI 타이밍 문제
+Codecov에 업로드된 커버리지 데이터는 **CI가 실행된 시점**의 커밋 기반이다. PR #45 첫 커밋이 병합되기 전에 Codecov를 확인했기 때문에, 실제로는 로컬에서 이미 59.52%까지 올라가 있었는데 Codecov 대시보드는 이전 CI 결과를 보여주고 있었다.
+
+### 2. SonarCloud vs Codecov 지표 불일치
+더 근본적인 혼동 원인은 두 도구의 측정 범위 차이였다.
+
+| 도구 | 측정 범위 | 분모 |
+|------|-----------|------|
+| Codecov (vitest) | `src/lib/**`, `src/services/**`, `src/providers/**`, `src/repositories/**` | ~10,601 lines |
+| SonarCloud | 프로젝트 내 모든 TypeScript 파일 | ~21,980 lines |
+
+`vitest.config.ts`의 `coverage.include` 설정이 4개 디렉터리만 추적하도록 되어 있어서, SonarCloud는 테스트가 전혀 없는 `components/`, `app/`, `hooks/`, `stores/` (~11,379 lines)를 분모에 포함하기 때문에 항상 낮게 나온다. Codecov가 71%여도 SonarCloud는 구조적으로 40% 이하로 나올 수밖에 없다.
+
+**교훈**: 여러 커버리지 도구를 함께 사용할 때 각 도구의 측정 범위를 먼저 확인해야 한다. 숫자만 비교하면 잘못된 결론을 내린다.
+
+---
+
+## 무엇이 효과적이었나
+
+### 0% 파일 타겟팅 전략
+가장 효과적인 접근은 "이미 70%인 파일을 75%로 올리기"보다 "0%인 파일에 기본 커버리지 추가"였다. tracked scope 내 0% 파일 목록을 먼저 뽑고, 파일당 테스트를 집중 추가하는 방식이 커버리지 숫자를 빠르게 올렸다.
+
+### Mock-heavy 테스트도 소스 커버리지에 기여한다
+처음에는 "DB나 fetch를 mock하면 실제 코드가 실행되지 않는다"고 오해했다. 하지만 V8 커버리지는 **소스 라인이 실행되었는지**를 측정하고, mock된 의존성을 호출하는 코드(service/repository 메서드 본문)는 실제로 실행된다. `supabase.from().select().eq()` 체인을 mock해도 그 체인을 조립하는 repository 코드는 실행된다.
+
+### Supabase 체이닝 mock 패턴 표준화
+```ts
+const chain = {
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  single: vi.fn().mockResolvedValue({ data: item, error: null }),
+};
+supabase.from = vi.fn().mockReturnValue(chain);
+```
+이 패턴 하나로 대부분의 Supabase repository를 테스트할 수 있었다. 패턴이 확립된 뒤에는 새 테스트 파일 작성이 단순 반복 작업이 되었다.
+
+### global fetch mock 패턴
+`githubService.ts`, `railwayService.ts` 같은 외부 HTTP 호출 파일은 `vi.stubGlobal('fetch', mockFetch)` 패턴으로 일관되게 처리했다. Node.js `http` 모듈이 아닌 Web Fetch API를 쓰는 파일에서 신뢰성이 높았다.
+
+### 병렬 에이전트 디스패치
+한 세션에서 여러 에이전트를 병렬로 실행하여 독립적인 파일들을 동시에 작성했다. 파일 간 의존성이 없는 테스트 파일 추가 작업에서 속도 이점이 컸다.
+
+---
+
+## 무엇이 어려웠나
+
+### 모듈 레벨 상태 격리 (`eventPersister.ts`)
+`let registered = false` 같은 모듈 레벨 플래그가 있는 파일은 테스트 간 상태가 누출된다. 해결책은 `vi.resetModules()` + 매 테스트마다 `await import('./eventPersister')` 동적 임포트였다. 이 패턴이 필요한 파일은 반드시 사전에 식별해야 한다.
+
+### `generationPipeline.ts`의 `evaluateComplexityScore` 보너스 중복
+복잡도 점수 테스트에서 "모든 API에 같은 category를 쓰면 sameCategoryMultiple 보너스가 자동으로 발동"하는 사이드이펙트가 있었다. 각 시그널을 독립적으로 테스트하려면 다른 시그널을 격리할 수 있는 데이터를 신중하게 설계해야 했다. 처음에는 이 때문에 3개 테스트가 실패했다.
+
+### PR 타이밍 실수
+PR #45가 2차·3차 커밋이 추가되기 전에 병합되었다. cherry-pick으로 해결했지만 추가 PR(#46)이 필요해졌다. 이런 상황에는 "PR을 먼저 생성하되 병합은 모든 작업 완료 후"라는 워크플로우가 더 안전하다.
+
+### `findAllByUser` / `getProjectApiIds` 체인 resolution 차이
+같은 Supabase 체이닝 패턴이지만, 일부 메서드는 `.single()`이 아닌 `.eq()`에서 최종 resolve가 일어났다. 이를 미리 파악하지 못하면 mock이 실제 코드 경로와 맞지 않아 undefined 반환이나 타임아웃이 발생한다. 소스 코드를 먼저 읽고 **실제로 어느 체인 메서드가 최종 await를 받는지** 확인하는 것이 필수다.
+
+---
+
+## 커버리지 한계 분석
+
+현재 추가 개선이 구조적으로 어려운 파일들:
+
+| 파일/디렉터리 | 이유 |
+|--------------|------|
+| `lib/auth/` (supabase 클라이언트 초기화) | Next.js 서버 컨텍스트 의존, `cookies()` 호출 불가 |
+| `lib/supabase/` (클라이언트 초기화) | 환경변수 의존, 실제 클라이언트 생성 경로 테스트 불필요 |
+| `lib/db/schema.ts` | Drizzle 스키마 정의 — 실행 코드가 없음 |
+| `lib/qc/renderingQc.ts`, `deepQcRunner.ts` | Playwright 브라우저 실행 의존 |
+| `lib/ai/generationPipeline.ts`의 `runGenerationPipeline` | Stage 0~3 + qualityLoop + QC 전체 체인 — 의존성이 너무 많아 단위 테스트로 의미있는 커버리지 확보 어려움 |
+
+SonarCloud 32% → 50%+ 이상 끌어올리려면 `components/`, `app/`의 React 컴포넌트 테스트가 필요하다. 그러나 이 파일들은 UI 렌더링, Zustand store, Next.js router에 깊이 의존하여 비용 대비 효용이 낮다.
+
+**현실적 목표**: tracked scope(lib/services/providers/repositories) 75~80%가 합리적인 다음 목표. SonarCloud 40%+는 컴포넌트 테스트 없이는 어렵다.
+
+---
+
+## 신규 확립된 테스트 패턴 (docs/guides/testing.md에 문서화 완료)
+
+1. **Supabase 체이닝 mock** — select/eq/single/order를 mockReturnThis로 연결
+2. **Drizzle mock** — `makeMockDb()`로 `.select()/.from()/.where()` 체인 mock
+3. **global fetch mock** — `vi.stubGlobal` + `afterEach(vi.unstubAllGlobals)`
+4. **module-level 상태 격리** — `vi.resetModules()` + 동적 import
+5. **Factory mock** — `vi.mock` + type cast로 반환값 제어
+
+---
+
+## 다음 커버리지 개선 기회
+
+우선순위 순:
+
+1. **`lib/ai/stageRunner.ts`** — Stage 실행 함수, evaluateComplexityScore와 유사하게 함수별 단위 테스트 가능
+2. **`lib/qc/qcChecks.ts` (현재 37%)** — 개별 체크 함수들은 DOM-free라 테스트 용이
+3. **`services/generationService.ts`** — 현재 커버되지 않은 브랜치 추가 가능
+4. **React 컴포넌트 테스트** — `@testing-library/react` 도입 시 SonarCloud 수치 극적 개선 가능 (단, ROI 고려 필요)

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -9,22 +9,22 @@
 ### 테스트 피라미드
 
 ```
-          ┌─────────┐
-          │   E2E   │  ~11개 × 3디바이스 (Playwright)
-         ─┼─────────┼─
-        │ 컴포넌트  │  ~10개 (React, happy-dom)
-       ──┼──────────┼──
-      │    통합     │  ~113개 (API Routes, Vitest)
-     ────┼──────────┼────
-    │       단위    │  ~376개 (lib, providers, services, repositories)
-    ──────────────────
+             ┌─────────┐
+             │   E2E   │  ~11개 × 3디바이스 (Playwright)
+            ─┼─────────┼─
+           │ 컴포넌트  │  ~10개 (React, happy-dom)
+          ──┼──────────┼──
+         │    통합     │  ~110개 (API Routes, Vitest)
+        ────┼──────────┼────
+       │       단위    │  ~947개 (lib, providers, services, repositories)
+       ──────────────────
 ```
 
-**총 46개 Vitest 파일, 526개 테스트 + 3개 Playwright E2E 파일**
+**총 81개 Vitest 파일, 1,078개 테스트 + 3개 Playwright E2E 파일**
 
 ### 핵심 원칙
 
-1. **외부 서비스는 항상 Mock** — Supabase, Claude API는 테스트 환경에서 절대 직접 호출하지 않는다
+1. **외부 서비스는 항상 Mock** — Supabase, Claude API, GitHub API, Railway API는 테스트 환경에서 절대 직접 호출하지 않는다
 2. **모듈 격리** — API route 테스트는 `vi.resetModules()` + dynamic import로 모듈 레벨 사이드이펙트를 격리
 3. **보안 검증 필수** — SSRF, XSS, 코드 인젝션 검증은 단위/통합 양쪽에서 모두 검증
 4. **레이트리밋 경계값** — 429 응답, fail-open 정책, best-effort 보상 등 rate limit 관련 엣지케이스를 명시적으로 검증
@@ -42,7 +42,7 @@
 
 ## 2. 테스트 분류 및 검증 항목
 
-### 2.1 lib 유틸리티 단위 테스트 (15파일, ~167개)
+### 2.1 lib 유틸리티 단위 테스트 (~35파일, ~550개)
 
 `pnpm test:unit`으로 실행 (대상: `src/lib/**`)
 
@@ -51,70 +51,117 @@
 | 파일 | 검증 항목 |
 |------|----------|
 | `src/lib/ai/codeValidator.test.ts` | `eval()`, `innerHTML`, `document.write`, API키 하드코딩 감지 (정적 분석). HTML 구조 검증, viewport 존재 여부. 구조 점수·모바일 점수·fetchCallCount·placeholderCount 기반 품질 평가 |
-| `src/lib/utils/sanitizeCss.test.ts` | CSS XSS 차단: `expression()`, `url(javascript:)`, `behavior:`, `-moz-binding:` — 생성된 CSS가 브라우저에서 임의 스크립트를 실행하지 못하도록 |
+| `src/lib/utils/sanitizeCss.test.ts` | CSS XSS 차단: `expression()`, `url(javascript:)`, `behavior:`, `-moz-binding:`, 프로토콜 상대 URL(`url(//evil.com)`) — 생성된 CSS가 브라우저에서 임의 스크립트를 실행하지 못하도록 |
+| `src/lib/utils/adminAuth.test.ts` | `verifyAdminKey()` 타이밍 공격 방어 (HMAC 상수시간 비교), CORS 헤더 적용 |
+| `src/lib/db/errors.test.ts` | `isUniqueViolation()` — Supabase `{code:'23505'}` / Drizzle Error 인스턴스 양쪽 감지 |
 
 #### AI 코드 생성 파이프라인
 
 | 파일 | 검증 항목 |
 |------|----------|
-| `src/__tests__/lib/ai/generationPipeline.test.ts` | 3-stage 파이프라인(Stage1→Stage2Function→Stage3) 순차 실행, `generateCodeStream` 3회 호출, stage별 올바른 프롬프트 전달, progress 이벤트 순서, Stage1 실패 시 이후 stage 중단, `codeRepo.create` 정확히 1회 |
-| `src/__tests__/lib/ai/promptBuilder.test.ts` / `src/lib/ai/promptBuilder.test.ts` | Stage1·Stage2 시스템 프롬프트 내용(보안 규칙·모바일 퍼스트·코드 패턴), 사용자 프롬프트에 API·엔드포인트·exampleCall 포함, placeholder blocklist(로딩 스피너·더미 데이터 금지), no mock data mandate |
-| `src/lib/ai/codeParser.test.ts` | 마크다운 코드블록에서 HTML/CSS/JS 파싱, `assembleHtml()` — CSS·JS 주입, OG 태그, 파비콘, 이미지 lazy loading, 모바일 안전 CSS, viewport 자동 주입 |
-| `src/lib/ai/qualityLoop.test.ts` | `shouldRetryGeneration()` — 점수 40점 미만·모바일 점수 미달·fetchCallCount 0·placeholder 잔존 시 재시도 결정. `buildQualityImprovementPrompt()` — 재시도 프롬프트 생성 |
+| `src/lib/ai/generationPipeline.test.ts` | `evaluateComplexityScore()` — API 수·인증 방식·엔드포인트·컨텍스트·결제 키워드 5종 신호 스코어링, 35pt 임계값 경계값 검증 |
+| `src/lib/ai/stageRunner.test.ts` | `runStage1`/`runStage2Function`/`runStage3` 각 stage 실행, Extended Thinking 분기, `isCancelled` 중단 처리 |
+| `src/lib/ai/generationSaver.test.ts` | Supabase/Drizzle 경로별 코드 저장, 트랜잭션 롤백, QC 통합, slugSuggester 연동 |
+| `src/__tests__/lib/ai/promptBuilder.test.ts` | Stage1·Stage2 시스템 프롬프트 내용(보안 규칙·모바일 퍼스트·코드 패턴), placeholder blocklist |
+| `src/lib/ai/codeParser.test.ts` | 마크다운 코드블록에서 HTML/CSS/JS 파싱, `assembleHtml()` — CSS·JS 주입, OG 태그, viewport 자동 주입 |
+| `src/lib/ai/qualityLoop.test.ts` | `shouldRetryGeneration()` — 점수 40점 미만·fetchCallCount 0·placeholder 잔존 시 재시도 결정 |
+| `src/lib/ai/slugSuggester.test.ts` | AI 기반 slug 추천: 유효한 형식, 예약어 필터링, AI 에러 시 빈 배열 반환 |
 
 #### QC (Quality Control)
 
 | 파일 | 검증 항목 |
 |------|----------|
-| `src/lib/qc/renderingQc.test.ts` | Playwright 기반 렌더링 QC: `checkConsoleErrors`(JavaScript 에러 없음), `checkHorizontalScroll`(가로 스크롤 없음), `checkFooterVisible`(푸터 접근성), `checkTouchTargets`(모바일 터치 영역 44px 이상). `isQcEnabled` 환경변수 제어, `shouldRetryGeneration` + `QcReport` 통합 |
+| `src/lib/qc/renderingQc.test.ts` | Playwright 기반 렌더링 QC: 콘솔 에러 없음, 가로 스크롤 없음, 푸터 접근성, 터치 타겟 44px 이상 |
 
 #### 인프라 유틸리티
 
 | 파일 | 검증 항목 |
 |------|----------|
-| `src/__tests__/lib/db/failover.test.ts` | Circuit Breaker: `isDbConnectionError` 판별, NORMAL→TRIPPED 상태 전환(실패 임계값 도달), 윈도우 밖 실패 카운트 리셋, `FAILOVER_ENABLED=false` 시 항상 NORMAL |
-| `src/lib/encryption.test.ts` | AES-256-GCM 암호화·복호화 라운드트립, IV 랜덤성(동일 입력에 다른 암호문), 형식 검증, `ENCRYPTION_KEY` 미설정 시 에러, `maskApiKey` 마스킹 |
-| `src/lib/utils/errors.test.ts` | 에러 클래스별 올바른 HTTP statusCode 반환(NotFoundError→404, AuthRequired→401, Forbidden→403, RateLimit→429, Generation→500), `handleApiError` — AppError/일반Error/ZodError 분기 처리 |
-| `src/lib/config/providers.test.ts` | `getDbProvider()` — `supabase`(기본)/`postgres`/미설정/알 수 없는 값 처리. `getAuthProvider()` — `supabase`/`authjs` 분기 |
-| `src/lib/ai/categoryDesignMap.test.ts` | 카테고리별 디자인 테마 추론(금융→modern-dark, 날씨→ocean-blue, 빈 배열→clean-light), `useMap`·`useChart`·`allowedSections` 힌트 |
-| `src/lib/auth/authorize.test.ts` | `assertOwner()` — 소유자 일치/불일치/빈 문자열 엣지케이스 |
-| `src/lib/ai/slugSuggester.test.ts` | AI 기반 slug 추천: 유효한 형식, 예약어 필터링, AI 에러 시 빈 배열 반환, 중복 제거, 50자 초과 자르기 |
-| `src/__tests__/lib/correlationId.test.ts` | UUID 생성, 요청 간 유니크성, `X-Correlation-Id` 헤더 추출, `setCorrelationId` |
+| `src/__tests__/lib/db/failover.test.ts` + `src/lib/db/failover.test.ts` | Circuit Breaker: 상태 전환(NORMAL→TRIPPED), `isDbConnectionError` 7종 에러 감지, `FAILOVER_ENABLED=false` |
+| `src/lib/db/errors.test.ts` | `isUniqueViolation()` — Supabase/Drizzle 양쪽 23505 감지 |
+| `src/lib/encryption.test.ts` | AES-256-GCM 라운드트립, IV 랜덤성, 32바이트 키 검증, `maskApiKey` |
+| `src/lib/utils/errors.test.ts` | 에러 클래스별 HTTP statusCode, `handleApiError` — AppError/ZodError 분기 |
+| `src/lib/config/providers.test.ts` | `getDbProvider()` / `getAuthProvider()` 환경변수 분기 |
+| `src/lib/events/eventBus.test.ts` | `on`/`emit`/`unsubscribe`, 복수 핸들러, 에러 격리 |
+| `src/lib/events/eventPersister.test.ts` | `registerEventPersister()` 멱등성, 이벤트 → DB 자동 저장, 실패 시 logger.warn |
+| `src/lib/utils/slugify.test.ts` | `toSlug`/`generateSlug`/`isValidSlug`, 예약어(www/api/admin/dashboard) 필터링 |
+| `src/lib/utils/publishUrl.test.ts` | 환경별 URL 생성 (localhost/127.0.0.1/production) |
+| `src/lib/utils/htmlTitle.test.ts` | `extractTitle()` — `<title>` 파싱, 대소문자 무관, 없으면 null |
+| `src/lib/utils/adminAuth.test.ts` | `withAdminCors` CORS 헤더, `verifyAdminKey` 타이밍 공격 방어 |
+| `src/lib/services/popularServices.test.ts` | `pickTopIds`/`computePopularServices`/`resolveCuratedServices`, `CURATED_SERVICES` 구조 검증 |
+| `src/lib/templates/siteError.test.ts` | `notFoundHtml`/`preparingHtml` HTML 구조, XSS 이스케이프 (`<script>` → `&lt;script&gt;`) |
+| `src/lib/apiKeyGuides.test.ts` | `getApiKeyGuide` — 알려진 API 반환, 미등록 API null, 공공데이터포털 계열 공유 가이드 |
+| `src/lib/ai/categoryDesignMap.test.ts` | 카테고리별 디자인 테마 추론 |
+| `src/lib/auth/authorize.test.ts` | `assertOwner()` — 소유자 일치/불일치 |
+| `src/__tests__/lib/correlationId.test.ts` | UUID 생성, `X-Correlation-Id` 헤더 추출 |
+| `src/lib/deploy/githubService.test.ts` | `createRepository`(422 중복 처리), `pushCode`(6-step fetch 체인), `setSecrets`(libsodium no-op), `enableGithubPages`(409 충돌 처리) |
+| `src/lib/deploy/railwayService.test.ts` | GraphQL 래퍼(`graphql()`), `createProject`/`createServiceFromRepo`/`setEnvironmentVariables`(환경 없음 분기)/`triggerDeploy`/`getDeploymentStatus`/`getServiceDomain`/`generateServiceDomain`/`deleteProject` |
 
 ---
 
-### 2.2 Provider 단위 테스트 (2파일, ~30개)
+### 2.2 Provider 단위 테스트 (~5파일, ~80개)
 
 `pnpm test:unit`으로 실행 (대상: `src/providers/**`)
 
 | 파일 | 검증 항목 |
 |------|----------|
-| `src/providers/ai/ClaudeProvider.test.ts` | `name`·`model` 속성, `generateCode` — content·token·durationMs 반환. API 에러 처리. `generateCodeStream` — 청크 누적. `withRetry` — 429·500·503 재시도(최대 2회, 지수 백오프), 400·401 즉시 실패. `checkAvailability`. `cache_control` 블록 배열 전달(Prompt Caching) |
-| `src/providers/ai/AiProviderFactory.test.ts` | 태스크별 모델 선택(generation→Opus 4.7, suggestion→Haiku 4.5), `AI_MODEL_GENERATION` 환경변수 오버라이드, 허용되지 않은 모델 ID 설정 시 기본값으로 폴백, 싱글톤 캐시(동일 태스크·모델이면 동일 인스턴스), `clearCache()` |
+| `src/providers/ai/ClaudeProvider.test.ts` | `generateCode`/`generateCodeStream`, API 에러, `withRetry` 지수 백오프, `cache_control` Prompt Caching |
+| `src/providers/ai/AiProviderFactory.test.ts` | 태스크별 모델 선택, `AI_MODEL_GENERATION` 환경변수 오버라이드, 싱글톤 캐시 |
+| `src/providers/deploy/DeployProviderFactory.test.ts` | `create()` 캐싱, `getSupportedPlatforms()`, 미지원 플랫폼 에러 |
+| `src/providers/deploy/GithubPagesDeployer.test.ts` | 배포 전체 플로우, `resolveRepo` GitHub 저장소 조회/생성 분기 |
+| `src/providers/deploy/RailwayDeployer.test.ts` | Railway GraphQL 기반 배포 전체 플로우, 상태 폴링, 롤백 |
 
 ---
 
-### 2.3 Service 단위 테스트 (3파일, ~28개)
+### 2.3 Service 단위 테스트 (~5파일, ~75개)
 
 | 파일 | 검증 항목 |
 |------|----------|
-| `src/services/projectService.test.ts` | `create` — API 수 초과(5개 이상), 컨텍스트 길이(50~2000자), 존재하지 않는 API ID, 사용자 프로젝트 한도 초과. `getById` — NotFoundError, ForbiddenError(타인 프로젝트). `delete`. `publish` — 첫 게시 시 slug 자동 할당, 충돌 시 suffix(-2~-10) 추가, PostgreSQL unique violation(23505) 시 1회 재시도, 재게시 시 기존 slug 유지, 미완성 프로젝트 게시 차단 |
-| `src/__tests__/services/rateLimitService.test.ts` | `checkAndIncrementDailyLimit` — 한도 미달 시 허용, 한도 초과 시 RateLimitError, DB 에러 시 **fail-open**(요청 허용). `decrementDailyLimit` — 생성 실패 후 best-effort 보상(에러 스왈로우). `getCurrentUsage` — DB 에러 시 0 반환(UI 보호) |
-| `src/services/deployService.test.ts` | `deploy` — NotFoundError(프로젝트 없음), ForbiddenError(타인 소유), ValidationError(코드 없음), 정상 배포(deployUrl 반환), DEPLOYMENT_STARTED·DEPLOYMENT_COMPLETED 이벤트 발행, 실패 시 이전 status 복원 + DEPLOYMENT_FAILED 이벤트, `onProgress` 콜백 순서 |
+| `src/services/projectService.test.ts` | `create` 입력 검증, `publish` slug 자동 할당·충돌 재시도(23505), `unpublish`, `getByUserId`, `getProjectApiIds`, `updateStatus` |
+| `src/__tests__/services/rateLimitService.test.ts` | fail-open 정책, `decrementDailyLimit` 에러 스왈로우, `getCurrentUsage` 0 폴백 |
+| `src/services/deployService.test.ts` | 정상 배포, DEPLOYMENT_STARTED/COMPLETED/FAILED 이벤트, 실패 시 status 복원 |
+| `src/services/catalogService.test.ts` | `search`(totalPages 계산), `getById`, `getCategories`, `getByIds` |
+| `src/services/factory.test.ts` | `createProjectService`/`createCatalogService`/`createDeployService`/`createRateLimitService` — SupabaseClient 전달 |
 
 ---
 
-### 2.4 Repository 단위 테스트 (3파일, ~29개)
+### 2.4 Repository 단위 테스트 (~20파일, ~270개)
+
+#### Drizzle ORM 구현체 (postgres 경로)
 
 | 파일 | 검증 항목 |
 |------|----------|
-| `src/__tests__/repositories/codeRepository.test.ts` | `countByProject`, `pruneOldVersions` — 삭제 대상 있음/없음/오류 처리, `getNextVersion` |
-| `src/__tests__/repositories/eventRepository.test.ts` | `persist` — 정상 삽입, DB 오류 best-effort(에러 스왈로우), context 없음, payload에서 `projectId` 자동 추출. `persistAsync`. `findByUser` — limit 100 cap(요청값 초과 시 100으로 고정) |
-| `src/__tests__/repositories/catalogRepository.test.ts` | `toDomain` JSONB 매퍼: `verificationStatus`, `verifiedAt`, `parseEndpoints` — `exampleCall`·`responseDataPath`·`requestHeaders` snake_case↔camelCase 이중 처리(DB 직접 삽입 vs 코드 경로 차이). `getApiUsageFromProjects`, `getActiveNameToIdMap`, `ping`, `getUsageCounts` |
+| `src/__tests__/repositories/drizzleCatalogRepository.test.ts` | findById/findMany/create/update/delete/count/search(카테고리·키워드 필터)/getCategories/findByIds/getApiUsageFromProjects/getActiveNameToIdMap/ping/getUsageCounts |
+| `src/__tests__/repositories/drizzleUserRepository.test.ts` | findById/findMany/create/update/delete/count/createWithAuthId/findByEmail |
+| `src/__tests__/repositories/drizzleUserApiKeyRepository.test.ts` | upsert/delete/findByUserAndApi/findAllByUser/updateVerificationStatus |
+| `src/__tests__/repositories/drizzleEventRepository.test.ts` | persist(성공·실패)/persistAsync/findByUser(limit 100 cap) |
+| `src/__tests__/repositories/drizzleRateLimitRepository.test.ts` | checkAndIncrementDailyLimit/decrementDailyLimit/getCurrentUsage/checkAndIncrementDailyDeployLimit |
+| `src/__tests__/repositories/drizzleProjectRepository.test.ts` | 8개 메서드 전체, `projectRowToDomain` 매핑 |
+| `src/__tests__/repositories/drizzleCodeRepository.test.ts` | countByProject/pruneOldVersions/getNextVersion/`codeRowToDomain` 매핑 |
+
+#### Supabase 구현체
+
+| 파일 | 검증 항목 |
+|------|----------|
+| `src/repositories/base/BaseRepository.test.ts` | findById(PGRST116 null)/findMany(필터·null count)/create/update(updated_at 자동)/delete/count(필터) |
+| `src/repositories/projectRepository.test.ts` | findByUserId/countTodayGenerations/insertProjectApis/getProjectApiIds/findBySlug/updateSuggestedSlugs/updateSlug |
+| `src/repositories/userRepository.test.ts` | createWithAuthId/findByEmail(PGRST116 null) |
+| `src/repositories/supabaseRateLimitRepository.test.ts` | 4개 RPC 메서드 성공·실패 |
+| `src/repositories/supabaseUserApiKeyRepository.test.ts` | upsert/delete/findByUserAndApi(PGRST116)/findAllByUser/updateVerificationStatus(true→ISO/false→null) |
+| `src/repositories/factory.test.ts` | 7개 팩토리 함수 × postgres(Drizzle)/supabase(SupabaseClient)/supabase(클라이언트 없음→에러) 분기 |
+
+#### 유틸리티
+
+| 파일 | 검증 항목 |
+|------|----------|
+| `src/__tests__/repositories/catalogRepository.test.ts` | `toDomain` JSONB 매퍼, `parseEndpoints` snake_case↔camelCase 이중 처리 |
+| `src/__tests__/repositories/codeRepository.test.ts` | `countByProject`, `pruneOldVersions`, `getNextVersion` |
+| `src/__tests__/repositories/eventRepository.test.ts` | `persist`/`persistAsync`/`findByUser` limit 100 cap |
+| `src/repositories/utils/conditionBuilder.test.ts` | `buildConditions()` — undefined/빈 객체/단일·복수 조건 |
 
 ---
 
-### 2.5 API Route 통합 테스트 (11파일, ~109개)
+### 2.5 API Route 통합 테스트 (11파일, ~110개)
 
 `pnpm test:integration`으로 실행 (대상: `src/app/api/**`)
 
@@ -124,37 +171,32 @@
 
 | 파일 | 엔드포인트 | 주요 검증 항목 |
 |------|-----------|---------------|
-| `generate.test.ts` | `POST /api/v1/generate` | SSE 스트리밍 포맷(data:/event: 헤더), 레이트리밋 초과 시 429 SSE 에러 이벤트, AI 실패 시 `decrementDailyLimit` 보상 호출, 보안 검증 실패 시 generation 중단, `templateId` 힌트 전달 |
+| `generate.test.ts` | `POST /api/v1/generate` | SSE 스트리밍 포맷, 레이트리밋 429 SSE 에러, AI 실패 시 `decrementDailyLimit` 보상, `templateId` 전달 |
 
 #### 보안 관련
 
 | 파일 | 엔드포인트 | 주요 검증 항목 |
 |------|-----------|---------------|
-| `proxy.test.ts` | `GET /api/v1/proxy` | **SSRF 방지**: loopback(127.0.0.1/::1), RFC1918 사설 IP(10.x/172.16-31.x/192.168.x), AWS 메타데이터 서버(169.254.169.254), 6가지 패턴 모두 차단. path traversal(`../`), double slash(`//`), UUID 형식 검증. 분당 60회 rate limit, upstream 타임아웃 시 502 |
+| `proxy.test.ts` | `GET /api/v1/proxy` | **SSRF 방지**: loopback/RFC1918/AWS 메타데이터/IPv6(`[::1]`/`[fe80::1]`) 6종 차단, 분당 60회 rate limit, upstream 타임아웃 502 |
+| `admin.test.ts` | 관리자 API | Bearer 토큰 인증, IP 스푸핑 방지, CORS 헤더, QC rate limit |
 
 #### 배포·게시·관리
 
 | 파일 | 엔드포인트 | 주요 검증 항목 |
 |------|-----------|---------------|
-| `deploy.test.ts` | `POST /api/v1/deploy` | SSE progress 이벤트 순서(10%→20%→...→100%), 일일 배포 rate limit, 플랫폼 유효성(railway/github_pages), DEPLOYMENT_FAILED 이벤트 |
-| `preview.test.ts` | `GET /api/v1/preview/[id]` | 정상 HTML 응답 + CSP 헤더 포함, `version` 쿼리 파라미터 검증 |
-| `projects-publish.test.ts` | `POST /DELETE /api/v1/projects/[id]/publish` | slug 전달, body 파싱 실패 허용(slug 없이도 게시 가능), QC 경고, 게시 취소(slug 제거) |
-| `projects-rollback.test.ts` | `POST /api/v1/projects/[id]/rollback` | version 유효성, 지정 버전 미존재, 롤백 성공(새 버전 생성) + 이벤트 발행 |
-| `projects-slug-check.test.ts` | `POST /api/v1/projects/[id]/slug/check` | 예약어(`api`, `admin`, `www` 등), 중복 slug, 자기 프로젝트 slug 재사용은 허용 |
-| `admin.test.ts` | 관리자 API | Bearer 토큰 인증(`Authorization: Bearer <key>`), QC rate limit(60회/분), ENABLE_RENDERING_QC=false 상태 처리 |
+| `deploy.test.ts` | `POST /api/v1/deploy` | SSE progress 이벤트 순서(10%→100%), 일일 배포 rate limit, 플랫폼 유효성 |
+| `preview.test.ts` | `GET /api/v1/preview/[id]` | HTML 응답 + CSP 헤더, `version` 쿼리 파라미터 |
+| `projects-publish.test.ts` | `POST/DELETE /api/v1/projects/[id]/publish` | slug 전달, QC 경고, 게시 취소 |
+| `projects-rollback.test.ts` | `POST /api/v1/projects/[id]/rollback` | version 유효성, 롤백 성공 + 이벤트 |
+| `projects-slug-check.test.ts` | `POST /api/v1/projects/[id]/slug/check` | 예약어(`api`/`admin`/`www`) 차단, 자기 slug 재사용 허용 |
+| `health.test.ts` | `GET /api/v1/health` | `healthy`/`degraded`/`unhealthy`, `usage` 필드 |
 
 #### AI 추천 관련
 
 | 파일 | 엔드포인트 | 주요 검증 항목 |
 |------|-----------|---------------|
-| `suggest-apis.test.ts` | `POST /api/v1/suggest-apis` | context 길이(50~2000자), Claude 기반 API 추천, 파싱 실패 시 빈 배열, 존재하지 않는 API ID 필터링 |
-| `suggest-context.test.ts` | `POST /api/v1/suggest-context` | apis 배열 검증(최대 5개), AI 응답 JSON 파싱, 파싱 실패 시 빈 배열 반환 |
-
-#### 인프라
-
-| 파일 | 엔드포인트 | 주요 검증 항목 |
-|------|-----------|---------------|
-| `health.test.ts` | `GET /api/v1/health` | DB 연결 정상: `healthy` 또는 `degraded`, DB 연결 실패: `unhealthy`, `usage` 필드(일일 생성 수) 포함 |
+| `suggest-apis.test.ts` | `POST /api/v1/suggest-apis` | context 길이(50~2000자), 파싱 실패 시 빈 배열 |
+| `suggest-context.test.ts` | `POST /api/v1/suggest-context` | apis 배열 최대 5개, AI 응답 JSON 파싱 |
 
 ---
 
@@ -164,8 +206,8 @@
 
 | 파일 | 검증 항목 |
 |------|----------|
-| `src/components/dashboard/PublishDialog.test.tsx` | AI 추천 slug 라디오 버튼 선택, 커스텀 slug 입력 폼, slug 가용성 체크 후 버튼 활성화, 취소 버튼·ESC 키 동작 |
-| `src/components/dashboard/RePromptSection.test.tsx` | 버전 번호 표시, `projectId` props 전달, `onRegenerationComplete` 시 `router.refresh()` 호출 및 버전 업데이트 |
+| `src/components/dashboard/PublishDialog.test.tsx` | AI 추천 slug 라디오, 커스텀 slug 입력, slug 가용성 체크 후 버튼 활성화 |
+| `src/components/dashboard/RePromptSection.test.tsx` | 버전 번호 표시, `router.refresh()` 호출 |
 
 ---
 
@@ -178,14 +220,10 @@
 | 파일 | 검증 항목 |
 |------|----------|
 | `e2e/health.spec.ts` | `GET /api/v1/health` → 200, `GET /api/v1/catalog` → 200 |
-| `e2e/pages/landing.spec.ts` | 페이지 로드 성공, 헤더·푸터 표시, CTA 버튼 존재, 가로 스크롤 없음, 콘솔 에러 없음 |
-| `e2e/pages/catalog.spec.ts` | API 카드 렌더링(최소 1개 이상), 가로 스크롤 없음 |
+| `e2e/pages/landing.spec.ts` | 페이지 로드, 헤더·푸터, CTA 버튼, 가로 스크롤 없음, 콘솔 에러 없음 |
+| `e2e/pages/catalog.spec.ts` | API 카드 렌더링(최소 1개), 가로 스크롤 없음 |
 
-**헬퍼 함수** (`e2e/helpers/responsive.ts`):
-- `checkNoHorizontalScroll(page)` — `scrollWidth > clientWidth` 조건 검사
-- `checkNoConsoleErrors(page)` — `console.error` 이벤트 감지
-
-> E2E는 반응형 레이아웃 회귀를 검증하는 데 초점. 코드 생성 등 AI 기능은 단위·통합 계층에서 검증.
+> E2E는 반응형 레이아웃 회귀 검증에 초점. AI 기능은 단위·통합 계층에서 검증.
 
 ---
 
@@ -195,7 +233,6 @@
 
 ```typescript
 // src/test/mocks/handlers.ts
-// Claude API 전체를 MSW로 인터셉트
 http.post('https://api.anthropic.com/v1/messages', () => {
   return HttpResponse.json({
     content: [{ type: 'text', text: '```html\n...\n```' }],
@@ -210,13 +247,11 @@ http.post('https://api.anthropic.com/v1/messages', () => {
 ### 내부 모듈 — vi.mock
 
 ```typescript
-// Supabase 클라이언트 mock
 vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(),
   createServiceClient: vi.fn(),
 }));
 
-// 서비스·리포지토리 팩토리 mock
 vi.mock('@/services/factory', () => ({
   createProjectService: vi.fn(),
 }));
@@ -224,41 +259,52 @@ vi.mock('@/services/factory', () => ({
 
 ### API Route 모듈 격리 — vi.resetModules
 
-API route는 모듈 레벨에서 `registerEventPersister()` 같은 사이드이펙트가 실행되므로, 테스트 간 오염을 막기 위해 매 테스트마다 모듈을 재로딩:
-
 ```typescript
 beforeEach(async () => {
   vi.resetModules();
-  // mock 재설정 후 dynamic import
   const { POST } = await import('@/app/api/v1/generate/route');
-  // ...
 });
 ```
 
-### 환경변수 격리
+### global fetch 모킹 (proxy, githubService, railwayService 테스트)
 
 ```typescript
-const originalEnv = process.env;
-beforeEach(() => { process.env = { ...originalEnv }; });
-afterEach(() => { process.env = originalEnv; });
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+afterEach(() => { vi.unstubAllGlobals(); });
+```
+
+### Drizzle ORM mock 패턴
+
+```typescript
+function makeMockDb() {
+  return {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    // ...
+  };
+}
+```
+
+### Supabase 체인 mock 패턴
+
+```typescript
+// single() 로 끝나는 체인
+const chain = {
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  single: vi.fn().mockResolvedValue({ data: row, error: null }),
+};
+const supabase = { from: vi.fn().mockReturnValue(chain) } as unknown as SupabaseClient;
 ```
 
 ### 싱글톤 캐시 초기화
 
 ```typescript
-// AiProviderFactory 내부 Map 초기화
 AiProviderFactory.clearCache();
-
-// DB/Auth provider 감지 캐시 초기화
 _resetProviderCache();
-```
-
-### global fetch 모킹 (proxy 테스트)
-
-```typescript
-vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
-  new Response('<html>...</html>', { status: 200 })
-));
+(DeployProviderFactory as unknown as { providers: Map<string, unknown> })['providers'] = new Map();
 ```
 
 ---
@@ -279,7 +325,7 @@ vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
 
 ## 5. CI 파이프라인 연동
 
-GitHub Actions (`.github/workflows/`) 실행 순서:
+GitHub Actions (`.github/workflows/ci.yml`) 실행 순서:
 
 ```
 push/PR
@@ -288,7 +334,9 @@ lint (ESLint)
   ↓
 type-check (tsc --noEmit)
   ↓
-test (pnpm test — 464개)
+test (pnpm test — 1,078개)
+  ↓
+커버리지 업로드 (Codecov + SonarCloud)
   ↓
 build (Next.js standalone)
   ↓
@@ -305,14 +353,25 @@ build (Next.js standalone)
 
 **대상 디렉터리**: `src/lib/**`, `src/services/**`, `src/providers/**`, `src/repositories/**`
 
-**임계값** (미달 시 CI 실패):
+**현재 달성값** (로컬 기준):
+
+| 지표 | 달성값 |
+|------|--------|
+| lines | **71.77%** |
+| statements | **70.76%** |
+| branches | **67.18%** |
+| functions | **65.79%** |
+
+**CI 임계값** (미달 시 CI 실패):
 
 | 지표 | 임계값 |
 |------|--------|
-| branches | 50% |
-| functions | 60% |
-| lines | 60% |
-| statements | 60% |
+| branches | 40% |
+| functions | 30% |
+| lines | 45% |
+| statements | 43% |
+
+커버리지 외부 연동: **Codecov** + **SonarCloud** (PR마다 자동 스캔)
 
 커버리지 리포트 생성: `pnpm test:coverage` → `coverage/` 디렉터리
 
@@ -341,12 +400,10 @@ vi.mock('@/providers/ai/AiProviderFactory', () => ({
 }));
 ```
 
-> `create`와 `createForTask` 모두 포함하지 않으면 runtime error 발생.
-
 ### vi.mock factory 안에서 top-level 변수 참조 금지
 
 ```typescript
-// ❌ 잘못된 예 — hoisting으로 인해 undefined
+// ❌ hoisting으로 인해 undefined
 const mockFn = vi.fn();
 vi.mock('@/lib/foo', () => ({ fn: mockFn }));
 
@@ -354,9 +411,18 @@ vi.mock('@/lib/foo', () => ({ fn: mockFn }));
 vi.mock('@/lib/foo', () => ({ fn: vi.fn() }));
 ```
 
-### 코드 생성 품질 채점 기준
+### 모듈 레벨 상태를 가진 파일 테스트 (eventPersister 패턴)
 
-수동 테스트·QA 시 아래 기준으로 평가:
+```typescript
+// 모듈 레벨 변수(registered 등)를 테스트 간 초기화하려면:
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+const { registerEventPersister } = await import('./eventPersister');
+```
+
+### 코드 생성 품질 채점 기준
 
 | 점수 | 기준 |
 |------|------|

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@supabase/supabase-js": "^2.104.1",
     "drizzle-orm": "^0.45.2",
     "isomorphic-dompurify": "^3.10.0",
+    "libsodium-wrappers": "^0.8.4",
     "lucide-react": "^1.11.0",
     "next": "^16.2.4",
     "next-auth": "5.0.0-beta.31",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       isomorphic-dompurify:
         specifier: ^3.10.0
         version: 3.10.0
+      libsodium-wrappers:
+        specifier: ^0.8.4
+        version: 0.8.4
       lucide-react:
         specifier: ^1.11.0
         version: 1.11.0(react@19.2.5)
@@ -3388,6 +3391,12 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libsodium-wrappers@0.8.4:
+    resolution: {integrity: sha512-mu8aAWucZjTB5O/BtGXtW4e1agy7uHxNYG7zPthmmD1jU43LCDmSWZLN4JhflbdPXj3yDO4lxM1O9hLDgIOXDw==}
+
+  libsodium@0.8.4:
+    resolution: {integrity: sha512-lMcYaRi0zcs7tarATsQUYC7rstliIXZuoq0c6zXSgNtSNtdvBgkSegjWhpMJAXzKX3SUSwIp7+zEsob+j3LuRw==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -7670,6 +7679,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libsodium-wrappers@0.8.4:
+    dependencies:
+      libsodium: 0.8.4
+
+  libsodium@0.8.4: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true

--- a/scripts/migrate-encryption-key.ts
+++ b/scripts/migrate-encryption-key.ts
@@ -1,0 +1,133 @@
+/**
+ * ENCRYPTION_KEY 마이그레이션 스크립트
+ *
+ * 사용법:
+ *   OLD_ENCRYPTION_KEY=<기존키> NEW_ENCRYPTION_KEY=<신규키> \
+ *   NEXT_PUBLIC_SUPABASE_URL=<url> SUPABASE_SERVICE_ROLE_KEY=<key> \
+ *   npx tsx scripts/migrate-encryption-key.ts
+ *
+ * 동작:
+ *   1. user_api_keys 테이블 전체 조회
+ *   2. 각 행의 encrypted_key를 OLD_ENCRYPTION_KEY로 복호화
+ *   3. NEW_ENCRYPTION_KEY로 재암호화
+ *   4. DB 업데이트
+ *
+ * 주의사항:
+ *   - 프로덕션 실행 전 반드시 스테이징/백업 환경에서 검증
+ *   - 실행 중 서버 중단 시 부분 마이그레이션 상태 → 재실행 가능 (멱등성 보장)
+ *   - 재실행 시 이미 NEW_KEY로 암호화된 행은 복호화 실패 → 자동 스킵 (오류 로그 출력)
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+import { createClient } from '@supabase/supabase-js';
+
+const ALGORITHM = 'aes-256-gcm';
+
+function makeKey(raw: string): Buffer {
+  const buf = Buffer.from(raw, 'utf8');
+  if (buf.byteLength < 32) throw new Error('키가 32바이트 미만입니다.');
+  return buf.subarray(0, 32);
+}
+
+function decrypt(ciphertext: string, key: Buffer): string {
+  const parts = ciphertext.split(':');
+  if (parts.length !== 3) throw new Error('잘못된 암호화 형식');
+  const [ivHex, tagHex, encHex] = parts;
+  const decipher = createDecipheriv(ALGORITHM, key, Buffer.from(ivHex, 'hex'));
+  decipher.setAuthTag(Buffer.from(tagHex, 'hex'));
+  return decipher.update(Buffer.from(encHex, 'hex')).toString('utf8') + decipher.final('utf8');
+}
+
+function encrypt(plaintext: string, key: Buffer): string {
+  const iv = randomBytes(16);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${iv.toString('hex')}:${tag.toString('hex')}:${encrypted.toString('hex')}`;
+}
+
+async function main() {
+  const oldKeyRaw = process.env.OLD_ENCRYPTION_KEY;
+  const newKeyRaw = process.env.NEW_ENCRYPTION_KEY;
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!oldKeyRaw || !newKeyRaw || !supabaseUrl || !serviceRoleKey) {
+    console.error('필수 환경변수 누락: OLD_ENCRYPTION_KEY, NEW_ENCRYPTION_KEY, NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY');
+    process.exit(1);
+  }
+
+  if (oldKeyRaw === newKeyRaw) {
+    console.error('OLD_ENCRYPTION_KEY와 NEW_ENCRYPTION_KEY가 동일합니다. 다른 키를 사용하세요.');
+    process.exit(1);
+  }
+
+  const oldKey = makeKey(oldKeyRaw);
+  const newKey = makeKey(newKeyRaw);
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+  console.log('user_api_keys 조회 중...');
+  const { data: rows, error: fetchError } = await supabase
+    .from('user_api_keys')
+    .select('id, encrypted_key')
+    .not('encrypted_key', 'is', null);
+
+  if (fetchError) {
+    console.error('조회 실패:', fetchError.message);
+    process.exit(1);
+  }
+
+  if (!rows || rows.length === 0) {
+    console.log('마이그레이션할 행이 없습니다.');
+    return;
+  }
+
+  console.log(`총 ${rows.length}개 행 처리 시작...`);
+
+  let success = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const row of rows) {
+    const { id, encrypted_key } = row as { id: string; encrypted_key: string };
+
+    let plaintext: string;
+    try {
+      plaintext = decrypt(encrypted_key, oldKey);
+    } catch {
+      // 이미 new key로 암호화되었거나 형식이 다름 → 스킵
+      console.warn(`[SKIP] id=${id}: 복호화 실패 (이미 마이그레이션됐거나 형식 오류)`);
+      skipped++;
+      continue;
+    }
+
+    const newEncrypted = encrypt(plaintext, newKey);
+
+    const { error: updateError } = await supabase
+      .from('user_api_keys')
+      .update({ encrypted_key: newEncrypted })
+      .eq('id', id);
+
+    if (updateError) {
+      console.error(`[FAIL] id=${id}: ${updateError.message}`);
+      failed++;
+    } else {
+      success++;
+      if (success % 10 === 0) console.log(`  처리 완료: ${success}/${rows.length}`);
+    }
+  }
+
+  console.log('\n=== 마이그레이션 완료 ===');
+  console.log(`성공: ${success}, 스킵: ${skipped}, 실패: ${failed}`);
+
+  if (failed > 0) {
+    console.error(`${failed}개 행 업데이트 실패. 로그를 확인하고 재실행하세요.`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('예상치 못한 오류:', err);
+  process.exit(1);
+});

--- a/src/__tests__/api/generate.test.ts
+++ b/src/__tests__/api/generate.test.ts
@@ -25,6 +25,10 @@ vi.mock('@/lib/events/eventPersister', () => ({
   registerEventPersister: vi.fn(),
 }));
 
+vi.mock('@/lib/monitoring/errorRateMonitor', () => ({
+  registerErrorRateMonitor: vi.fn(),
+}));
+
 vi.mock('@/providers/ai/AiProviderFactory', () => ({
   AiProviderFactory: {
     create: vi.fn(),

--- a/src/__tests__/api/suggest-context.test.ts
+++ b/src/__tests__/api/suggest-context.test.ts
@@ -1,16 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ---------- Module mocks ----------
-vi.mock('@/lib/supabase/server', () => ({
-  createClient: vi.fn(),
-}));
-
 vi.mock('@/lib/auth/index', () => ({
   getAuthUser: vi.fn(),
-}));
-
-vi.mock('@/services/factory', () => ({
-  createRateLimitService: vi.fn(),
 }));
 
 vi.mock('@/providers/ai/AiProviderFactory', () => ({
@@ -22,10 +14,6 @@ vi.mock('@/providers/ai/AiProviderFactory', () => ({
 
 vi.mock('@/lib/utils/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-}));
-
-vi.mock('@/lib/config/providers', () => ({
-  getDbProvider: vi.fn().mockReturnValue('supabase'),
 }));
 
 // ---------- Test data ----------
@@ -54,12 +42,6 @@ function makeRawRequest(rawBody: string) {
 async function setupAuth(user: typeof mockUser | null = mockUser) {
   const { getAuthUser } = await import('@/lib/auth/index');
   vi.mocked(getAuthUser).mockResolvedValue(user);
-
-  const { createRateLimitService } = await import('@/services/factory');
-  vi.mocked(createRateLimitService).mockReturnValue({
-    checkAndIncrementDailyLimit: vi.fn().mockResolvedValue(undefined),
-    decrementDailyLimit: vi.fn().mockResolvedValue(undefined),
-  } as never);
 }
 
 // ---------- Tests ----------
@@ -168,5 +150,33 @@ describe('POST /api/v1/suggest-context', () => {
     const json = await response.json();
     expect(json.success).toBe(true);
     expect(json.data.suggestions).toEqual([]);
+  });
+
+  it('일일 생성 한도를 소비하지 않는다', async () => {
+    // suggest-context는 코드 생성 한도와 무관하게 동작해야 한다.
+    // createRateLimitService가 임포트되지 않으므로, 이 테스트는
+    // 정상 요청이 rate limit 없이 통과되는지 확인한다.
+    await setupAuth();
+
+    const { AiProviderFactory } = await import('@/providers/ai/AiProviderFactory');
+    vi.mocked(AiProviderFactory.createForTask).mockReturnValue({
+      name: 'claude',
+      generateCode: vi.fn().mockResolvedValue({
+        content: '["제안1", "제안2", "제안3"]',
+        provider: 'claude',
+        model: 'claude-haiku-4-5',
+        durationMs: 300,
+        tokensUsed: { input: 30, output: 60 },
+      }),
+    } as never);
+
+    const { POST } = await import('@/app/api/v1/suggest-context/route');
+    const response = await POST(makeRequest({ apis: mockApis }));
+
+    // rate limit 없이 성공해야 한다
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.success).toBe(true);
+    expect(json.data.suggestions).toHaveLength(3);
   });
 });

--- a/src/app/api/v1/generate/regenerate/route.ts
+++ b/src/app/api/v1/generate/regenerate/route.ts
@@ -1,8 +1,8 @@
 import { getDbProvider } from '@/lib/config/providers';
-import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { createClient } from '@/lib/supabase/server';
 import { getAuthUser } from '@/lib/auth/index';
 import { createProjectService, createCatalogService, createRateLimitService } from '@/services/factory';
-import { createCodeRepository } from '@/repositories/factory';
+import { createCodeRepository, createProjectRepository } from '@/repositories/factory';
 import { registerEventPersister } from '@/lib/events/eventPersister';
 import { registerErrorRateMonitor } from '@/lib/monitoring/errorRateMonitor';
 
@@ -28,7 +28,6 @@ import { getLimits } from '@/lib/config/features';
 import { regenerateSchema } from '@/types/schemas';
 import { createSseWriter } from '@/lib/ai/sseWriter';
 import { runGenerationPipeline } from '@/lib/ai/generationPipeline';
-import { createProjectRepository } from '@/repositories/factory';
 import { generationTracker } from '@/lib/ai/generationTracker';
 
 export async function POST(request: Request): Promise<Response> {
@@ -51,7 +50,6 @@ export async function POST(request: Request): Promise<Response> {
     const correlationId = getCorrelationId(request);
     const provider = getDbProvider();
     const supabase = provider === 'supabase' ? await createClient() : undefined;
-    const serviceSupabase = provider === 'supabase' ? await createServiceClient() : undefined;
 
     const rateLimitService = createRateLimitService(supabase);
     await rateLimitService.checkAndIncrementDailyLimit(user.id);

--- a/src/app/api/v1/generate/regenerate/route.ts
+++ b/src/app/api/v1/generate/regenerate/route.ts
@@ -4,8 +4,10 @@ import { getAuthUser } from '@/lib/auth/index';
 import { createProjectService, createCatalogService, createRateLimitService } from '@/services/factory';
 import { createCodeRepository } from '@/repositories/factory';
 import { registerEventPersister } from '@/lib/events/eventPersister';
+import { registerErrorRateMonitor } from '@/lib/monitoring/errorRateMonitor';
 
 registerEventPersister();
+registerErrorRateMonitor();
 import {
   buildStage1SystemPrompt,
   buildStage1RegenerationUserPrompt,

--- a/src/app/api/v1/generate/route.ts
+++ b/src/app/api/v1/generate/route.ts
@@ -1,8 +1,8 @@
 import { getDbProvider } from '@/lib/config/providers';
-import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { createClient } from '@/lib/supabase/server';
 import { getAuthUser } from '@/lib/auth/index';
 import { createProjectService, createCatalogService, createRateLimitService } from '@/services/factory';
-import { createCodeRepository } from '@/repositories/factory';
+import { createCodeRepository, createProjectRepository } from '@/repositories/factory';
 import { registerEventPersister } from '@/lib/events/eventPersister';
 import { registerErrorRateMonitor } from '@/lib/monitoring/errorRateMonitor';
 
@@ -23,7 +23,6 @@ import { generateSchema } from '@/types/schemas';
 import { templateRegistry } from '@/templates/TemplateRegistry';
 import { createSseWriter } from '@/lib/ai/sseWriter';
 import { runGenerationPipeline } from '@/lib/ai/generationPipeline';
-import { createProjectRepository } from '@/repositories/factory';
 import { generationTracker } from '@/lib/ai/generationTracker';
 
 export async function POST(request: Request): Promise<Response> {
@@ -46,7 +45,6 @@ export async function POST(request: Request): Promise<Response> {
     const correlationId = getCorrelationId(request);
     const provider = getDbProvider();
     const supabase = provider === 'supabase' ? await createClient() : undefined;
-    const serviceSupabase = provider === 'supabase' ? await createServiceClient() : undefined;
 
     const rateLimitService = createRateLimitService(supabase);
     await rateLimitService.checkAndIncrementDailyLimit(user.id);

--- a/src/app/api/v1/generate/route.ts
+++ b/src/app/api/v1/generate/route.ts
@@ -4,8 +4,10 @@ import { getAuthUser } from '@/lib/auth/index';
 import { createProjectService, createCatalogService, createRateLimitService } from '@/services/factory';
 import { createCodeRepository } from '@/repositories/factory';
 import { registerEventPersister } from '@/lib/events/eventPersister';
+import { registerErrorRateMonitor } from '@/lib/monitoring/errorRateMonitor';
 
 registerEventPersister();
+registerErrorRateMonitor();
 import type { DesignPreferences } from '@/types/project';
 import {
   buildStage1SystemPrompt,

--- a/src/app/api/v1/suggest-context/route.ts
+++ b/src/app/api/v1/suggest-context/route.ts
@@ -1,8 +1,5 @@
-import { getDbProvider } from '@/lib/config/providers';
-import { createClient } from '@/lib/supabase/server';
 import { getAuthUser } from '@/lib/auth/index';
 import { AiProviderFactory } from '@/providers/ai/AiProviderFactory';
-import { createRateLimitService } from '@/services/factory';
 import { AuthRequiredError, ValidationError, handleApiError, jsonResponse } from '@/lib/utils/errors';
 import { suggestContextSchema } from '@/types/schemas';
 import { logger } from '@/lib/utils/logger';
@@ -17,11 +14,6 @@ export async function POST(request: Request): Promise<Response> {
   try {
     const user = await getAuthUser();
     if (!user) throw new AuthRequiredError();
-
-    const supabase = getDbProvider() === 'supabase' ? await createClient() : undefined;
-
-    const rateLimitService = createRateLimitService(supabase);
-    await rateLimitService.checkAndIncrementDailyLimit(user.id);
 
     let apis: SuggestApiItem[];
     try {

--- a/src/lib/ai/generationPipeline.integration.test.ts
+++ b/src/lib/ai/generationPipeline.integration.test.ts
@@ -1,0 +1,412 @@
+/**
+ * runGenerationPipeline integration test
+ *
+ * 검증 목적:
+ *  - Stage 2 skip 조건 (품질 충분 → stage1 결과 그대로 진행)
+ *  - Stage 3 skip 조건 (점수 충분 → polish 스킵)
+ *  - 전체 happy path (stage 0→1→2→3→QC→qualityLoop→저장)
+ *  - 파이프라인 실패 경로 (rate limit 복구, 이벤트 발행, SSE error)
+ *  - Extended Thinking 임계값 조건
+ *  - stage 0 실패 → 무시하고 계속 진행 (best-effort)
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+// ── mock declarations ──────────────────────────────────────────────────────────
+
+vi.mock('@/providers/ai/AiProviderFactory', () => ({
+  AiProviderFactory: { createForTask: vi.fn() },
+}));
+vi.mock('@/lib/ai/stageRunner', () => ({
+  runStage1: vi.fn(),
+  runStage2Function: vi.fn(),
+  runStage3: vi.fn(),
+}));
+vi.mock('@/lib/ai/qualityLoop', () => ({
+  runQualityLoop: vi.fn(),
+}));
+vi.mock('@/lib/ai/featureExtractor', () => ({
+  extractFeatures: vi.fn(),
+}));
+vi.mock('@/lib/ai/generationSaver', () => ({
+  saveGeneratedCode: vi.fn(),
+}));
+vi.mock('@/lib/ai/codeValidator', () => ({
+  validateAll: vi.fn(),
+  evaluateQuality: vi.fn(),
+}));
+vi.mock('@/lib/qc', () => ({
+  runFastQc: vi.fn(),
+  isQcEnabled: vi.fn(),
+}));
+vi.mock('@/lib/events/eventBus', () => ({
+  eventBus: { emit: vi.fn() },
+}));
+vi.mock('@/lib/ai/generationTracker', () => ({
+  generationTracker: {
+    start: vi.fn(),
+    updateProgress: vi.fn(),
+    fail: vi.fn(),
+    complete: vi.fn(),
+  },
+}));
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ── imports after mocks ────────────────────────────────────────────────────────
+
+import { runGenerationPipeline, type PipelineInput, type PipelineServices } from './generationPipeline';
+import { AiProviderFactory } from '@/providers/ai/AiProviderFactory';
+import { runStage1, runStage2Function, runStage3 } from '@/lib/ai/stageRunner';
+import { runQualityLoop } from '@/lib/ai/qualityLoop';
+import { extractFeatures } from '@/lib/ai/featureExtractor';
+import { saveGeneratedCode } from '@/lib/ai/generationSaver';
+import { validateAll, evaluateQuality } from '@/lib/ai/codeValidator';
+import { runFastQc, isQcEnabled } from '@/lib/qc';
+import { eventBus } from '@/lib/events/eventBus';
+import { generationTracker } from '@/lib/ai/generationTracker';
+import type { ApiCatalogItem } from '@/types/api';
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+function makeSse() {
+  const events: Array<{ event: string; data: unknown }> = [];
+  return {
+    send: vi.fn((event: string, data: unknown) => { events.push({ event, data }); }),
+    events,
+  };
+}
+
+function makeApi(overrides: Partial<ApiCatalogItem> = {}): ApiCatalogItem {
+  return {
+    id: 'api-1', name: 'Weather API', category: 'weather',
+    description: 'Weather data', tags: [], documentationUrl: null,
+    exampleCall: null, responseFormat: null, authRequired: false,
+    rateLimitInfo: null, authType: 'none', endpoints: [],
+    ...overrides,
+  } as ApiCatalogItem;
+}
+
+function makeStageResult(html = '<html><body><p>hi</p></body></html>', extra?: object) {
+  return {
+    parsed: { html, css: 'body{}', js: 'console.log(1)' },
+    provider: 'claude',
+    model: 'claude-opus-4-7',
+    durationMs: 100,
+    tokensUsed: { input: 10, output: 20 },
+    userPrompt: 'user prompt',
+    ...extra,
+  };
+}
+
+function makeQualityMetrics(overrides: object = {}) {
+  return {
+    fetchCallCount: 1,
+    placeholderCount: 0,
+    structuralScore: 85,
+    mobileScore: 80,
+    details: [],
+    ...overrides,
+  };
+}
+
+function makeServices(): PipelineServices {
+  return {
+    codeRepo: { saveVersion: vi.fn(), findLatestVersion: vi.fn() } as never,
+    projectService: { updateStatus: vi.fn().mockResolvedValue(undefined) },
+    rateLimitService: { decrementDailyLimit: vi.fn().mockResolvedValue(undefined) },
+  };
+}
+
+function makeInput(apiOverrides: Partial<ApiCatalogItem>[] = [{}]): PipelineInput {
+  return {
+    projectId: 'proj-1',
+    userId: 'user-1',
+    correlationId: 'corr-1',
+    apis: apiOverrides.map(makeApi),
+    projectContext: 'A weather dashboard with 7-day forecast',
+    stage1SystemPrompt: 'system1',
+    stage1UserPrompt: 'user1',
+    stage2FunctionSystemPrompt: 'sys2fn',
+    buildStage2FunctionUserPrompt: vi.fn().mockReturnValue('user2fn'),
+    stage2SystemPrompt: 'sys2',
+    buildStage2UserPrompt: vi.fn().mockReturnValue('user2'),
+  };
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────────
+
+describe('runGenerationPipeline()', () => {
+  const mockProvider = { name: 'claude', generate: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (AiProviderFactory.createForTask as Mock).mockReturnValue(mockProvider);
+    (extractFeatures as Mock).mockResolvedValue({ features: [] });
+    (isQcEnabled as Mock).mockReturnValue(false);
+    (validateAll as Mock).mockReturnValue({ errors: [], warnings: [] });
+    (evaluateQuality as Mock).mockReturnValue(makeQualityMetrics());
+
+    const stageResult = makeStageResult();
+    (runStage1 as Mock).mockResolvedValue(stageResult);
+    (runStage2Function as Mock).mockResolvedValue(stageResult);
+    (runStage3 as Mock).mockResolvedValue(stageResult);
+    (runQualityLoop as Mock).mockResolvedValue({
+      parsed: stageResult.parsed,
+      quality: makeQualityMetrics(),
+      qcReport: null,
+      qualityLoopUsed: false,
+    });
+    (saveGeneratedCode as Mock).mockResolvedValue(undefined);
+  });
+
+  describe('happy path', () => {
+    it('전체 파이프라인 순서대로 실행 — stage1→stage2→stage3→qualityLoop→저장', async () => {
+      const sse = makeSse();
+      const services = makeServices();
+      const input = makeInput();
+
+      // stage2 필요하게 만들기: fetch 미호출
+      (evaluateQuality as Mock)
+        .mockReturnValueOnce(makeQualityMetrics({ fetchCallCount: 0 }))  // stage1 QC
+        .mockReturnValueOnce(makeQualityMetrics({ fetchCallCount: 1 }))  // pre-stage3 QC (skip 조건 미충족)
+        .mockReturnValueOnce(makeQualityMetrics({ fetchCallCount: 1 })); // validate
+
+      await runGenerationPipeline(input, sse as never, services);
+
+      expect(runStage1).toHaveBeenCalledOnce();
+      expect(runStage2Function).toHaveBeenCalledOnce();
+      expect(runStage3).toHaveBeenCalledOnce();
+      expect(runQualityLoop).toHaveBeenCalledOnce();
+      expect(saveGeneratedCode).toHaveBeenCalledOnce();
+    });
+
+    it('tracker.start → updateProgress(5) 호출', async () => {
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      expect(generationTracker.start).toHaveBeenCalledWith('proj-1', 'user-1');
+      expect(generationTracker.updateProgress).toHaveBeenCalledWith(
+        'proj-1', 5, 'analyzing', expect.any(String),
+      );
+    });
+
+    it('SSE progress 이벤트 순서: analyzing → (stage 진행) → validating', async () => {
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      const progressEvents = sse.events.filter(e => e.event === 'progress');
+      const steps = progressEvents.map(e => (e.data as { step: string }).step);
+      expect(steps[0]).toBe('analyzing');
+      expect(steps).toContain('validating');
+    });
+  });
+
+  describe('Stage 2 skip 조건', () => {
+    it('fetch 호출 존재 + placeholder 없음 + QC 비활성 → stage2 스킵', async () => {
+      (evaluateQuality as Mock)
+        .mockReturnValueOnce(makeQualityMetrics({ fetchCallCount: 1, placeholderCount: 0 }))
+        .mockReturnValueOnce(makeQualityMetrics());
+
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      expect(runStage2Function).not.toHaveBeenCalled();
+    });
+
+    it('fetch 미호출 → stage2 실행', async () => {
+      (evaluateQuality as Mock)
+        .mockReturnValueOnce(makeQualityMetrics({ fetchCallCount: 0 }))
+        .mockReturnValueOnce(makeQualityMetrics());
+
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      expect(runStage2Function).toHaveBeenCalledOnce();
+    });
+
+    it('placeholder 존재 → stage2 실행', async () => {
+      (evaluateQuality as Mock)
+        .mockReturnValueOnce(makeQualityMetrics({ placeholderCount: 2 }))
+        .mockReturnValueOnce(makeQualityMetrics());
+
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      expect(runStage2Function).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('Stage 3 skip 조건', () => {
+    it('structuralScore>=80, mobileScore>=70, fetch있음, placeholder없음, stage2 스킵됨 → stage3 스킵', async () => {
+      // stage2 스킵 조건 (fetch 있음)
+      // stage3 스킵 조건 (점수 충분, stage2 불필요했음)
+      (evaluateQuality as Mock)
+        .mockReturnValueOnce(makeQualityMetrics({ fetchCallCount: 1, placeholderCount: 0 })) // stage1
+        .mockReturnValueOnce(makeQualityMetrics({ structuralScore: 85, mobileScore: 75, fetchCallCount: 1, placeholderCount: 0 })) // pre-stage3
+        .mockReturnValueOnce(makeQualityMetrics()); // final
+
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      expect(runStage2Function).not.toHaveBeenCalled();
+      expect(runStage3).not.toHaveBeenCalled();
+    });
+
+    it('structuralScore<80 → stage3 실행', async () => {
+      (evaluateQuality as Mock)
+        .mockReturnValueOnce(makeQualityMetrics({ fetchCallCount: 1 })) // stage1: no stage2
+        .mockReturnValueOnce(makeQualityMetrics({ structuralScore: 70 })) // pre-stage3: 낮음
+        .mockReturnValueOnce(makeQualityMetrics());
+
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      expect(runStage3).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('Stage 0 — featureExtractor', () => {
+    it('feature 추출 성공 → stage1SystemPrompt에 기능 목록 주입', async () => {
+      (extractFeatures as Mock).mockResolvedValue({
+        features: [{ id: 'F1', description: '7일 예보', verifiableBy: 'DOM 확인' }],
+      });
+
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      const [promptArg] = (runStage1 as Mock).mock.calls[0] as [string, ...unknown[]];
+      expect(promptArg).toContain('F1');
+      expect(promptArg).toContain('7일 예보');
+    });
+
+    it('featureExtractor 실패 → 파이프라인 계속 진행 (stage1 호출됨)', async () => {
+      (extractFeatures as Mock).mockRejectedValue(new Error('timeout'));
+
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      expect(runStage1).toHaveBeenCalledOnce();
+      expect(saveGeneratedCode).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('보안 검증 실패', () => {
+    it('validateAll 에러 존재 → 파이프라인 중단 + rateLimitService.decrementDailyLimit 호출', async () => {
+      (validateAll as Mock).mockReturnValue({ errors: ['eval() 사용 금지'], warnings: [] });
+
+      const sse = makeSse();
+      const services = makeServices();
+      await runGenerationPipeline(makeInput(), sse as never, services);
+
+      expect(services.rateLimitService.decrementDailyLimit).toHaveBeenCalledWith('user-1');
+      expect(saveGeneratedCode).not.toHaveBeenCalled();
+
+      const errorEvents = sse.events.filter(e => e.event === 'error');
+      expect(errorEvents.length).toBe(1);
+    });
+  });
+
+  describe('파이프라인 실패 처리', () => {
+    it('stage1 throw → rateLimitService.decrementDailyLimit 호출 + SSE error 발행', async () => {
+      (runStage1 as Mock).mockRejectedValue(new Error('AI 서비스 응답 없음'));
+
+      const sse = makeSse();
+      const services = makeServices();
+      await runGenerationPipeline(makeInput(), sse as never, services);
+
+      expect(services.rateLimitService.decrementDailyLimit).toHaveBeenCalledWith('user-1');
+      expect(eventBus.emit).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'CODE_GENERATION_FAILED' }),
+      );
+      expect(generationTracker.fail).toHaveBeenCalledWith('proj-1', expect.any(String));
+
+      const errorEvent = sse.events.find(e => e.event === 'error');
+      expect(errorEvent).toBeDefined();
+      expect((errorEvent!.data as { message: string }).message).toContain('AI 서비스 응답 없음');
+    });
+
+    it('saveGeneratedCode throw → rateLimitService 호출 + SSE error 발행', async () => {
+      (saveGeneratedCode as Mock).mockRejectedValue(new Error('DB 저장 실패'));
+
+      const sse = makeSse();
+      const services = makeServices();
+      await runGenerationPipeline(makeInput(), sse as never, services);
+
+      expect(services.rateLimitService.decrementDailyLimit).toHaveBeenCalled();
+      const errorEvent = sse.events.find(e => e.event === 'error');
+      expect(errorEvent).toBeDefined();
+    });
+
+    it('AiProviderFactory 초기화 실패 → early throw + SSE error', async () => {
+      (AiProviderFactory.createForTask as Mock).mockImplementation(() => {
+        throw new Error('ANTHROPIC_API_KEY 누락');
+      });
+
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      const errorEvent = sse.events.find(e => e.event === 'error');
+      expect(errorEvent).toBeDefined();
+      expect((errorEvent!.data as { message: string }).message).toContain('AI 서비스 초기화 실패');
+    });
+  });
+
+  describe('QC 활성화 경로', () => {
+    it('isQcEnabled=true + Fast QC 실패 → stage2 강제 실행', async () => {
+      (isQcEnabled as Mock).mockReturnValue(true);
+      (runFastQc as Mock).mockResolvedValue({
+        passed: false,
+        overallScore: 40,
+        checks: [{ name: 'console-errors', passed: false, score: 0 }],
+      });
+      // stage1 품질은 충분하지만 QC 실패로 stage2 강제
+      (evaluateQuality as Mock)
+        .mockReturnValueOnce(makeQualityMetrics({ fetchCallCount: 1, placeholderCount: 0 }))
+        .mockReturnValueOnce(makeQualityMetrics())
+        .mockReturnValueOnce(makeQualityMetrics());
+
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      expect(runStage2Function).toHaveBeenCalledOnce();
+    });
+
+    it('isQcEnabled=true + runFastQc throw → 계속 진행 (QC 실패 무시)', async () => {
+      (isQcEnabled as Mock).mockReturnValue(true);
+      (runFastQc as Mock).mockRejectedValue(new Error('Playwright 사용 불가'));
+
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      expect(saveGeneratedCode).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('Extended Thinking', () => {
+    it('복잡도 낮은 API 1개 → ET 미활성화', async () => {
+      const sse = makeSse();
+      await runGenerationPipeline(
+        makeInput([{ authType: 'none', endpoints: [] }]),
+        sse as never,
+        makeServices(),
+      );
+
+      // runStage1(systemPrompt, userPrompt, aiProvider, sse, useET) — 5번째 인자
+      const args = (runStage1 as Mock).mock.calls[0] as [unknown, unknown, unknown, unknown, boolean];
+      expect(args[4]).toBe(false);
+    });
+
+    it('OAuth + 500자 이상 컨텍스트 → ET 활성화', async () => {
+      const sse = makeSse();
+      const input = makeInput([{ authType: 'oauth', endpoints: [{ method: 'POST' as const, path: '/x', description: '', params: [], responseExample: {} }] }]);
+      input.projectContext = 'A'.repeat(500);
+
+      await runGenerationPipeline(input, sse as never, makeServices());
+
+      const args = (runStage1 as Mock).mock.calls[0] as [unknown, unknown, unknown, unknown, boolean];
+      expect(args[4]).toBe(true);
+    });
+  });
+});

--- a/src/lib/ai/generationPipeline.ts
+++ b/src/lib/ai/generationPipeline.ts
@@ -196,7 +196,7 @@ ${featureList}
     }
 
     // ── Stage 1: 구조·기능 생성 (5→28%) ───────────────────────────────────────
-    const stage1Result = await runStage1(input.stage1SystemPrompt, input.stage1UserPrompt, aiProvider, sse, useET);
+    const stage1Result = await runStage1(stage1SystemPrompt, input.stage1UserPrompt, aiProvider, sse, useET);
     const stage1Code = stage1Result.parsed;
 
     // Stage 1 정적 QC — stage2Function에 전달

--- a/src/lib/deploy/githubService.test.ts
+++ b/src/lib/deploy/githubService.test.ts
@@ -4,6 +4,17 @@ vi.mock('@/lib/utils/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
+vi.mock('libsodium-wrappers', () => ({
+  default: {
+    ready: Promise.resolve(),
+    from_base64: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3])),
+    from_string: vi.fn().mockReturnValue(new Uint8Array([4, 5, 6])),
+    crypto_box_seal: vi.fn().mockReturnValue(new Uint8Array([7, 8, 9])),
+    to_base64: vi.fn().mockReturnValue('encrypted-base64=='),
+    base64_variants: { ORIGINAL: 1 },
+  },
+}));
+
 const mockFetch = vi.fn();
 
 beforeEach(() => {
@@ -220,34 +231,51 @@ describe('pushCode()', () => {
 // ── setSecrets ────────────────────────────────────────────────────────────────
 
 describe('setSecrets()', () => {
-  it('빈 secrets {} → public-key 호출 후 logger.info 호출', async () => {
-    mockFetch.mockResolvedValueOnce(
-      mockResponse({ key: 'base64key==', key_id: 'kid1' }),
-    );
-
+  it('빈 secrets {} → fetch 호출 없이 logger.info 호출 (early return)', async () => {
     const { setSecrets } = await import('./githubService');
     const { logger } = await import('@/lib/utils/logger');
 
     await expect(setSecrets('test-org/my-repo', {})).resolves.toBeUndefined();
-    expect(mockFetch).toHaveBeenCalledOnce();
-    expect(logger.info).toHaveBeenCalledWith('Secrets configured', expect.any(Object));
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith('Secrets configured', expect.objectContaining({ secretCount: 0 }));
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it('non-empty secrets → logger.warn(libsodium 미구현) + logger.info 호출', async () => {
-    mockFetch.mockResolvedValueOnce(
-      mockResponse({ key: 'base64key==', key_id: 'kid1' }),
-    );
+  it('non-empty secrets → public-key 조회 + PUT /actions/secrets/:name 호출', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockResponse({ key: 'base64key==', key_id: 'kid1' }))  // GET public-key
+      .mockResolvedValueOnce({ ok: true, status: 204, json: vi.fn() })                // PUT API_KEY
+      .mockResolvedValueOnce({ ok: true, status: 204, json: vi.fn() });               // PUT DB_URL
 
     const { setSecrets } = await import('./githubService');
     const { logger } = await import('@/lib/utils/logger');
 
     await setSecrets('test-org/my-repo', { API_KEY: 'secret-value', DB_URL: 'postgres://...' });
 
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('libsodium encryption not yet implemented'),
-      expect.objectContaining({ secretNames: ['API_KEY', 'DB_URL'] }),
+    // GET public-key + PUT 2개 = 3회 fetch
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/test-org/my-repo/actions/secrets/public-key',
+      expect.any(Object),
     );
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/actions/secrets/API_KEY'),
+      expect.objectContaining({ method: 'PUT' }),
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith('Secrets configured', expect.objectContaining({ secretCount: 2 }));
+  });
+
+  it('PUT 응답 400 → logger.warn 기록 후 나머지 계속 진행', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockResponse({ key: 'base64key==', key_id: 'kid1' }))
+      .mockResolvedValueOnce({ ok: false, status: 400, json: vi.fn() });
+
+    const { setSecrets } = await import('./githubService');
+    const { logger } = await import('@/lib/utils/logger');
+
+    await expect(setSecrets('test-org/my-repo', { BAD_SECRET: 'val' })).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith('Failed to set secret', expect.objectContaining({ status: 400 }));
     expect(logger.info).toHaveBeenCalledWith('Secrets configured', expect.any(Object));
   });
 
@@ -262,7 +290,6 @@ describe('setSecrets()', () => {
       'Failed to get public key for secrets',
       expect.objectContaining({ status: 403 }),
     );
-    // info는 호출되지 않음 (early return)
     expect(logger.info).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/deploy/githubService.ts
+++ b/src/lib/deploy/githubService.ts
@@ -1,3 +1,4 @@
+import sodium from 'libsodium-wrappers';
 import { logger } from '@/lib/utils/logger';
 import type { FileEntry } from '@/providers/deploy/IDeployProvider';
 
@@ -150,7 +151,12 @@ export async function setSecrets(
 ): Promise<void> {
   const headers = getHeaders();
 
-  // Get public key for encrypting secrets
+  if (Object.keys(secrets).length === 0) {
+    logger.info('Secrets configured', { repoFullName, secretCount: 0 });
+    return;
+  }
+
+  // Get repo public key for sealed-box encryption (GitHub Actions requires this)
   const keyRes = await fetch(`${GITHUB_API}/repos/${repoFullName}/actions/secrets/public-key`, {
     headers,
   });
@@ -160,24 +166,28 @@ export async function setSecrets(
   }
   const keyData = await keyRes.json();
 
-  // TODO(secrets): libsodium(tweetnacl)으로 Actions secret 암호화 후 주입 필요.
-  // 현재 이 함수는 no-op로 동작하며, 배포 시 secret은 수동 설정을 전제로 함.
-  // 구현 방법:
-  //   npm install tweetnacl tweetnacl-util
-  //   import nacl from 'tweetnacl';
-  //   import { encodeBase64, decodeBase64 } from 'tweetnacl-util';
-  //   const keyBytes = decodeBase64(keyData.key);
-  //   const valueBytes = new TextEncoder().encode(value);
-  //   const encrypted = nacl.box.seal(valueBytes, keyBytes);
-  //   const encrypted_value = encodeBase64(encrypted);
-  //   PUT /repos/{owner}/{repo}/actions/secrets/{secret_name} with { encrypted_value, key_id }
-  if (Object.keys(secrets).length > 0) {
-    logger.warn(
-      'GitHub Actions secret injection skipped: libsodium encryption not yet implemented. ' +
-      'Secrets must be set manually in the repository settings.',
-      { repoFullName, secretNames: Object.keys(secrets) }
-    );
-  }
+  await sodium.ready;
+  const repoPublicKey = sodium.from_base64(keyData.key as string, sodium.base64_variants.ORIGINAL);
+
+  await Promise.all(
+    Object.entries(secrets).map(async ([name, value]) => {
+      const valueBytes = sodium.from_string(value);
+      const encryptedBytes = sodium.crypto_box_seal(valueBytes, repoPublicKey);
+      const encryptedValue = sodium.to_base64(encryptedBytes, sodium.base64_variants.ORIGINAL);
+
+      const res = await fetch(
+        `${GITHUB_API}/repos/${repoFullName}/actions/secrets/${name}`,
+        {
+          method: 'PUT',
+          headers,
+          body: JSON.stringify({ encrypted_value: encryptedValue, key_id: keyData.key_id }),
+        }
+      );
+      if (!res.ok && res.status !== 204) {
+        logger.warn('Failed to set secret', { repoFullName, name, status: res.status });
+      }
+    })
+  );
 
   logger.info('Secrets configured', { repoFullName, secretCount: Object.keys(secrets).length });
 }

--- a/src/lib/monitoring/errorRateMonitor.ts
+++ b/src/lib/monitoring/errorRateMonitor.ts
@@ -1,0 +1,67 @@
+import { eventBus } from '@/lib/events/eventBus';
+import { sendSlackAlert } from './slackAlert';
+import { logger } from '@/lib/utils/logger';
+
+// 5분 윈도우 내 생성 실패 횟수 추적 (인메모리, Railway 단일 인스턴스 전제)
+const WINDOW_MS = 5 * 60 * 1000;
+const ALERT_THRESHOLD = Number(process.env.ERROR_RATE_ALERT_THRESHOLD ?? 5);
+
+interface FailureWindow {
+  count: number;
+  windowStart: number;
+  alerted: boolean;
+}
+
+const state: FailureWindow = {
+  count: 0,
+  windowStart: Date.now(),
+  alerted: false,
+};
+
+let monitorRegistered = false;
+
+function resetWindowIfExpired(): void {
+  if (Date.now() - state.windowStart > WINDOW_MS) {
+    state.count = 0;
+    state.windowStart = Date.now();
+    state.alerted = false;
+  }
+}
+
+/**
+ * 서버 시작 시 1회 호출.
+ * CODE_GENERATION_FAILED 이벤트를 구독하여 5분 윈도우 내 임계값 초과 시 Slack 알림.
+ */
+export function registerErrorRateMonitor(): void {
+  if (monitorRegistered) return;
+  monitorRegistered = true;
+
+  eventBus.on(async (event) => {
+    if (event.type !== 'CODE_GENERATION_FAILED') return;
+
+    resetWindowIfExpired();
+    state.count++;
+
+    logger.info('Error rate monitor', {
+      count: state.count,
+      threshold: ALERT_THRESHOLD,
+      windowStart: new Date(state.windowStart).toISOString(),
+    });
+
+    if (state.count >= ALERT_THRESHOLD && !state.alerted) {
+      state.alerted = true;
+      const payload = event.payload as { projectId?: string; error?: string; provider?: string };
+      await sendSlackAlert({
+        level: 'error',
+        title: '코드 생성 실패율 임계값 초과',
+        message: `5분 내 ${state.count}회 실패가 감지되었습니다. 서비스 상태를 확인하세요.`,
+        fields: {
+          '5분 내 실패 횟수': state.count,
+          '임계값': ALERT_THRESHOLD,
+          'Provider': payload.provider ?? 'unknown',
+          '마지막 에러': payload.error?.slice(0, 100) ?? '-',
+        },
+      });
+    }
+  });
+}

--- a/src/lib/monitoring/slackAlert.ts
+++ b/src/lib/monitoring/slackAlert.ts
@@ -1,0 +1,51 @@
+import { logger } from '@/lib/utils/logger';
+
+export interface SlackAlertOptions {
+  level: 'error' | 'warning' | 'info';
+  title: string;
+  message: string;
+  fields?: Record<string, string | number>;
+}
+
+const LEVEL_EMOJI: Record<SlackAlertOptions['level'], string> = {
+  error: ':red_circle:',
+  warning: ':warning:',
+  info: ':information_source:',
+};
+
+/**
+ * SLACK_WEBHOOK_URL 환경변수가 설정된 경우 Slack 알림을 전송합니다.
+ * 미설정이면 no-op (서버 로그만 출력).
+ */
+export async function sendSlackAlert(opts: SlackAlertOptions): Promise<void> {
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+  if (!webhookUrl) {
+    logger.warn('SLACK_WEBHOOK_URL 미설정 — Slack 알림 스킵', { title: opts.title });
+    return;
+  }
+
+  const emoji = LEVEL_EMOJI[opts.level];
+  const fieldLines = opts.fields
+    ? Object.entries(opts.fields).map(([k, v]) => `• *${k}*: ${v}`).join('\n')
+    : '';
+
+  const text = [
+    `${emoji} *${opts.title}*`,
+    opts.message,
+    fieldLines,
+    `_환경: ${process.env.NODE_ENV ?? 'unknown'} | ${new Date().toISOString()}_`,
+  ].filter(Boolean).join('\n');
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    });
+    if (!res.ok) {
+      logger.warn('Slack 알림 전송 실패', { status: res.status, title: opts.title });
+    }
+  } catch (err) {
+    logger.warn('Slack 알림 전송 오류', { error: err instanceof Error ? err.message : String(err) });
+  }
+}

--- a/src/providers/ai/ClaudeProvider.test.ts
+++ b/src/providers/ai/ClaudeProvider.test.ts
@@ -115,9 +115,10 @@ describe('ClaudeProvider', () => {
       );
     });
 
-    it('기본 temperature는 0.7이다', async () => {
+    it('temperature를 API에 전달하지 않는다 (Claude 4.x deprecated)', async () => {
       await provider.generateCode({ system: 'sys', user: 'user' });
-      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ temperature: 0.7 }));
+      const callArg = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(callArg).not.toHaveProperty('temperature');
     });
 
     it('기본 max_tokens는 48000이다', async () => {
@@ -135,19 +136,13 @@ describe('ClaudeProvider', () => {
       );
     });
 
-    it('extendedThinking 활성화 시 thinking 파라미터와 temperature 1이 전달된다', async () => {
+    it('extendedThinking 활성화 시 thinking 파라미터가 전달된다', async () => {
       await provider.generateCode({ system: 'sys', user: 'user', extendedThinking: true });
-      expect(mockCreate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          thinking: { type: 'enabled', budget_tokens: 32000 },
-          temperature: 1,
-        })
-      );
-    });
-
-    it('extendedThinking 비활성화 시 기본 temperature 0.7이 전달된다', async () => {
-      await provider.generateCode({ system: 'sys', user: 'user' });
-      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ temperature: 0.7 }));
+      const callArg = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(callArg).toMatchObject({
+        thinking: { type: 'enabled', budget_tokens: 32000 },
+      });
+      expect(callArg).not.toHaveProperty('temperature');
     });
   });
 

--- a/src/providers/ai/ClaudeProvider.ts
+++ b/src/providers/ai/ClaudeProvider.ts
@@ -87,8 +87,6 @@ export class ClaudeProvider implements IAiProvider {
         model: this.model,
         system: buildSystemParam(prompt.system),
         messages: [{ role: 'user', content: prompt.user }],
-        // Extended thinking 활성화 시 temperature 1 필수 (API 요구사항)
-        temperature: useThinking ? 1 : (prompt.temperature ?? 0.7),
         max_tokens: prompt.maxTokens ?? 48000,
         ...(useThinking && {
           thinking: { type: 'enabled' as const, budget_tokens: 32000 },
@@ -126,7 +124,6 @@ export class ClaudeProvider implements IAiProvider {
         model: this.model,
         system: buildSystemParam(prompt.system),
         messages: [{ role: 'user', content: prompt.user }],
-        temperature: useThinking ? 1 : (prompt.temperature ?? 0.7),
         max_tokens: prompt.maxTokens ?? 48000,
         ...(useThinking && {
           thinking: { type: 'enabled' as const, budget_tokens: 32000 },


### PR DESCRIPTION
## Summary

- **docs**: PR #45·#46 커버리지 개선 회고 문서 작성, CLAUDE.md 업데이트 (PR 병합 타이밍, 모듈 상태 격리, SonarCloud/Codecov 지표 불일치 설명)
- **fix/feat**: githubService libsodium 실제 암호화, generationPipeline featureSpec 주입 버그 수정, slackAlert + errorRateMonitor 추가, ENCRYPTION_KEY 마이그레이션 스크립트
- **fix**: `suggest-context` API가 코드 생성 일일 한도(`checkAndIncrementDailyLimit`)를 잘못 소비하는 버그 수정 → 추천 컨텍스트 사용 후 생성 시도 시 429 발생하던 프로덕션 장애 해결
- **fix**: Anthropic Claude 4.x 모델에서 `temperature` 파라미터 deprecated로 인한 400 오류 수정 → `ClaudeProvider`에서 temperature 전달 완전 제거

## Test plan

- [x] `pnpm test` — 1,097개 전체 통과
- [x] suggest-context 테스트: rate limit mock 제거, 한도 미소비 검증 테스트 추가
- [x] ClaudeProvider 테스트: temperature 미전달 검증으로 업데이트
- [ ] Railway 배포 후 `/api/v1/generate` 정상 동작 확인
- [ ] `/api/v1/suggest-context` 호출 후 생성 시도 → 성공 확인
- [ ] `curl https://xzawed.xyz/api/v1/health` → `{ status: 'ok' }` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)