### PR TITLE
docs: PR-1 — 문서-코드 정합성 일괄 동기화 (S6/S7/S8/S10/S12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,11 @@ pnpm test:coverage    # 커버리지 리포트
 - `MAX_APIS_PER_PROJECT`, `MAX_DAILY_GENERATIONS` 등 제한 설정
 - `AI_MODEL_SUGGESTION` — 추천용 모델 (기본: `claude-haiku-4-5`)
 - `AI_MODEL_GENERATION` — 코드 생성 모델 (기본: `claude-opus-4-7`, Sonnet 폴백: `claude-sonnet-4-6`)
+- `ET_COMPLEXITY_THRESHOLD` — Extended Thinking 활성화 임계값 (기본: 35점, `evaluateComplexityScore()` 결과 비교)
+- `QUALITY_LOOP_ITERATION_TIMEOUT_MS` — Quality Loop 반복당 타임아웃 (기본: 120000ms = 120초)
+- `QUALITY_LOOP_STRICT_ADOPTION` — Quality Loop retry 채택 가드 (기본: `true`. `false`로 설정 시 한쪽 점수 향상만으로도 채택하는 기존 OR 로직 복원 — 운영 데이터 비교용 롤백 스위치)
+- `QC_QUALITY_THRESHOLD`, `QC_MOBILE_THRESHOLD` — Quality Loop 재시도 트리거 점수 임계값 (각 기본: 60)
+- 전체 환경변수 목록은 [docs/reference/env-vars.md](docs/reference/env-vars.md) 참조
 
 ## 문서 참조
 

--- a/docs/architecture/ai-pipeline.md
+++ b/docs/architecture/ai-pipeline.md
@@ -209,8 +209,12 @@ DB 저장 구조 (code_versions 테이블):
 - **Claude API (Anthropic)** — 기본 Provider
   - 구현: `src/providers/ai/ClaudeProvider.ts`
   - 팩토리: `AiProviderFactory.create()`, `AiProviderFactory.createForTask()`
-  - 모델: **`claude-opus-4-7`** (기본), 태스크별 최적 모델 자동 선택
-  - 환경변수 오버라이드: `AI_MODEL_GENERATION` (코드 생성), `AI_MODEL_SUGGESTION` (slug 제안) — 허용 목록(`claude-*`) 검증 후 적용
+  - 태스크별 모델 (팩토리 기본값):
+    - `generation` (코드 생성): **`claude-opus-4-7`**
+    - `suggestion` (slug/추천): **`claude-haiku-4-5`**
+  - `ClaudeProvider` 클래스 자체 기본값(직접 인스턴스화 시): **`claude-sonnet-4-6`** — 일반적으로는 팩토리를 통해 호출되므로 `generation`/`suggestion` 기본값이 우선 적용됨
+  - 허용 모델: `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-opus-4-7`
+  - 환경변수 오버라이드: `AI_MODEL_GENERATION` (코드 생성), `AI_MODEL_SUGGESTION` (slug 제안) — 허용 목록 검증 후 적용
 
 ### Provider 인터페이스 (`src/providers/ai/IAiProvider.ts`)
 - `generateCode(prompt)` — 단일 응답 생성

--- a/docs/architecture/events.md
+++ b/docs/architecture/events.md
@@ -70,6 +70,20 @@ export type DomainEvent =
   | {
       type: 'STAGE3_FALLBACK_USED';
       payload: { projectId: string; error: string };
+    }
+  | {
+      type: 'STAGE_SKIPPED';
+      payload: { projectId: string; stage: 'stage2' | 'stage3'; reason: string };
+    }
+  | {
+      type: 'QUALITY_LOOP_COMPLETED';
+      payload: {
+        projectId: string;
+        iterations: number;
+        improved: boolean;
+        finalStructuralScore: number;
+        finalMobileScore: number;
+      };
     };
 
 export type DomainEventType = DomainEvent['type'];
@@ -158,3 +172,18 @@ eventBus.emit({
 
 이벤트는 핵심 비즈니스 로직(저장, 상태 변경)이 완료된 후 발행하여,
 구독자(분석, 알림, 모니터링)가 메인 흐름에 영향을 주지 않도록 합니다.
+
+---
+
+## 정확도 가시화 이벤트 (2026-04-30 ADR)
+
+생성 파이프라인의 정확도 게이트 효율성을 시계열로 측정하기 위해 추가된 이벤트:
+
+| 이벤트 | 발행처 | 용도 |
+|--------|--------|------|
+| `STAGE3_FALLBACK_USED` | `generationPipeline.ts` Stage 3 catch | Stage 3 디자인 폴리시 실패 시 Stage 2 결과로 폴백한 빈도 추적 |
+| `STAGE_SKIPPED` | `generationPipeline.ts` Stage 2/3 skip 분기 | Stage 2/3 진입 없이 통과된 비율(파이프라인 효율성) — `payload.stage`로 'stage2'/'stage3' 구분 |
+| `QUALITY_LOOP_COMPLETED` | `qualityLoop.ts` 종료 직후 (loop 미진입 포함, `iterations=0`으로도 발행) | Quality Loop 평균 반복 횟수, 개선 성공률, 최종 점수 분포 |
+
+이 이벤트들은 `eventPersister`가 `platform_events` 테이블에 자동 영속화하며,
+Admin QC Stats API(`/api/v1/admin/qc-stats`)가 이를 집계해 운영 지표로 노출합니다.

--- a/docs/guides/qc-process.md
+++ b/docs/guides/qc-process.md
@@ -91,7 +91,12 @@ Playwright headless Chromium으로 실제 렌더링 검증:
 재생성된 코드에 대해 **Step 2 + Step 3을 다시 실행**:
 - `evaluateQuality()` 재실행
 - `runFastQc()` 재실행
-- 코드 점수 OR QC 점수가 개선되면 채택, 아니면 원본 유지
+- 채택 가드 (2026-04-30 ADR S12로 강화):
+  - **strict 모드 (기본 `QUALITY_LOOP_STRICT_ADOPTION=true`)** — 한 점수 향상 + 다른 점수 동등 이상일 때만 채택. 시소 진동(한쪽 향상 + 다른 쪽 회귀) 방지
+  - **OR 모드 (`QUALITY_LOOP_STRICT_ADOPTION=false`)** — 한쪽 점수만 향상해도 채택 (구 동작, 운영 데이터 비교용 롤백 스위치)
+  - QC 점수 향상은 별도 OR 조건으로 채택 가능
+- 재생성 시 사용자 feedback이 있으면 (`extraMetadata.userFeedback`) 매 반복마다 프롬프트의 "## 사용자 요청" 섹션에 누적 주입 (2026-04-30 ADR S10) — 3회 반복 동안 사용자 요청이 무시되지 않도록 보장
+- Quality Loop 종료 직후 `QUALITY_LOOP_COMPLETED` 이벤트 발행(반복 횟수, 채택 여부, 최종 점수) — 운영 시계열 분석용
 
 ### Step 6: 저장
 
@@ -193,6 +198,7 @@ ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 
 | 날짜 | 변경 |
 |------|------|
+| 2026-04-30 | 정확도 게이트 강화: Quality Loop 채택 가드 AND 모드(`QUALITY_LOOP_STRICT_ADOPTION` 토글), 사용자 feedback 매 반복 누적 주입, `STAGE_SKIPPED`/`QUALITY_LOOP_COMPLETED` 이벤트 발행, Stage 2 트리거에 `hardcodedArrayCount` 포함, placeholder blocklist 단일 출처화(`getPlaceholderBlocklistText()`) |
 | 2026-04-29 | Phase 2 품질 개선: 인라인 스크립트 탐지 error→warning, Quality Loop 반복당 타임아웃(`QUALITY_LOOP_ITERATION_TIMEOUT_MS`) 추가 |
 | 2026-04-04 | 초안 작성 — Phase 1(코드 레벨) + Phase 2(렌더링 QC) + 격차 해소 |
 | 2026-04-05 | 임계값 40→60, 재시도 최대 2회, Deep QC 조건부 실행, 푸터/레이아웃 체크 추가 |

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -807,6 +807,14 @@ QC 통계 조회
         "qcPassRate": 0.85,
         "qualityLoopUsageRate": 0.32,
         "deepQcFailedCount": 5,
+        "stage3FallbackCount": 3,
+        "stage3FallbackRate": 0.02,
+        "stage2SkipCount": 90,
+        "stage3SkipCount": 60,
+        "stage2SkipRate": 0.6,
+        "stage3SkipRate": 0.4,
+        "avgQualityLoopIterations": 0.45,
+        "qualityLoopImprovementRate": 0.78,
         "commonFailures": [
             { "check": "contrast", "failCount": 12, "rate": 0.08 }
         ]
@@ -825,8 +833,16 @@ QC 통계 조회
 | `avgMobileScore` | number | 평균 모바일 QC 점수 |
 | `avgRenderingQcScore` | number | 평균 렌더링 QC 점수 |
 | `qcPassRate` | number | QC 통과율 (0.0 ~ 1.0) |
-| `qualityLoopUsageRate` | number | Quality Loop 사용률 (0.0 ~ 1.0) |
+| `qualityLoopUsageRate` | number | Quality Loop 사용률 (`metadata.qualityLoopUsed` boolean 집계, 0.0 ~ 1.0) |
 | `deepQcFailedCount` | number | Deep QC 실패 건수 |
+| `stage3FallbackCount` | number | Stage 3 디자인 폴리시 실패 → Stage 2 폴백 횟수 (`STAGE3_FALLBACK_USED` 이벤트 집계) |
+| `stage3FallbackRate` | number | Stage 3 폴백 비율 = `stage3FallbackCount / (totalGenerations + failureCount)` |
+| `stage2SkipCount` | number | Stage 2 기능 검증 스킵 횟수 (Stage 1 품질 충분 시) |
+| `stage3SkipCount` | number | Stage 3 디자인 폴리시 스킵 횟수 (점수 충분 + Stage 2 불필요) |
+| `stage2SkipRate` | number | Stage 2 스킵 비율 = `stage2SkipCount / totalGenerations` |
+| `stage3SkipRate` | number | Stage 3 스킵 비율 = `stage3SkipCount / totalGenerations` |
+| `avgQualityLoopIterations` | number | Quality Loop 평균 반복 횟수 (loop 미진입 시 0 포함, `QUALITY_LOOP_COMPLETED` 이벤트 평균) |
+| `qualityLoopImprovementRate` | number | Quality Loop 개선 성공률 = `improved=true` 이벤트 수 / 전체 `QUALITY_LOOP_COMPLETED` 이벤트 수 |
 | `commonFailures` | array | 빈도 상위 실패 체크 목록 |
 
 ### POST /api/v1/admin/trigger-qc


### PR DESCRIPTION
## Summary

5개 에이전트(Explore 4 + Plan 1) 협업 진단으로 식별된 **문서-코드 정합성 위반 P0 항목**을 일괄 갱신합니다. **코드 변경 0건**, 후속 PR(env vars 추출, CDN 통합, 에러 i18n)의 단일 출처 역할을 합니다.

## 변경 사항

### `docs/architecture/events.md`
- `DomainEvent` union에 `STAGE_SKIPPED`, `QUALITY_LOOP_COMPLETED` 2종 반영 (S7/S8에서 코드 추가됐으나 문서 미갱신)
- "정확도 가시화 이벤트" 섹션 신규 — 발행처·용도 표

### `docs/architecture/ai-pipeline.md`
- 모델 기본값 정정. 실제 코드 동작:
  - 팩토리 `generation`: `claude-opus-4-7`
  - 팩토리 `suggestion`: `claude-haiku-4-5`
  - `ClaudeProvider` 직접 인스턴스화 시: `claude-sonnet-4-6`
- 허용 모델 4종 명시 (`haiku-4-5`/`sonnet-4-6`/`opus-4-6`/`opus-4-7`)

### `docs/reference/api-endpoints.md`
- `/admin/qc-stats` 응답에 7개 신규 필드 문서화:
  - `stage3FallbackCount`, `stage3FallbackRate`
  - `stage2SkipCount`, `stage3SkipCount`
  - `stage2SkipRate`, `stage3SkipRate`
  - `avgQualityLoopIterations`, `qualityLoopImprovementRate`

### `CLAUDE.md`
- 환경변수 5개 추가: `ET_COMPLEXITY_THRESHOLD`, `QUALITY_LOOP_ITERATION_TIMEOUT_MS`, `QUALITY_LOOP_STRICT_ADOPTION`, `QC_QUALITY_THRESHOLD`, `QC_MOBILE_THRESHOLD`
- 전체 환경변수 목록은 `docs/reference/env-vars.md` 참조 안내

### `docs/guides/qc-process.md`
- Step 5 채택 가드: strict 모드(AND) vs OR 모드(env 토글) 명시
- `userFeedback` 매 반복 누적 주입(S10) 명시
- `QUALITY_LOOP_COMPLETED` 이벤트 발행 명시
- 변경 이력에 2026-04-30 항목 추가

## 진단 출처

5개 에이전트 협업 결과:
- A1 (정합성) — 즉시 수정 Top 3 + 단순 갱신 5건 모두 처리
- Plan 에이전트 PR-1 권장 step-by-step 그대로 따름

## Test plan

- [x] `pnpm type-check` — 통과 (코드 변경 0건)
- [x] `pnpm lint` — 통과
- [x] `pnpm test` — 1394 tests 모두 통과
- [ ] 후속 PR (env vars 추출, CDN 통합, 에러 i18n)이 이 PR을 단일 출처로 사용

## 관련 작업

- 이번 진단 보고서의 P0 5건 처리
- 후속 PR-2 (proxy 보안 가드 + 어설션 좁힘), PR-3 (env vars 추출), PR-4 (CDN/도메인 중앙화), PR-5 (qualityLoop silent skip 가시화) 등이 이어질 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEkkQ6FGXoLrFphzUnNKs3)_