### PR TITLE
fix: SonarCloud Phase 1 — 보안 취약점(S8479) + 접근성 버그 3건(S1082) 수정

### DIFF
--- a/src/components/catalog/ApiCard.tsx
+++ b/src/components/catalog/ApiCard.tsx
@@ -40,9 +40,11 @@ export function ApiCard({ api, isSelected, onSelect, onDetail }: ApiCardProps) {
   const catStyle = categoryBadgeStyle[api.category] ?? categoryBadgeStyle.utility;
 
   return (
-    <div
+    <button
+      type="button"
       onClick={onSelect}
-      className="card group relative cursor-pointer p-5"
+      aria-pressed={isSelected}
+      className="card group relative w-full cursor-pointer p-5 text-left"
       style={isSelected ? { borderColor: 'var(--accent-primary)', boxShadow: 'var(--shadow-glow)' } : undefined}
     >
       {/* Selection indicator */}
@@ -104,6 +106,6 @@ export function ApiCard({ api, isSelected, onSelect, onDetail }: ApiCardProps) {
       >
         <ExternalLink className="h-4 w-4" />
       </button>
-    </div>
+    </button>
   );
 }

--- a/src/components/dashboard/PublishDialog.tsx
+++ b/src/components/dashboard/PublishDialog.tsx
@@ -247,6 +247,8 @@ export function PublishDialog({ project, onClose, onPublished }: PublishDialogPr
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       onClick={handleBackdropClick}
+      onKeyDown={(e) => { if (e.key === 'Escape') onClose(); }}
+      tabIndex={0}
     >
       <div
         ref={dialogRef}

--- a/src/components/settings/ApiKeyGuideModal.tsx
+++ b/src/components/settings/ApiKeyGuideModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from 'react';
 import { X, ExternalLink, CheckCircle, Clock } from 'lucide-react';
 import type { ApiKeyGuide } from '@/lib/apiKeyGuides';
 
@@ -10,14 +11,22 @@ interface Props {
 }
 
 export function ApiKeyGuideModal({ apiName, guide, onClose }: Props) {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
       style={{ background: 'rgba(0,0,0,0.7)' }}
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
+      {/* Backdrop button — click outside to close */}
+      <button type="button" className="absolute inset-0" onClick={onClose} aria-label="닫기" />
+
       <div
-        className="glass relative w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-2xl p-6"
+        className="glass relative z-10 w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-2xl p-6"
         style={{ background: 'var(--bg-card)' }}
       >
         {/* 헤더 */}
@@ -54,7 +63,7 @@ export function ApiKeyGuideModal({ apiName, guide, onClose }: Props) {
         {/* 단계별 안내 */}
         <ol className="mb-5 space-y-4">
           {guide.steps.map((step, i) => (
-            <li key={i} className="flex gap-4">
+            <li key={step.title} className="flex gap-4">
               <div
                 className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white"
                 style={{ background: 'linear-gradient(135deg, #06b6d4, #8b5cf6)' }}
@@ -84,8 +93,8 @@ export function ApiKeyGuideModal({ apiName, guide, onClose }: Props) {
         {/* 팁 */}
         {guide.tips && guide.tips.length > 0 && (
           <div className="mb-5 space-y-2">
-            {guide.tips.map((tip, i) => (
-              <div key={i} className="flex items-start gap-2 text-sm text-slate-400">
+            {guide.tips.map((tip) => (
+              <div key={tip} className="flex items-start gap-2 text-sm text-slate-400">
                 <CheckCircle className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
                 <span>{tip}</span>
               </div>

--- a/src/lib/ai/codeParser.test.ts
+++ b/src/lib/ai/codeParser.test.ts
@@ -148,4 +148,19 @@ describe('assembleHtml', () => {
     const result = assembleHtml({ html: '<p>content</p>', css: '', js: '' });
     expect(result).toContain('alpinejs@3.14.8/dist/cdn.min.js');
   });
+
+  it('인라인 script 태그를 sanitize로 제거한다', () => {
+    const result = assembleHtml({
+      html: '<div><script>alert("xss")</script><p>Hello</p></div>',
+      css: '',
+      js: '',
+    });
+    expect(result).not.toContain('<script>alert');
+    expect(result).toContain('<p>Hello</p>');
+  });
+
+  it('Alpine.js CDN script 태그는 buildHeadInjections로 포함한다', () => {
+    const result = assembleHtml({ html: '<p>Hello</p>', css: '', js: '' });
+    expect(result).toContain('alpinejs');
+  });
 });

--- a/src/lib/ai/codeParser.ts
+++ b/src/lib/ai/codeParser.ts
@@ -168,14 +168,13 @@ function optimizeImages(html: string): string {
 export function assembleHtml(parsed: ParsedCode): string {
   const safeCss = parsed.css ? sanitizeCss(parsed.css) : '';
 
-  // Sanitize AI-generated HTML: strip event handlers and javascript: URIs while
-  // preserving <script>/<style>/<link> (already validated by securityValidator)
-  // and Alpine.js custom attributes (x-*, :*, @*).
+  // Sanitize AI-generated HTML. ADD_TAGS is intentionally empty: script/style/link are
+  // all omitted to prevent DOM-based attacks (SonarQube S8479). CSS comes from parsed.css
+  // and Alpine.js is injected by buildHeadInjections() after sanitization.
   const isFullDoc = parsed.html.includes('</head>');
   const safeHtml = DOMPurify.sanitize(parsed.html, {
     WHOLE_DOCUMENT: isFullDoc,
     FORCE_BODY: !isFullDoc,
-    ADD_TAGS: ['script', 'style', 'link'],
   });
 
   // If HTML is a full document, inject additional CSS and JS

--- a/src/lib/ai/codeValidator.test.ts
+++ b/src/lib/ai/codeValidator.test.ts
@@ -30,6 +30,22 @@ describe('validateSecurity', () => {
     expect(result.passed).toBe(true);
     expect(result.errors).toHaveLength(0);
   });
+
+  it('인라인 script 태그가 있으면 에러를 반환한다', () => {
+    const result = validateSecurity('<script>alert(1)</script>');
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('인라인 스크립트'))).toBe(true);
+  });
+
+  it('src 속성이 있는 script 태그는 차단하지 않는다', () => {
+    const result = validateSecurity('<script src="https://cdn.example.com/lib.js"></script>');
+    expect(result.errors.some((e) => e.includes('인라인 스크립트'))).toBe(false);
+  });
+
+  it('script 없는 정상 HTML은 인라인 스크립트 에러 없음', () => {
+    const result = validateSecurity('<div class="app"><h1>Hello</h1></div>');
+    expect(result.errors.some((e) => e.includes('인라인 스크립트'))).toBe(false);
+  });
 });
 
 describe('validateFunctionality', () => {

--- a/src/lib/ai/codeValidator.ts
+++ b/src/lib/ai/codeValidator.ts
@@ -30,6 +30,11 @@ export function validateSecurity(code: string): ValidationResult {
     errors.push('eval() 사용이 감지되었습니다. 보안상 허용되지 않습니다.');
   }
 
+  // Block: inline script tags (src= 속성 없는 경우만 — CDN 태그는 허용)
+  if (/<script(?!\s[^>]*\bsrc\s*=)[^>]*>/i.test(code)) {
+    errors.push('AI 생성 코드에 인라인 스크립트는 허용되지 않습니다.');
+  }
+
   // Block: definite hardcoded key formats
   for (const pattern of DEFINITE_KEY_PATTERNS) {
     if (pattern.test(code)) {


### PR DESCRIPTION
## Summary

- **HIGH 보안 취약점 (S8479)**: `codeParser.ts`의 DOMPurify `ADD_TAGS`에서 `script`/`style`/`link` 완전 제거 — AI 생성 HTML에서 스크립트 주입 차단
- **codeValidator 보강**: `validateSecurity()`에 인라인 `<script>` 태그 차단 규칙 추가 (CDN `src=` 태그는 허용)
- **접근성 버그 3건 (S1082)**: `onClick` 핸들러에 키보드 이벤트 누락
  - `ApiCard`: `div` → `button` 변환 + `aria-pressed`
  - `PublishDialog`: 백드롭에 `onKeyDown`/`tabIndex` 추가
  - `ApiKeyGuideModal`: 백드롭을 독립 `<button>`으로 분리 + `useEffect` Escape 핸들러

## Test plan

- [x] `pnpm test` — 1102 tests, 82 files, all pass
- [x] `pnpm lint` — no errors
- [x] `pnpm type-check` — no errors
- [ ] SonarCloud 분석 결과 확인 (CI 완료 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)