### PR TITLE
test: Quality Loop retry 채택 분기 커버리지 보강 (#60 후속)

### DIFF
--- a/src/lib/ai/qualityLoop.adoption.test.ts
+++ b/src/lib/ai/qualityLoop.adoption.test.ts
@@ -1,0 +1,236 @@
+// Quality Loop의 retry 채택 분기(qualityLoop.ts:211-214)와 QC 활성 분기(:188-190) 테스트.
+// 기존 qualityLoop.test.ts는 실제 evaluateQuality를 사용해 retry 채택 시나리오를 만들기 어려워
+// 이 파일에서 evaluateQuality를 mock하여 채택 결정만 격리해 검증한다.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { QualityMetrics } from '@/lib/ai/codeValidator';
+import type { IAiProvider } from '@/providers/ai/IAiProvider';
+import type { SseWriter } from '@/lib/ai/sseWriter';
+import type { QcReport } from '@/types/qc';
+
+vi.mock('@/lib/events/eventBus', () => ({
+  eventBus: { emit: vi.fn() },
+}));
+
+vi.mock('@/lib/ai/codeValidator', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/ai/codeValidator')>('@/lib/ai/codeValidator');
+  return { ...actual, evaluateQuality: vi.fn() };
+});
+
+vi.mock('@/lib/qc', () => ({
+  runFastQc: vi.fn(),
+  isQcEnabled: vi.fn(),
+}));
+
+import { runQualityLoop } from './qualityLoop';
+import { evaluateQuality } from '@/lib/ai/codeValidator';
+import { runFastQc, isQcEnabled } from '@/lib/qc';
+
+const baseMetrics: QualityMetrics = {
+  structuralScore: 80, mobileScore: 80,
+  hasSemanticHtml: true, hasMockData: false, hasInteraction: true,
+  hasResponsiveClasses: true, hasAdequateResponsive: true, noFixedOverflow: true,
+  hasImageProtection: true, hasMobileNav: true, hasFooter: true, hasImgAlt: true,
+  fetchCallCount: 1, hasProxyCall: true, hasJsonParse: true, placeholderCount: 0,
+  hardcodedArrayCount: 0,
+  details: [],
+};
+
+const lowQuality: QualityMetrics = {
+  ...baseMetrics,
+  structuralScore: 30,
+  mobileScore: 30,
+};
+
+const validRetryContent =
+  '### HTML\n```html\n' +
+  '<main>' + '<p>retry</p>'.repeat(20) + '</main>\n' +
+  '```\n### CSS\n```css\nbody{margin:0;padding:0;display:flex}\n```\n' +
+  '### JavaScript\n```javascript\nfetch("/api/v1/proxy")\n```';
+
+function makeMockSse(): SseWriter {
+  return { send: vi.fn(), isCancelled: vi.fn().mockReturnValue(false) };
+}
+
+function makeMockProvider(generateCode: ReturnType<typeof vi.fn>): IAiProvider {
+  return {
+    name: 'mock',
+    model: 'mock',
+    generateCode: generateCode as unknown as IAiProvider['generateCode'],
+    generateCodeStream: vi.fn(),
+    checkAvailability: vi.fn(),
+  };
+}
+
+describe('runQualityLoop — retry 채택 분기 (Quality Loop 정확도 게이트)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(isQcEnabled).mockReturnValue(false);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it('retry quality가 둘 다 향상되면 채택한다 (strict 모드 기본)', async () => {
+    // 초기 quality는 낮음(shouldRetry=true 트리거) → retry는 둘 다 향상 → 채택
+    vi.mocked(evaluateQuality).mockReturnValueOnce({
+      ...baseMetrics,
+      structuralScore: 90,
+      mobileScore: 90,
+    });
+
+    const generateCode = vi.fn().mockResolvedValueOnce({ content: validRetryContent });
+
+    const result = await runQualityLoop(
+      { html: '<div>old</div>', css: '', js: '' },
+      lowQuality,
+      null,
+      'sys',
+      makeMockProvider(generateCode),
+      makeMockSse(),
+      false,
+      'p-adopt-1',
+    );
+
+    expect(result.qualityLoopUsed).toBe(true);
+    expect(result.quality.structuralScore).toBe(90);
+    expect(result.quality.mobileScore).toBe(90);
+  });
+
+  it('retry quality 한쪽 향상 + 한쪽 동등은 채택한다 (strict 모드 boundary)', async () => {
+    // strict 모드에서 (struct↑ + mobile=) 또는 (mobile↑ + struct=)는 채택 (AND 가드)
+    vi.mocked(evaluateQuality).mockReturnValueOnce({
+      ...baseMetrics,
+      structuralScore: 50,
+      mobileScore: 30, // 동등
+    });
+
+    const generateCode = vi.fn().mockResolvedValueOnce({ content: validRetryContent });
+
+    const result = await runQualityLoop(
+      { html: '<div>old</div>', css: '', js: '' },
+      lowQuality,
+      null,
+      'sys',
+      makeMockProvider(generateCode),
+      makeMockSse(),
+      false,
+      'p-adopt-2',
+    );
+
+    expect(result.qualityLoopUsed).toBe(true);
+    expect(result.quality.structuralScore).toBe(50);
+  });
+
+  it('retry quality 한쪽 향상 + 한쪽 회귀는 strict 모드에서 거부한다', async () => {
+    // strict 가드: structuralScore↑ but mobileScore↓ → 거부
+    // shouldRetryGeneration이 다음 attempt에서 또 true가 되도록 retry quality는 여전히 미달
+    vi.mocked(evaluateQuality).mockReturnValue({
+      ...baseMetrics,
+      structuralScore: 50,
+      mobileScore: 20, // 회귀
+    });
+
+    const generateCode = vi.fn().mockResolvedValue({ content: validRetryContent });
+
+    const result = await runQualityLoop(
+      { html: '<div>old</div>', css: '', js: '' },
+      lowQuality,
+      null,
+      'sys',
+      makeMockProvider(generateCode),
+      makeMockSse(),
+      false,
+      'p-adopt-3',
+    );
+
+    expect(result.qualityLoopUsed).toBe(false);
+    expect(result.parsed.html).toContain('<div>old</div>'); // 초기 유지
+  });
+
+  it('QUALITY_LOOP_STRICT_ADOPTION=false → 한쪽만 향상해도 채택', async () => {
+    vi.stubEnv('QUALITY_LOOP_STRICT_ADOPTION', 'false');
+
+    vi.mocked(evaluateQuality).mockReturnValueOnce({
+      ...baseMetrics,
+      structuralScore: 50,
+      mobileScore: 20, // 회귀이지만 OR 로직이라 채택
+    });
+
+    const generateCode = vi.fn().mockResolvedValueOnce({ content: validRetryContent });
+
+    const result = await runQualityLoop(
+      { html: '<div>old</div>', css: '', js: '' },
+      lowQuality,
+      null,
+      'sys',
+      makeMockProvider(generateCode),
+      makeMockSse(),
+      false,
+      'p-adopt-4',
+    );
+
+    expect(result.qualityLoopUsed).toBe(true);
+    expect(result.quality.structuralScore).toBe(50);
+  });
+
+  it('isQcEnabled=true + runFastQc 성공 → QC 리포트가 채택 결과에 포함된다', async () => {
+    vi.mocked(isQcEnabled).mockReturnValue(true);
+    const retryQcReport: QcReport = {
+      overallScore: 90,
+      passed: true,
+      checks: [],
+    } as unknown as QcReport;
+    vi.mocked(runFastQc).mockResolvedValueOnce(retryQcReport);
+
+    vi.mocked(evaluateQuality).mockReturnValueOnce({
+      ...baseMetrics,
+      structuralScore: 90,
+      mobileScore: 90,
+    });
+
+    const generateCode = vi.fn().mockResolvedValueOnce({ content: validRetryContent });
+
+    const result = await runQualityLoop(
+      { html: '<div>old</div>', css: '', js: '' },
+      lowQuality,
+      null,
+      'sys',
+      makeMockProvider(generateCode),
+      makeMockSse(),
+      false,
+      'p-adopt-qc',
+    );
+
+    expect(runFastQc).toHaveBeenCalled();
+    expect(result.qualityLoopUsed).toBe(true);
+    expect(result.qcReport).toEqual(retryQcReport);
+  });
+
+  it('isQcEnabled=true + runFastQc throw → QC 실패해도 코드 채택은 진행', async () => {
+    vi.mocked(isQcEnabled).mockReturnValue(true);
+    vi.mocked(runFastQc).mockRejectedValueOnce(new Error('QC 실패'));
+
+    vi.mocked(evaluateQuality).mockReturnValueOnce({
+      ...baseMetrics,
+      structuralScore: 90,
+      mobileScore: 90,
+    });
+
+    const generateCode = vi.fn().mockResolvedValueOnce({ content: validRetryContent });
+
+    const result = await runQualityLoop(
+      { html: '<div>old</div>', css: '', js: '' },
+      lowQuality,
+      null,
+      'sys',
+      makeMockProvider(generateCode),
+      makeMockSse(),
+      false,
+      'p-adopt-qc-fail',
+    );
+
+    expect(result.qualityLoopUsed).toBe(true); // QC 실패해도 코드 점수로 채택
+  });
+});


