### PR TITLE
test: SonarCloud Phase 2 — 커버리지 향상 (slackAlert, errorRateMonitor, generationTracker)

### DIFF
--- a/src/lib/ai/generationTracker.test.ts
+++ b/src/lib/ai/generationTracker.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('GenerationTracker', () => {
+  it('start()는 generating 상태의 엔트리를 생성한다', async () => {
+    const { generationTracker, stopCleanup } = await import('./generationTracker');
+    generationTracker.start('p1', 'user-1');
+
+    const entry = generationTracker.get('p1');
+    expect(entry?.status).toBe('generating');
+    expect(entry?.userId).toBe('user-1');
+    expect(entry?.progress).toBe(0);
+    expect(entry?.step).toBe('initializing');
+
+    stopCleanup();
+  });
+
+  it('updateProgress()는 progress, step, message를 갱신한다', async () => {
+    const { generationTracker, stopCleanup } = await import('./generationTracker');
+    generationTracker.start('p2', 'user-1');
+    generationTracker.updateProgress('p2', 50, 'stage1_generating', '1단계 생성 중...');
+
+    const entry = generationTracker.get('p2');
+    expect(entry?.progress).toBe(50);
+    expect(entry?.step).toBe('stage1_generating');
+    expect(entry?.message).toBe('1단계 생성 중...');
+
+    stopCleanup();
+  });
+
+  it('complete()는 status를 completed로 설정하고 result를 저장한다', async () => {
+    const { generationTracker, stopCleanup } = await import('./generationTracker');
+    const result = { projectId: 'p3', version: 1, previewUrl: 'https://example.com' };
+    generationTracker.start('p3', 'user-1');
+    generationTracker.complete('p3', result);
+
+    const entry = generationTracker.get('p3');
+    expect(entry?.status).toBe('completed');
+    expect(entry?.progress).toBe(100);
+    expect(entry?.result).toEqual(result);
+
+    stopCleanup();
+  });
+
+  it('fail()은 status를 failed로 설정하고 error를 저장한다', async () => {
+    const { generationTracker, stopCleanup } = await import('./generationTracker');
+    generationTracker.start('p4', 'user-1');
+    generationTracker.fail('p4', 'AI 응답 오류');
+
+    const entry = generationTracker.get('p4');
+    expect(entry?.status).toBe('failed');
+    expect(entry?.error).toBe('AI 응답 오류');
+
+    stopCleanup();
+  });
+
+  it('get()은 존재하지 않는 projectId에 대해 undefined를 반환한다', async () => {
+    const { generationTracker, stopCleanup } = await import('./generationTracker');
+    expect(generationTracker.get('unknown-id')).toBeUndefined();
+    stopCleanup();
+  });
+
+  it('isGenerating()은 generating 상태에서 true, completed 이후 false를 반환한다', async () => {
+    const { generationTracker, stopCleanup } = await import('./generationTracker');
+    generationTracker.start('p5', 'user-1');
+    expect(generationTracker.isGenerating('p5')).toBe(true);
+
+    generationTracker.complete('p5', { projectId: 'p5', version: 1, previewUrl: '' });
+    expect(generationTracker.isGenerating('p5')).toBe(false);
+
+    stopCleanup();
+  });
+
+  it('generating 엔트리는 30분 TTL 후 cleanup에서 제거된다', async () => {
+    vi.useFakeTimers();
+    const { generationTracker, stopCleanup } = await import('./generationTracker');
+
+    generationTracker.start('p6', 'user-1');
+    expect(generationTracker.get('p6')).toBeDefined();
+
+    // Advance past 30-minute TTL; cleanup interval fires every 60s
+    vi.advanceTimersByTime(31 * 60 * 1000);
+
+    expect(generationTracker.get('p6')).toBeUndefined();
+    stopCleanup();
+  });
+
+  it('completed 엔트리는 10분 TTL 후 cleanup에서 제거된다', async () => {
+    vi.useFakeTimers();
+    const { generationTracker, stopCleanup } = await import('./generationTracker');
+
+    generationTracker.start('p7', 'user-1');
+    generationTracker.complete('p7', { projectId: 'p7', version: 1, previewUrl: '' });
+    expect(generationTracker.get('p7')).toBeDefined();
+
+    // Still present at 9 minutes
+    vi.advanceTimersByTime(9 * 60 * 1000);
+    expect(generationTracker.get('p7')).toBeDefined();
+
+    // Gone after 11 minutes total
+    vi.advanceTimersByTime(2 * 60 * 1000);
+    expect(generationTracker.get('p7')).toBeUndefined();
+    stopCleanup();
+  });
+});

