### PR TITLE
fix: 생성 성공률 개선 Phase 2 — 타임아웃·인라인스크립트·폴백 이벤트·성공률 지표 (#58)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ pnpm test:coverage    # 커버리지 리포트
 | CI ESLint 마이그레이션 ADR | [docs/decisions/2026-04-26-ci-eslint-migration.md](docs/decisions/2026-04-26-ci-eslint-migration.md) |
 | 커버리지 개선 회고 (PR #45·#46) | [docs/decisions/2026-04-26-coverage-improvement-retrospective.md](docs/decisions/2026-04-26-coverage-improvement-retrospective.md) |
 | 보안·접근성·커버리지 수정 ADR (PR #49·#50) | [docs/decisions/2026-04-26-sonarcloud-security-a11y-coverage.md](docs/decisions/2026-04-26-sonarcloud-security-a11y-coverage.md) |
+| 생성 성공률 개선 ADR (Phase 2, PR #58) | [docs/decisions/2026-04-29-generation-success-rate-improvement.md](docs/decisions/2026-04-29-generation-success-rate-improvement.md) |
 
 - [README.md](README.md) — 프로젝트 전체 개요
 - [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) — PR 템플릿

--- a/docs/architecture/ai-pipeline.md
+++ b/docs/architecture/ai-pipeline.md
@@ -1,6 +1,6 @@
 # AI 코드 생성 파이프라인
 
-> **최종 업데이트:** 2026-04-17
+> **최종 업데이트:** 2026-04-29
 
 ## 1. 개요
 
@@ -219,7 +219,9 @@ DB 저장 구조 (code_versions 테이블):
 
 ### ClaudeProvider 재시도 전략 (`withRetry`)
 - `generateCode` / `generateCodeStream` 모두 `withRetry()` 헬퍼로 래핑
-- HTTP 429·500·502·503·504 또는 네트워크 에러 시 최대 2회 지수 백오프 재시도 (1초→2초)
+- HTTP 429·500·502·503·504 또는 네트워크 에러 시 최대 2회 재시도
+- **429 Retry-After 헤더** 있으면 해당 시간(초→밀리초) 후 재시도, 없으면 지수 백오프(1초→2초)
+- **SDK 타임아웃**: Anthropic 클라이언트 `timeout: 270,000ms` — Railway 300초 HTTP 컷 30초 전 안전 종료
 - 재시도 불가 에러는 즉시 throw
 
 ### 성능 최적화 (현재 적용 중)
@@ -343,10 +345,11 @@ Avoid: [제외할 요소]
 | `generationPipeline.ts` | 오케스트레이터 (~120줄) — generate/regenerate 공통 진입점 |
 | `stageRunner.ts` | `runStage1()` / `runStage2Function()` / `runStage3()` — SSE + AI 호출 + 파싱 |
 | `generationSaver.ts` | DB 저장, slug 제안(fire-and-forget), 버전 정리, Deep QC, 상태 갱신, SSE complete |
-| `qualityLoop.ts` | `shouldRetryGeneration()` + `runQualityLoop()` (최대 3회, best-of-n 반환) |
+| `qualityLoop.ts` | `shouldRetryGeneration()` + `runQualityLoop()` (최대 3회, best-of-n 반환, 반복당 타임아웃 `QUALITY_LOOP_ITERATION_TIMEOUT_MS` 기본 120초) |
 | `generationTracker.ts` | 서버 메모리 진행 상태 싱글톤 (모바일 폴링 fallback용) |
 
-`handlePipelineFailure()` (generationPipeline.ts 내부): Rate Limit 복구, 실패 이벤트 발행(`eventBus.emit`), Tracker 실패 표시
+`handlePipelineFailure()` (generationPipeline.ts 내부): Rate Limit 복구, 실패 이벤트 발행(`eventBus.emit`), Tracker 실패 표시  
+**Stage 3 fallback**: Stage 3 AI 호출 실패 시 Stage 2 결과로 폴백하며 `STAGE3_FALLBACK_USED` 이벤트 발행 → `platform_events` 테이블 자동 기록 (빈도 추적 용도)
 
 **이벤트 흐름**: 생성 성공/실패 시 `eventBus.emit()` → `eventPersister` 구독자가 자동으로 `platform_events` 테이블에 기록 (수동 `persistAsync` 이중 호출 없음)
 

--- a/docs/architecture/ai-pipeline.md
+++ b/docs/architecture/ai-pipeline.md
@@ -231,7 +231,7 @@ DB 저장 구조 (code_versions 테이블):
 
 **Extended Thinking (조건부 — 복잡도 스코어링)**
 - `evaluateComplexityScore(apis, context)` 함수로 0~100점 복잡도 점수 산출 후, `shouldUseExtendedThinking()` 로 활성화 여부 결정
-- 임계값: `ET_COMPLEXITY_THRESHOLD` 환경변수 (기본 **45점**)
+- 임계값: `ET_COMPLEXITY_THRESHOLD` 환경변수 (기본 **35점**)
 - **스코어링 신호 (5종):**
 
   | 신호 | 기여 점수 |

--- a/docs/architecture/events.md
+++ b/docs/architecture/events.md
@@ -66,6 +66,10 @@ export type DomainEvent =
   | {
       type: 'QC_REPORT_FAILED';
       payload: { projectId: string; stage: 'fast' | 'deep'; error: string };
+    }
+  | {
+      type: 'STAGE3_FALLBACK_USED';
+      payload: { projectId: string; error: string };
     };
 
 export type DomainEventType = DomainEvent['type'];

--- a/docs/decisions/2026-04-29-generation-success-rate-improvement.md
+++ b/docs/decisions/2026-04-29-generation-success-rate-improvement.md
@@ -1,0 +1,71 @@
+# ADR: 코드 생성 성공률 개선 — Phase 2 (2026-04-29)
+
+## 배경
+
+프로덕션 운영 중 코드 생성 파이프라인에서 세 가지 범주의 문제가 반복적으로 발생했다.
+
+1. **하드 타임아웃**: Railway의 300초 요청 제한으로 인해 Claude API 호출이 커넥션 끊김으로 종료되는 경우, 파이프라인이 graceful termination 없이 실패했다.
+2. **Quality Loop 교착**: Quality Loop의 단일 반복(iteration)이 hang 상태에 빠지면 전체 3회 재시도가 소진될 때까지 블록되었다.
+3. **오탐(False Positive) 검증**: `validateSecurity()` 가 인라인 `<script>`를 오류로 분류했으나, `assembleHtml()`의 DOMPurify가 어차피 이를 제거하므로 실질적인 차단이 없음에도 생성 성공률을 낮추고 있었다.
+
+또한 Stage 3(디자인 폴리시) 실패가 로그에만 남고 구조화된 모니터링이 없어 얼마나 자주 폴백이 발생하는지 파악할 수 없었으며, Admin QC Stats API가 성공 건수만 보여줘 실제 성공률을 계산할 수 없었다.
+
+## 결정 사항
+
+### 1. ClaudeProvider 타임아웃·재시도 개선
+
+**무엇을**: Claude API 호출에 270초 타임아웃 설정. 429(Rate Limit) 응답 시 `Retry-After` 헤더 값을 우선 사용하여 대기 시간 계산.
+
+**왜**: Railway는 300초 이후 TCP 커넥션을 강제 종료한다. 타임아웃을 270초로 설정하면 Railway 컷오프 전에 파이프라인이 명시적 오류를 반환할 수 있어 사용자에게 더 명확한 피드백을 제공한다. `Retry-After` 헤더를 무시하고 지수 백오프만 사용할 경우 실제 허용 대기 시간보다 훨씬 긴 불필요한 대기가 발생할 수 있다.
+
+**관련 파일**: `src/providers/ClaudeProvider.ts`
+
+### 2. Quality Loop 반복당 타임아웃
+
+**무엇을**: `QUALITY_LOOP_ITERATION_TIMEOUT_MS` 환경변수 도입(기본값: 120,000ms / 120초). Quality Loop의 각 반복에 개별 타임아웃을 적용.
+
+**왜**: 단일 반복이 hang 상태에 빠지면 기존 구조에서는 모든 재시도 기회(최대 3회)를 소비하는 동안 전체 요청이 블록됐다. 반복당 타임아웃을 적용하면 한 번의 hang이 전체 Quality Loop를 마비시키는 상황을 방지할 수 있다.
+
+**관련 파일**: `src/lib/ai/qualityLoop.ts`, `docs/reference/env-vars.md`
+
+### 3. 인라인 스크립트 탐지 강등 (error → warning)
+
+**무엇을**: `validateSecurity()` 내 인라인 `<script>` 탐지를 오류(error)에서 경고(warning)로 강등.
+
+**왜**: `assembleHtml()`은 DOMPurify를 통해 인라인 스크립트를 자동으로 제거한다. 따라서 인라인 스크립트가 포함된 코드가 생성되더라도 최종 서빙 결과물에는 포함되지 않는다. 이미 자동 제거되는 내용을 이유로 생성 자체를 차단하는 것은 오탐이며, 불필요하게 성공률을 낮추는 결과를 초래했다.
+
+**관련 파일**: `src/lib/qc/validateSecurity.ts`
+
+### 4. Stage 3 폴백 이벤트 추적
+
+**무엇을**: Stage 3(디자인 폴리시) catch 블록에서 `STAGE3_FALLBACK_USED` 도메인 이벤트 발행. Stage 3 실패 시 Stage 2 결과로 폴백하며 이 사실을 이벤트로 기록. `eventPersister`를 통해 `platform_events` 테이블에 자동 영속화.
+
+**왜**: Stage 3 실패는 기존에 콘솔 로그로만 남아 운영 중 얼마나 자주 발생하는지 집계가 불가능했다. 구조화된 이벤트로 기록함으로써 Stage 3 실패율을 시계열로 추적하고, 개선 우선순위를 데이터 기반으로 결정할 수 있다.
+
+**관련 파일**: `src/lib/ai/generationPipeline.ts`, `src/types/events.ts`, `docs/architecture/events.md`
+
+### 5. Admin QC Stats — 실성공률 지표 추가
+
+**무엇을**: Admin QC Stats API 응답에 `failureCount`(CODE_GENERATION_FAILED 이벤트 수)와 `realSuccessRate`(성공 건수 / 전체 시도 건수) 필드 추가.
+
+**왜**: 기존 지표는 성공한 생성 건수만 보여줬다. 전체 시도 대비 성공 비율(실성공률)을 계산하려면 실패 건수도 함께 조회해야 하지만 해당 데이터가 API에 노출되지 않았다. 두 지표를 함께 제공함으로써 파이프라인 개선 효과를 정량적으로 측정할 수 있다.
+
+**관련 파일**: `src/app/api/v1/admin/qc/stats/route.ts`
+
+## 결과
+
+- **타임아웃 안전성**: Railway 컷오프 전 명시적 오류 반환 → 사용자 피드백 개선, 좀비 요청 감소
+- **Quality Loop 안정성**: 단일 hang이 전체 루프를 마비시키는 상황 제거
+- **오탐 감소**: 자동 제거되는 인라인 스크립트로 인한 생성 실패 제거
+- **모니터링 가시성**: Stage 3 폴백 빈도를 데이터로 확인 가능 → 개선 우선순위 결정 근거 확보
+- **실성공률 추적**: Admin 대시보드에서 파이프라인 전체 성공률 확인 가능
+
+## 관련 파일
+
+- `src/providers/ClaudeProvider.ts` — 타임아웃 및 Retry-After 처리
+- `src/lib/ai/qualityLoop.ts` — 반복당 타임아웃
+- `src/lib/qc/validateSecurity.ts` — 인라인 스크립트 강등
+- `src/lib/ai/generationPipeline.ts` — STAGE3_FALLBACK_USED 이벤트 발행
+- `src/types/events.ts` — DomainEvent 유니온 타입에 STAGE3_FALLBACK_USED 추가
+- `src/app/api/v1/admin/qc/stats/route.ts` — failureCount, realSuccessRate 필드 추가
+- `docs/architecture/events.md` — 이벤트 타입 문서 갱신

--- a/docs/guides/qc-process.md
+++ b/docs/guides/qc-process.md
@@ -22,6 +22,7 @@
 | 하드코딩된 API 키 | 에러 | **즉시 차단** |
 | innerHTML 할당 | 경고 | 기록 후 진행 |
 | document.write() | 경고 | 기록 후 진행 |
+| 인라인 `<script>` 태그 (src 속성 없음) | 경고 | 기록 후 진행 (`assembleHtml`이 DOMPurify로 자동 제거) |
 
 **탐지 키 패턴 (`DEFINITE_KEY_PATTERNS`)**: OpenAI/Anthropic `sk-*`, Stripe `sk_live_*`, Google `AIza*`, GitHub `ghp_*`, Slack `xoxb-*`, AWS `AKIA*`
 
@@ -82,6 +83,8 @@ Playwright headless Chromium으로 실제 렌더링 검증:
 - 24개 구체적 수정 지침
 
 **담당**: `qualityLoop.shouldRetryGeneration()`, `buildQualityImprovementPrompt()`
+
+> **타임아웃**: 각 재생성 반복은 `QUALITY_LOOP_ITERATION_TIMEOUT_MS`(기본 120초) 타임아웃 적용. 단일 반복에서 AI 응답이 없으면 해당 반복을 건너뛰고 현재 최선 결과를 유지.
 
 ### Step 5: 재생성 코드 재검증
 
@@ -190,6 +193,7 @@ ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 
 | 날짜 | 변경 |
 |------|------|
+| 2026-04-29 | Phase 2 품질 개선: 인라인 스크립트 탐지 error→warning, Quality Loop 반복당 타임아웃(`QUALITY_LOOP_ITERATION_TIMEOUT_MS`) 추가 |
 | 2026-04-04 | 초안 작성 — Phase 1(코드 레벨) + Phase 2(렌더링 QC) + 격차 해소 |
 | 2026-04-05 | 임계값 40→60, 재시도 최대 2회, Deep QC 조건부 실행, 푸터/레이아웃 체크 추가 |
 | 2026-04-12 | Railway 활성화 가이드 추가 (Dockerfile 수정 방법, 메모리 요구사항) |

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -799,6 +799,8 @@ QC 통계 조회
     "data": {
         "period": { "from": "2026-04-05", "to": "2026-04-12", "days": 7 },
         "totalGenerations": 150,
+        "failureCount": 8,
+        "realSuccessRate": 0.95,
         "avgStructuralScore": 8.5,
         "avgMobileScore": 7.2,
         "avgRenderingQcScore": 6.8,
@@ -811,6 +813,21 @@ QC 통계 조회
     }
 }
 ```
+
+**응답 필드:**
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `period` | object | 조회 기간 (`from`, `to`, `days`) |
+| `totalGenerations` | number | 기간 내 완료된 생성 건수 |
+| `failureCount` | number | 기간 내 생성 실패 횟수 (`CODE_GENERATION_FAILED` 이벤트 집계) |
+| `realSuccessRate` | number | 실제 성공률 = 성공 생성 / 전체 시도 (0.0 ~ 1.0) |
+| `avgStructuralScore` | number | 평균 구조 QC 점수 |
+| `avgMobileScore` | number | 평균 모바일 QC 점수 |
+| `avgRenderingQcScore` | number | 평균 렌더링 QC 점수 |
+| `qcPassRate` | number | QC 통과율 (0.0 ~ 1.0) |
+| `qualityLoopUsageRate` | number | Quality Loop 사용률 (0.0 ~ 1.0) |
+| `deepQcFailedCount` | number | Deep QC 실패 건수 |
+| `commonFailures` | array | 빈도 상위 실패 체크 목록 |
 
 ### POST /api/v1/admin/trigger-qc
 특정 프로젝트에 대한 수동 QC 실행 (`ENABLE_RENDERING_QC=true` 필요)

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -37,6 +37,7 @@
 | `ANTHROPIC_API_KEY` | ✅ | ✅ | Claude API 키 |
 | `AI_MODEL_SUGGESTION` | 선택 | ➖ | 컨텍스트 추천용 모델 (기본: `claude-haiku-4-5`). 허용값: `claude-haiku-4-5` · `claude-sonnet-4-6` · `claude-opus-4-6` · `claude-opus-4-7` |
 | `AI_MODEL_GENERATION` | 선택 | ➖ | 코드 생성용 모델 (기본: `claude-opus-4-7`). 허용값 동일. **주의**: 날짜 suffix 포함 ID(예: `claude-haiku-4-5-20251001`)는 Anthropic 404 반환 |
+| `ET_COMPLEXITY_THRESHOLD` | 선택 | ➖ | Extended Thinking 활성화 복잡도 임계값 (기본: `35`). 0-100 점수 중 이 값 이상이면 ET 활성화 |
 
 ---
 
@@ -90,6 +91,7 @@
 | 변수 | 기본값 | Railway | 설명 |
 |------|--------|---------|------|
 | `ENABLE_RENDERING_QC` | `false` | ❌ | Playwright 렌더링 QC 활성화 |
+| `QUALITY_LOOP_ITERATION_TIMEOUT_MS` | `120000` | ➖ | 품질 루프 반복당 타임아웃 (ms). 단일 반복에서 AI 응답 없을 시 해당 반복 스킵 |
 
 ---
 

--- a/docs/superpowers/specs/2026-04-27-component-test-design.md
+++ b/docs/superpowers/specs/2026-04-27-component-test-design.md
@@ -1,0 +1,257 @@
+# 설계 문서: React 컴포넌트 테스트 도입
+
+**날짜**: 2026-04-27  
+**상태**: 승인됨  
+**우선순위**: A안 첫 번째 항목 (안정성 우선)
+
+---
+
+## 1. 배경 및 목표
+
+### 현황
+
+- 컴포넌트 총 32개, 테스트 파일 2개 (PublishDialog, RePromptSection) — 커버리지 약 6%
+- `vitest.config.ts`의 `coverage.include`에서 `src/components/**` 제외됨
+- `@testing-library/react`는 이미 devDependency에 존재
+- 기존 1,129개 Vitest 테스트는 `node` 환경으로 안정적으로 운영 중
+
+### 목표
+
+- UI 회귀(regression) 방지 — 사용자가 경험하는 화면이 정확히 동작하는지 검증
+- SonarCloud 커버리지 측정 대상에 `src/components/**` 포함
+- 기존 1,129개 테스트에 영향 없이 컴포넌트 테스트 환경 추가
+
+### 범위 밖
+
+- `GenerationProgress`, `RePromptPanel`, `Header`, `ProjectGrid` — SSE·인증 복합 의존으로 단위 테스트 비효율. E2E 영역으로 분류
+- Playwright E2E 테스트 신규 작성 (별도 작업)
+- Storybook 도입 (별도 검토)
+
+---
+
+## 2. 접근법 결정
+
+### 검토한 세 가지 방식
+
+| 방식 | 설명 | 기존 테스트 영향 | 채택 여부 |
+|------|------|----------------|----------|
+| A. 전역 환경 변경 | `vitest.config.ts`의 `environment`를 `happy-dom`으로 변경 | 1,129개 재검증 필요 | ❌ |
+| **B. 파일별 지시자** | 각 테스트 파일 첫 줄에 `// @vitest-environment happy-dom` | **영향 없음** | ✅ |
+| C. Workspace 분리 | `vitest.workspace.ts`로 환경 분리 | 없음, 설정 복잡 | ❌ |
+
+### 선택: B (파일별 환경 지시자)
+
+- `PublishDialog.test.tsx`, `RePromptSection.test.tsx`에서 이미 검증된 패턴
+- 기존 API 라우트·lib·서비스·Repository 테스트 완전 보호
+- 추가 설정 파일 없이 기존 인프라 활용
+
+---
+
+## 3. 설정 변경
+
+### 3.1 vitest.config.ts
+
+```typescript
+coverage: {
+  include: [
+    'src/lib/**',
+    'src/services/**',
+    'src/providers/**',
+    'src/repositories/**',
+    'src/components/**',   // ← 추가
+  ],
+}
+```
+
+임계값은 현행 유지 (컴포넌트 커버리지는 측정 시작만 목표, 강제 임계값 미적용).
+
+### 3.2 신규 파일 3개
+
+#### `src/test/mocks/zustand.ts`
+Zustand store mock 팩토리. 컴포넌트 테스트에서 store를 주입할 때 사용.
+
+```typescript
+// 패턴 예시
+export function mockThemeStore(overrides = {}) {
+  return { theme: 'light', setTheme: vi.fn(), ...overrides };
+}
+export function mockContextStore(overrides = {}) {
+  return { designPreferences: null, setDesignPreferences: vi.fn(), ...overrides };
+}
+```
+
+#### `src/test/helpers/component.ts`
+`@testing-library/react`의 `render`를 래핑. 추후 Provider 추가 시 단일 지점 수정.
+
+```typescript
+import { render, type RenderOptions } from '@testing-library/react';
+import type { ReactElement } from 'react';
+
+export function renderComponent(ui: ReactElement, options?: RenderOptions) {
+  return render(ui, options);
+}
+
+export * from '@testing-library/react';
+```
+
+#### 파일 선두 지시자 규칙
+모든 `*.test.tsx` 파일 첫 줄:
+```typescript
+// @vitest-environment happy-dom
+```
+
+---
+
+## 4. 테스트 대상 컴포넌트
+
+### Phase 1 — 순수 UI (2주)
+
+외부 의존성이 최소이고 비즈니스 중요도가 높은 컴포넌트 우선.
+
+| 컴포넌트 | 위치 | 핵심 테스트 케이스 | Mock 필요 |
+|---------|------|-----------------|----------|
+| `StepIndicator` | `builder/` | 현재 단계 강조, 완료 체크마크, 연결선 색상 | 없음 |
+| `CategoryTabs` | `catalog/` | 활성 탭 스타일, 클릭 시 onCategoryChange 호출 | 없음 |
+| `ApiCard` | `catalog/` | 선택/미선택 상태, 배지 렌더링, onClick 콜백 | 없음 |
+| `GuideQuestions` | `builder/` | 토글 열림·닫힘, onInsert 콜백 | 없음 |
+| `ApiDetailModal` | `catalog/` | ESC 키 닫기, 배경 클릭 닫기, 엔드포인트 표시 | 없음 |
+| `ApiSearchBar` | `catalog/` | debounce 동작, clear 버튼, vi.useFakeTimers 사용 | 없음 |
+| `ContextSuggestions` | `builder/` | 로딩 skeleton, 추천 카드 렌더링, 선택 콜백 | 없음 |
+
+### Phase 2 — 상태 + 이벤트 (2주)
+
+상태 관리·Next.js router·clipboard 등 mock이 필요한 컴포넌트.
+
+| 컴포넌트 | 위치 | 핵심 테스트 케이스 | Mock 필요 |
+|---------|------|-----------------|----------|
+| `ProjectCard` | `dashboard/` | 상태 배지, clipboard 복사, buildPublishUrl | `next/navigation`, `navigator.clipboard` |
+| `ApiRecommendations` | `builder/` | 로딩·에러·추천 3분기 렌더링 | 없음 (props 기반) |
+| `BuilderModeToggle` | `builder/` | 모드 텍스트 표시, onReset 콜백 | 없음 |
+| `TemplateSelector` | `builder/` | 12개 템플릿 버튼, AI 배지 | 없음 |
+| `CatalogView` | `catalog/` | 검색어 필터링, 카테고리 필터, 모달 열기 | 없음 |
+| `ProjectPublishActions` | `dashboard/` | 슬러그 유무 분기, PublishDialog 열기 | `next/navigation`, `usePublish` hook |
+| `ApiKeyGuideModal` | `settings/` | 가이드 내용 렌더링, 닫기 버튼 | 없음 |
+
+### Phase 3+ (보류)
+
+| 컴포넌트 | 보류 이유 |
+|---------|----------|
+| `GenerationProgress` | SSE 스트림·interval 복합 상태 |
+| `RePromptPanel` | SSE 폴링·fetch mock 복잡 |
+| `Header` | useAuth·useAuthStore·useRouter 복합 |
+| `ProjectGrid` | DELETE fetch 통합 |
+| `PreviewFrame` | iframe sandbox 환경 |
+
+---
+
+## 5. Mock 전략
+
+### Next.js Navigation
+
+```typescript
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn(), back: vi.fn() }),
+  usePathname: () => '/dashboard',
+}));
+```
+
+### Zustand Store
+
+```typescript
+vi.mock('@/stores/themeStore', () => ({
+  useThemeStore: () => mockThemeStore(),
+}));
+```
+
+### Clipboard API
+
+```typescript
+beforeEach(() => {
+  vi.stubGlobal('navigator', {
+    clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
+});
+afterEach(() => { vi.unstubAllGlobals(); });
+```
+
+### 타이머 (ApiSearchBar debounce)
+
+```typescript
+beforeEach(() => { vi.useFakeTimers(); });
+afterEach(() => { vi.useRealTimers(); });
+
+it('300ms debounce 후 onChange 호출', async () => {
+  await userEvent.type(input, 'test');
+  expect(onChange).not.toHaveBeenCalled();
+  vi.advanceTimersByTime(300);
+  expect(onChange).toHaveBeenCalledWith('test');
+});
+```
+
+---
+
+## 6. 파일 구조 (완료 후)
+
+```
+src/
+├── test/
+│   ├── mocks/
+│   │   ├── handlers.ts          (기존)
+│   │   ├── server.ts            (기존)
+│   │   └── zustand.ts           ← 신규
+│   ├── helpers/
+│   │   └── component.ts         ← 신규
+│   └── setup.ts                 (기존)
+└── components/
+    ├── builder/
+    │   ├── StepIndicator.test.tsx       ← Phase 1
+    │   ├── GuideQuestions.test.tsx      ← Phase 1
+    │   ├── ContextSuggestions.test.tsx  ← Phase 1
+    │   ├── ApiRecommendations.test.tsx  ← Phase 2
+    │   ├── BuilderModeToggle.test.tsx   ← Phase 2
+    │   └── TemplateSelector.test.tsx    ← Phase 2
+    ├── catalog/
+    │   ├── CategoryTabs.test.tsx        ← Phase 1
+    │   ├── ApiCard.test.tsx             ← Phase 1
+    │   ├── ApiSearchBar.test.tsx        ← Phase 1
+    │   ├── ApiDetailModal.test.tsx      ← Phase 1
+    │   └── CatalogView.test.tsx         ← Phase 2
+    ├── dashboard/
+    │   ├── PublishDialog.test.tsx       (기존)
+    │   ├── RePromptSection.test.tsx     (기존)
+    │   ├── ProjectCard.test.tsx         ← Phase 2
+    │   └── ProjectPublishActions.test.tsx ← Phase 2
+    └── settings/
+        └── ApiKeyGuideModal.test.tsx    ← Phase 2
+```
+
+---
+
+## 7. 예상 성과
+
+| 지표 | 현재 | Phase 1 완료 | Phase 2 완료 |
+|------|------|-------------|-------------|
+| 컴포넌트 테스트 파일 | 2개 | 9개 | 16개 |
+| 전체 Vitest 테스트 수 | 1,129개 | ~1,150개 | ~1,185개 |
+| 컴포넌트 커버리지 (측정 시작) | 미측정 | 측정 시작 | ~50%+ |
+| SonarCloud 대상 | lib/services/providers/repositories | + components | + components |
+
+---
+
+## 8. 리스크 및 완화
+
+| 리스크 | 확률 | 완화 방안 |
+|--------|------|---------|
+| 기존 1,129개 테스트 회귀 | 낮음 | 파일별 지시자 방식으로 환경 격리 |
+| Zustand mock 누락으로 테스트 실패 | 중간 | `src/test/mocks/zustand.ts` 팩토리 선 작성 후 컴포넌트 테스트 시작 |
+| debounce/timer 테스트 flake | 중간 | `vi.useFakeTimers()` + `vi.useRealTimers()` afterEach 철저히 적용 |
+| `@vitest-environment` 지시자 누락 | 중간 | PR 체크리스트 항목으로 추가 |
+
+---
+
+## 9. 연관 결정 사항 (로드맵 조정)
+
+이번 설계 세션에서 확정된 로드맵 변경:
+
+- **Item 2 (RBAC/팀·조직)**: 조건부 보류 — 팀 기능 실사용자 요청이 발생할 때 재검토
+- **Item 3 (React/Vite + esbuild)**: 조건부 보류 — Alpine.js 한계 사례 월 50건 이상 또는 복잡한 상태 관리 필요 비율 10% 초과 시 재검토

--- a/src/__tests__/api/admin.test.ts
+++ b/src/__tests__/api/admin.test.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ---------- Module mocks ----------
+const mockSupabaseChain = {
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  gte: vi.fn().mockResolvedValue({ count: 0, error: null }),
+};
+
 vi.mock('@/lib/supabase/server', () => ({
-  createServiceClient: vi.fn().mockResolvedValue({}),
+  createServiceClient: vi.fn().mockResolvedValue({
+    from: vi.fn().mockReturnValue(mockSupabaseChain),
+  }),
 }));
 
 vi.mock('@/repositories/codeRepository', () => ({

--- a/src/app/api/v1/admin/qc-stats/route.ts
+++ b/src/app/api/v1/admin/qc-stats/route.ts
@@ -19,8 +19,16 @@ export async function GET(request: Request): Promise<Response> {
 
       const supabase = await createServiceClient();
       const codeRepo = new CodeRepository(supabase);
-      const codes = await codeRepo.findMetadataByDateRange(from);
+      const [codes, failureCountResult] = await Promise.all([
+        codeRepo.findMetadataByDateRange(from),
+        supabase
+          .from('platform_events')
+          .select('id', { count: 'exact', head: true })
+          .eq('type', 'CODE_GENERATION_FAILED')
+          .gte('created_at', from.toISOString()),
+      ]);
 
+      const failureCount = failureCountResult.count ?? 0;
       const total = codes.length;
       if (total === 0) {
         return jsonResponse({
@@ -28,6 +36,8 @@ export async function GET(request: Request): Promise<Response> {
           data: {
             period: { from: from.toISOString().split('T')[0], to: now.toISOString().split('T')[0], days },
             totalGenerations: 0,
+            failureCount,
+            realSuccessRate: 0,
             avgStructuralScore: 0,
             avgMobileScore: 0,
             avgRenderingQcScore: 0,
@@ -80,11 +90,14 @@ export async function GET(request: Request): Promise<Response> {
         .sort((a, b) => b.failCount - a.failCount)
         .slice(0, 10);
 
+      const totalAttempts = total + failureCount;
       return jsonResponse({
         success: true,
         data: {
           period: { from: from.toISOString().split('T')[0], to: now.toISOString().split('T')[0], days },
           totalGenerations: total,
+          failureCount,
+          realSuccessRate: totalAttempts > 0 ? Math.round((total / totalAttempts) * 100) / 100 : 1,
           avgStructuralScore: Math.round((sumStructural / total) * 10) / 10,
           avgMobileScore: Math.round((sumMobile / total) * 10) / 10,
           avgRenderingQcScore: qcCount > 0 ? Math.round((sumQc / qcCount) * 10) / 10 : 0,

--- a/src/lib/ai/codeValidator.test.ts
+++ b/src/lib/ai/codeValidator.test.ts
@@ -31,10 +31,18 @@ describe('validateSecurity', () => {
     expect(result.errors).toHaveLength(0);
   });
 
-  it('인라인 script 태그가 있으면 에러를 반환한다', () => {
+  it('인라인 script 태그가 있으면 경고를 반환하고 패스한다', () => {
     const result = validateSecurity('<script>alert(1)</script>');
-    expect(result.passed).toBe(false);
-    expect(result.errors.some((e) => e.includes('인라인 스크립트'))).toBe(true);
+    expect(result.passed).toBe(true);
+    expect(result.errors.some((e) => e.includes('인라인 스크립트'))).toBe(false);
+    expect(result.warnings.some((w) => w.includes('인라인 스크립트'))).toBe(true);
+  });
+
+  it('script type="module" 태그는 경고만 발생하고 패스한다', () => {
+    const result = validateSecurity('<script type="module">import { x } from "./x.js"</script>');
+    expect(result.passed).toBe(true);
+    expect(result.errors.some((e) => e.includes('인라인 스크립트'))).toBe(false);
+    expect(result.warnings.some((w) => w.includes('인라인 스크립트'))).toBe(true);
   });
 
   it('src 속성이 있는 script 태그는 차단하지 않는다', () => {

--- a/src/lib/ai/codeValidator.ts
+++ b/src/lib/ai/codeValidator.ts
@@ -32,9 +32,9 @@ export function validateSecurity(code: string): ValidationResult {
     errors.push('eval() 사용이 감지되었습니다. 보안상 허용되지 않습니다.');
   }
 
-  // Block: inline script tags (src= 속성 없는 경우만 — CDN 태그는 허용)
+  // Warn: inline script tags (assembleHtml strips them anyway; warn instead of block)
   if (/<script(?!\s[^>]*\bsrc\s*=)[^>]*>/i.test(code)) {
-    errors.push('AI 생성 코드에 인라인 스크립트는 허용되지 않습니다.');
+    warnings.push('AI 생성 코드에 인라인 스크립트가 감지되었습니다. 렌더링 시 자동으로 제거됩니다.');
   }
 
   // Block: definite hardcoded key formats

--- a/src/lib/ai/generationPipeline.ts
+++ b/src/lib/ai/generationPipeline.ts
@@ -265,10 +265,12 @@ ${featureList}
       try {
         stage3Result = await runStage3(stage2Result.parsed, input.stage2SystemPrompt, input.buildStage2UserPrompt, aiProvider, sse, !needsStage2);
       } catch (stage3Err) {
+        const stage3ErrMsg = stage3Err instanceof Error ? stage3Err.message : String(stage3Err);
         logger.warn('Stage 3 (design polish) failed — falling back to Stage 2 result', {
           projectId,
-          error: stage3Err instanceof Error ? stage3Err.message : String(stage3Err),
+          error: stage3ErrMsg,
         });
+        eventBus.emit({ type: 'STAGE3_FALLBACK_USED', payload: { projectId, error: stage3ErrMsg } });
         sse.send('progress', { step: 'stage3_fallback', progress: 85, message: '디자인 적용 중 오류 — 기능 검증 버전으로 진행합니다.' });
         generationTracker.updateProgress(projectId, 85, 'stage3_fallback', '디자인 적용 중 오류 — 기능 검증 버전으로 진행합니다.');
         stage3Result = { ...stage2Result, durationMs: 0, tokensUsed: { input: 0, output: 0 }, userPrompt: '' };

--- a/src/lib/ai/qualityLoop.test.ts
+++ b/src/lib/ai/qualityLoop.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { shouldRetryGeneration, buildQualityImprovementPrompt } from './qualityLoop';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { shouldRetryGeneration, buildQualityImprovementPrompt, runQualityLoop } from './qualityLoop';
 import type { QualityMetrics } from '@/lib/ai/codeValidator';
+import type { IAiProvider } from '@/providers/ai/IAiProvider';
+import type { SseWriter } from '@/lib/ai/sseWriter';
 
 const baseMetrics: QualityMetrics = {
   structuralScore: 80, mobileScore: 80,
@@ -124,5 +126,61 @@ describe('buildQualityImprovementPrompt', () => {
       null,
     );
     expect(prompt).toMatch(/fetch|API 호출/i);
+  });
+});
+
+describe('runQualityLoop — iteration timeout', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it('타임아웃 발생 시 해당 반복을 건너뛰고 최초 결과를 반환한다', async () => {
+    vi.stubEnv('QUALITY_LOOP_ITERATION_TIMEOUT_MS', '100');
+
+    const lowQualityMetrics: QualityMetrics = {
+      ...baseMetrics,
+      structuralScore: 30,
+      mobileScore: 30,
+      hasSemanticHtml: false,
+      hasInteraction: false,
+      hasFooter: false,
+      details: ['품질 부족'],
+    };
+
+    const mockProvider: IAiProvider = {
+      name: 'mock',
+      model: 'mock',
+      generateCode: vi.fn().mockReturnValue(new Promise(() => {})), // 절대 완료되지 않음
+      generateCodeStream: vi.fn(),
+      checkAvailability: vi.fn(),
+    };
+
+    const mockSse: SseWriter = {
+      send: vi.fn(),
+      isCancelled: vi.fn().mockReturnValue(false),
+    };
+
+    const initialParsed = { html: '<div>초기</div>', css: 'body{}', js: 'fetch("/api/v1/proxy")' };
+
+    const loopPromise = runQualityLoop(
+      initialParsed,
+      lowQualityMetrics,
+      null,
+      'stage2 system prompt',
+      mockProvider,
+      mockSse,
+      false,
+      'test-project-id',
+    );
+
+    // 100ms 타임아웃 × 3회 반복 + 여유 시간
+    await vi.advanceTimersByTimeAsync(400);
+    const result = await loopPromise;
+
+    // 타임아웃으로 개선 없음 → 초기 결과 그대로 반환
+    expect(result.parsed).toEqual(initialParsed);
+    expect(result.qualityLoopUsed).toBe(false);
   });
 });

--- a/src/lib/ai/qualityLoop.ts
+++ b/src/lib/ai/qualityLoop.ts
@@ -157,7 +157,17 @@ export async function runQualityLoop(
 
     try {
       const improvementPrompt = buildQualityImprovementPrompt(bestParsed, bestQuality, bestQcReport);
-      const retryResponse = await aiProvider.generateCode({ system: stage2SystemPrompt, user: improvementPrompt, extendedThinking: useET });
+      const iterationTimeoutMs = Number(process.env.QUALITY_LOOP_ITERATION_TIMEOUT_MS ?? 120_000);
+      const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`Quality loop iteration timed out after ${iterationTimeoutMs}ms`)),
+          iterationTimeoutMs,
+        )
+      );
+      const retryResponse = await Promise.race([
+        aiProvider.generateCode({ system: stage2SystemPrompt, user: improvementPrompt, extendedThinking: useET }),
+        timeoutPromise,
+      ]);
       const retryParsed = parseGeneratedCode(retryResponse.content);
 
       if (retryParsed.html) {

--- a/src/providers/ai/ClaudeProvider.test.ts
+++ b/src/providers/ai/ClaudeProvider.test.ts
@@ -189,6 +189,49 @@ describe('ClaudeProvider', () => {
       vi.useRealTimers();
     });
 
+    it('429 Retry-After 헤더가 있으면 해당 시간 후 재시도한다', async () => {
+      mockCreate
+        .mockRejectedValueOnce({ status: 429, headers: { 'retry-after': '3' } })
+        .mockResolvedValueOnce({
+          content: [{ type: 'text', text: 'ok after retry-after' }],
+          usage: { input_tokens: 10, output_tokens: 10 },
+        });
+
+      const promise = provider.generateCode({ system: 'sys', user: 'user' });
+
+      // 2999ms — 아직 재시도 안 됨 (retry-after: 3초)
+      await vi.advanceTimersByTimeAsync(2999);
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      // 1ms 더 — 3000ms 도달, 재시도 실행
+      await vi.advanceTimersByTimeAsync(1);
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+
+      const result = await promise;
+      expect(result.content).toBe('ok after retry-after');
+    });
+
+    it('429 Retry-After 헤더가 없으면 기존 지수 백오프(1000ms)를 사용한다', async () => {
+      mockCreate
+        .mockRejectedValueOnce({ status: 429 }) // headers 없음
+        .mockResolvedValueOnce({
+          content: [{ type: 'text', text: 'ok fallback backoff' }],
+          usage: { input_tokens: 10, output_tokens: 10 },
+        });
+
+      const promise = provider.generateCode({ system: 'sys', user: 'user' });
+
+      // 999ms — 아직 재시도 안 됨
+      await vi.advanceTimersByTimeAsync(999);
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      // 1ms 더 — 1000ms, 재시도
+      await vi.advanceTimersByTimeAsync(1);
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+
+      await promise;
+    });
+
     it('첫 시도 성공 → 1회 호출, 정상 반환', async () => {
       mockCreate.mockResolvedValueOnce({
         content: [{ type: 'text', text: 'success' }],

--- a/src/providers/ai/ClaudeProvider.ts
+++ b/src/providers/ai/ClaudeProvider.ts
@@ -30,6 +30,19 @@ async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Retry-After 헤더가 있으면 그 값(초→밀리초)을 반환, 없으면 지수 백오프 값 반환 */
+function getRetryAfterMs(error: unknown, attempt: number): number {
+  if (error !== null && typeof error === 'object' && 'headers' in error) {
+    const headers = (error as { headers: unknown }).headers;
+    if (headers !== null && typeof headers === 'object' && 'retry-after' in headers) {
+      const val = (headers as Record<string, unknown>)['retry-after'];
+      const ms = Number(val) * 1000;
+      if (!Number.isNaN(ms) && ms > 0) return ms;
+    }
+  }
+  return RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+}
+
 /** 지수 백오프 재시도 래퍼. 재시도 가능한 에러에 대해 최대 MAX_RETRIES 회 재시도. */
 async function withRetry<T>(fn: (attempt: number) => Promise<T>, logTag: string): Promise<T> {
   let lastError: unknown;
@@ -37,7 +50,7 @@ async function withRetry<T>(fn: (attempt: number) => Promise<T>, logTag: string)
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       if (attempt > 0) {
-        const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+        const delay = getRetryAfterMs(lastError, attempt);
         logger.warn(`${logTag} retry ${attempt}/${MAX_RETRIES}`, { delay });
         await sleep(delay);
       }
@@ -73,7 +86,7 @@ export class ClaudeProvider implements IAiProvider {
   private client: Anthropic;
 
   constructor(apiKey: string, model = 'claude-sonnet-4-6') {
-    this.client = new Anthropic({ apiKey });
+    this.client = new Anthropic({ apiKey, timeout: 270_000 }); // 270s — Railway 300s 컷 전 안전 종료
     this.model = model;
   }
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -52,6 +52,10 @@ export type DomainEvent =
   | {
       type: 'QC_REPORT_FAILED';
       payload: { projectId: string; stage: 'fast' | 'deep'; error: string };
+    }
+  | {
+      type: 'STAGE3_FALLBACK_USED';
+      payload: { projectId: string; error: string };
     };
 
 export type DomainEventType = DomainEvent['type'];


### PR DESCRIPTION
## Summary

- **Task 1** `ClaudeProvider`: SDK 타임아웃 270초 설정(Railway 300초 컷 안전 마진), 429 `Retry-After` 헤더 준수 지수 백오프 대체
- **Task 2** `qualityLoop`: per-iteration 타임아웃 추가(`QUALITY_LOOP_ITERATION_TIMEOUT_MS`, 기본 120초) — 단일 반복이 전체 루프를 블로킹하는 문제 해소
- **Task 3** `codeValidator`: 인라인 스크립트 탐지를 `error → warning`으로 강등 — `assembleHtml()`이 DOMPurify로 자동 제거하므로 파이프라인 불필요 차단 방지
- **Task 4** `generationPipeline`: Stage 3 fallback 시 `STAGE3_FALLBACK_USED` 이벤트 발행 — `platform_events` 테이블에 자동 기록되어 빈도 추적 가능
- **Task 5** `admin/qc-stats`: `failureCount` + `realSuccessRate` 지표 추가 — `CODE_GENERATION_FAILED` 이벤트 집계로 실제 성공률(성공 생성 / 전체 시도) 측정
- **Task 6** `ai-pipeline.md`: ET 임계값 문서 동기화 (45점 → 35점, 코드와 불일치 수정)

## Test plan

- [ ] `pnpm test` — 1225/1225 통과 확인
- [ ] `pnpm type-check` — 에러 없음 확인
- [ ] `pnpm lint` — 경고 없음 확인
- [ ] `pnpm build` — 프로덕션 빌드 성공 확인
- [ ] Railway CI 통과 후 배포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)