### PR DESCRIPTION
## Summary

PR #60 머지 후 Codecov가 보고한 `qualityLoop.ts` patch coverage 누락(92.85%, 1줄)을 해소합니다. 누락 영역은 **정확도 게이트의 핵심 채택 분기**이므로 회귀 방지 가치가 큽니다.

### 누락 라인 식별 (`pnpm test:coverage` 기준)

| 라인 | 영역 |
|------|------|
| 188-190 | `isQcEnabled=true` + `safeAssembleHtml` 성공 + `runFastQc` 실행 |
| 211-214 | `bestParsed`/`bestQuality` 채택 분기 (`qualityLoopUsed=true`) |

### 원인 분석

기존 `qualityLoop.test.ts`는 실제 `evaluateQuality`를 사용해 retry가 **실제로 채택되는 시나리오**를 만들기 어려웠습니다 (입력 코드를 둘 다 만들어야 함). `evaluateQuality`를 mock한 별도 테스트 파일에서 채택 결정 로직만 격리해 검증합니다.

### 추가 테스트 (6 cases) — `qualityLoop.adoption.test.ts` 신규

- retry quality 둘 다 향상 → strict 모드 채택
- retry quality 한쪽 향상 + 한쪽 동등 → AND 가드 채택 (boundary)
- retry quality 한쪽 향상 + 한쪽 회귀 → strict 모드 거부
- `QUALITY_LOOP_STRICT_ADOPTION=false` → OR 로직 채택
- `isQcEnabled=true` + `runFastQc` 성공 → QC 리포트 채택 결과 포함
- `isQcEnabled=true` + `runFastQc` throw → QC 실패해도 코드 채택 진행

## Test plan

- [x] `pnpm test` — 1388 → 1394 tests 통과
- [x] `pnpm type-check` — 통과
- [x] `pnpm lint` — 통과
- [x] `pnpm test:coverage` — `qualityLoop.ts` coverage **80% → 93.84%** (S12에서 추가된 strict adoption 분기 포함 모두 커버)
- [ ] Codecov 통과 확인 (CI 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEkkQ6FGXoLrFphzUnNKs3)_