--- a/src/lib/monitoring/errorRateMonitor.test.ts
+++ b/src/lib/monitoring/errorRateMonitor.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/events/eventBus', () => ({
+  eventBus: { on: vi.fn() },
+}));
+vi.mock('./slackAlert', () => ({
+  sendSlackAlert: vi.fn(),
+}));
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  delete process.env.ERROR_RATE_ALERT_THRESHOLD;
+});
+
+type EventHandler = (event: { type: string; payload: unknown }) => Promise<void>;
+
+describe('registerErrorRateMonitor', () => {
+  it('eventBus.on에 핸들러를 1회 등록한다', async () => {
+    const { registerErrorRateMonitor } = await import('./errorRateMonitor');
+    const { eventBus } = await import('@/lib/events/eventBus');
+
+    registerErrorRateMonitor();
+
+    expect(eventBus.on).toHaveBeenCalledTimes(1);
+  });
+
+  it('중복 호출해도 핸들러를 1번만 등록한다', async () => {
+    const { registerErrorRateMonitor } = await import('./errorRateMonitor');
+    const { eventBus } = await import('@/lib/events/eventBus');
+
+    registerErrorRateMonitor();
+    registerErrorRateMonitor();
+
+    expect(eventBus.on).toHaveBeenCalledTimes(1);
+  });
+
+  it('임계값 미달 시 sendSlackAlert를 호출하지 않는다', async () => {
+    const { registerErrorRateMonitor } = await import('./errorRateMonitor');
+    const { eventBus } = await import('@/lib/events/eventBus');
+    const { sendSlackAlert } = await import('./slackAlert');
+
+    registerErrorRateMonitor();
+    const handler = (eventBus.on as ReturnType<typeof vi.fn>).mock.calls[0][0] as EventHandler;
+
+    for (let i = 0; i < 4; i++) {
+      await handler({ type: 'CODE_GENERATION_FAILED', payload: {} });
+    }
+
+    expect(sendSlackAlert).not.toHaveBeenCalled();
+  });
+
+  it('임계값(5회) 도달 시 sendSlackAlert를 호출한다', async () => {
+    const { registerErrorRateMonitor } = await import('./errorRateMonitor');
+    const { eventBus } = await import('@/lib/events/eventBus');
+    const { sendSlackAlert } = await import('./slackAlert');
+    (sendSlackAlert as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    registerErrorRateMonitor();
+    const handler = (eventBus.on as ReturnType<typeof vi.fn>).mock.calls[0][0] as EventHandler;
+
+    for (let i = 0; i < 5; i++) {
+      await handler({ type: 'CODE_GENERATION_FAILED', payload: { error: 'AI 오류', provider: 'claude' } });
+    }
+
+    expect(sendSlackAlert).toHaveBeenCalledTimes(1);
+    expect((sendSlackAlert as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
+      level: 'error',
+      title: '코드 생성 실패율 임계값 초과',
+    });
+  });
+
+  it('같은 윈도우 내 중복 알림을 보내지 않는다', async () => {
+    const { registerErrorRateMonitor } = await import('./errorRateMonitor');
+    const { eventBus } = await import('@/lib/events/eventBus');
+    const { sendSlackAlert } = await import('./slackAlert');
+    (sendSlackAlert as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    registerErrorRateMonitor();
+    const handler = (eventBus.on as ReturnType<typeof vi.fn>).mock.calls[0][0] as EventHandler;
+
+    for (let i = 0; i < 10; i++) {
+      await handler({ type: 'CODE_GENERATION_FAILED', payload: {} });
+    }
+
+    expect(sendSlackAlert).toHaveBeenCalledTimes(1);
+  });
+
+  it('CODE_GENERATION_FAILED 외 이벤트는 무시한다', async () => {
+    const { registerErrorRateMonitor } = await import('./errorRateMonitor');
+    const { eventBus } = await import('@/lib/events/eventBus');
+    const { sendSlackAlert } = await import('./slackAlert');
+
+    registerErrorRateMonitor();
+    const handler = (eventBus.on as ReturnType<typeof vi.fn>).mock.calls[0][0] as EventHandler;
+
+    for (let i = 0; i < 10; i++) {
+      await handler({ type: 'SERVICE_CREATED', payload: {} });
+    }
+
+    expect(sendSlackAlert).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/monitoring/slackAlert.test.ts
+++ b/src/lib/monitoring/slackAlert.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { sendSlackAlert } from './slackAlert';
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+describe('sendSlackAlert', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+    delete process.env.SLACK_WEBHOOK_URL;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.SLACK_WEBHOOK_URL;
+  });
+
+  it('SLACK_WEBHOOK_URL 미설정 시 fetch를 호출하지 않는다', async () => {
+    await sendSlackAlert({ level: 'error', title: '테스트', message: '내용' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('SLACK_WEBHOOK_URL 설정 시 올바른 엔드포인트로 POST 요청을 보낸다', async () => {
+    process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.com/test';
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await sendSlackAlert({ level: 'info', title: '제목', message: '메시지' });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://hooks.slack.com/test',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('HTTP 실패 응답 시 에러를 던지지 않는다', async () => {
+    process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.com/test';
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 500 }));
+
+    await expect(
+      sendSlackAlert({ level: 'error', title: '에러', message: '내용' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('fetch 예외 시 에러를 던지지 않는다', async () => {
+    process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.com/test';
+    fetchSpy.mockRejectedValueOnce(new Error('네트워크 오류'));
+
+    await expect(
+      sendSlackAlert({ level: 'warning', title: '경고', message: '내용' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('fields와 level 이모지가 전송 텍스트에 포함된다', async () => {
+    process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.com/test';
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await sendSlackAlert({
+      level: 'error',
+      title: '제목',
+      message: '메시지',
+      fields: { '실패 횟수': 5, '임계값': 3 },
+    });
+
+    const call = fetchSpy.mock.calls[0];
+    const body = JSON.parse(call[1]!.body as string) as { text: string };
+    expect(body.text).toContain(':red_circle:');
+    expect(body.text).toContain('실패 횟수');
+    expect(body.text).toContain('5');
+  });
+});


### PR DESCRIPTION
## Summary

SonarCloud 신규 코드 커버리지 31.9% → 80% 목표를 위한 테스트 추가.

- **slackAlert.test.ts** (5 tests): webhook 미설정 no-op, POST 전송, HTTP 실패/fetch 예외 허용, fields/이모지 포맷 검증
- **errorRateMonitor.test.ts** (5 tests): `vi.resetModules()` 패턴으로 모듈 레벨 상태 격리, 임계값 미달/초과/중복 알림/이벤트 필터링 검증
- **generationTracker.test.ts** (8 tests): start/update/complete/fail/get/isGenerating CRUD + `vi.useFakeTimers()`로 TTL 30분(generating)/10분(completed) 정확히 검증

## Test plan

- [x] 3개 신규 파일 — 19개 테스트 전체 통과
- [x] 전체 테스트 — 1116 tests, 85 files, all pass
- [x] `pnpm lint` — no errors
- [x] `pnpm type-check` — no errors
- [ ] SonarCloud 신규 코드 커버리지 확인 (CI 완료 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)