### PR TITLE
fix: PR-2 — proxy null user.id 가드 + 테스트 어설션 좁힘 (보안)

### DIFF
--- a/src/__tests__/api/proxy.test.ts
+++ b/src/__tests__/api/proxy.test.ts
@@ -379,13 +379,10 @@ describe('GET /api/v1/proxy', () => {
       expect(body.error.code).toBe('FORBIDDEN');
     });
 
-    it('null user.id (인증은 통과했지만 id 없음) → 401', async () => {
-      // AuthUser.id는 string(non-nullable)이지만 런타임에서 null이 들어오는 엣지 케이스 검증.
-      // 현재 route는 user 객체 존재 여부만 체크하고 user.id 값을 별도 검증하지 않으므로
-      // null id로 rate limit Map에 'null' 키가 등록될 수 있음.
-      // 이 테스트는 해당 엣지케이스를 문서화하며, 향후 id 검증 추가 시 401 반환을 기대함.
+    it('null user.id (인증은 통과했지만 id 없음) → 401 차단', async () => {
+      // AuthUser.id는 string(non-nullable)이지만 런타임 인증 정보 손상 시 null이 들어올 수 있음.
+      // route의 user.id 가드가 401을 반환하여 rate limit Map 오염·RLS 우회 차단.
       const { getAuthUser } = await import('@/lib/auth/index');
-      // null id를 가진 user 객체를 반환 (타입 캐스팅으로 강제)
       vi.mocked(getAuthUser).mockResolvedValue({ ...mockUser, id: null as unknown as string });
 
       const { createCatalogRepository } = await import('@/repositories/factory');
@@ -396,9 +393,39 @@ describe('GET /api/v1/proxy', () => {
       const { GET } = await import('@/app/api/v1/proxy/route');
       const res = await GET(makeRequest(VALID_API_ID, '/data'));
 
-      // TODO: 현재 구현은 id 값을 별도 검증하지 않아 200이 반환될 수 있음.
-      // 안전한 구현이라면 401을 반환해야 함. 현재 동작을 문서화.
-      expect([200, 401]).toContain(res.status);
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error.code).toBe('AUTH_REQUIRED');
+    });
+
+    it('빈 문자열 user.id → 401 차단', async () => {
+      const { getAuthUser } = await import('@/lib/auth/index');
+      vi.mocked(getAuthUser).mockResolvedValue({ ...mockUser, id: '' });
+
+      const { createCatalogRepository } = await import('@/repositories/factory');
+      vi.mocked(createCatalogRepository).mockReturnValue({
+        findById: vi.fn().mockResolvedValue(mockPublicApi),
+      } as never);
+
+      const { GET } = await import('@/app/api/v1/proxy/route');
+      const res = await GET(makeRequest(VALID_API_ID, '/data'));
+
+      expect(res.status).toBe(401);
+    });
+
+    it('user.id가 string이 아닌 경우(예: number) → 401 차단', async () => {
+      const { getAuthUser } = await import('@/lib/auth/index');
+      vi.mocked(getAuthUser).mockResolvedValue({ ...mockUser, id: 123 as unknown as string });
+
+      const { createCatalogRepository } = await import('@/repositories/factory');
+      vi.mocked(createCatalogRepository).mockReturnValue({
+        findById: vi.fn().mockResolvedValue(mockPublicApi),
+      } as never);
+
+      const { GET } = await import('@/app/api/v1/proxy/route');
+      const res = await GET(makeRequest(VALID_API_ID, '/data'));
+
+      expect(res.status).toBe(401);
     });
 
     it('프로젝트 API 키 조회 실패 시 플랫폼 키 폴백', async () => {

--- a/src/app/api/v1/proxy/route.ts
+++ b/src/app/api/v1/proxy/route.ts
@@ -76,6 +76,13 @@ async function handleProxy(request: Request, method: 'GET' | 'POST'): Promise<Re
     return errorResponse(401, 'AUTH_REQUIRED', '로그인이 필요합니다.');
   }
 
+  // user.id 가드 — 타입상 string(non-nullable)이지만 런타임에서 인증 정보 손상 시
+  // null/undefined가 들어올 수 있다. rate limit Map에 잘못된 키('null', 'undefined')가
+  // 등록되거나 RLS 우회 시도가 가능해지므로 401로 즉시 차단.
+  if (!user.id || typeof user.id !== 'string') {
+    return errorResponse(401, 'AUTH_REQUIRED', '로그인이 필요합니다.');
+  }
+
   // Rate Limit 확인
   if (!checkProxyRateLimit(user.id)) {
     return errorResponse(429, 'RATE_LIMITED', '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.');


### PR DESCRIPTION
## Summary

진단 보고서 A2-#1, A2-#5에서 식별된 보안 위협을 해소합니다. **`proxy.test.ts:401`의 `[200, 401]` 다중값 허용 어설션**(stale TODO 패턴)을 좁히면서 동시에 라우트에 `null user.id` 가드를 추가합니다.

## 배경

- `AuthUser.id`는 string(non-nullable) 타입이지만 런타임 인증 정보 손상 시 `null`/`undefined`/빈 문자열이 들어올 수 있음
- 이 경우 rate limit Map에 `'null'` 같은 잘못된 키가 등록되거나 RLS 우회 시도 가능
- 기존 테스트는 `expect([200, 401]).toContain(res.status)`로 두 결과 다 허용하며 안전성 TODO를 코드 주석으로만 남겨둠

## 변경 사항

### `src/app/api/v1/proxy/route.ts`
```typescript
// user.id 가드 — 타입상 string(non-nullable)이지만 런타임에서 인증 정보 손상 시
// null/undefined가 들어올 수 있다. rate limit Map에 잘못된 키('null', 'undefined')가
// 등록되거나 RLS 우회 시도가 가능해지므로 401로 즉시 차단.
if (!user.id || typeof user.id !== 'string') {
  return errorResponse(401, 'AUTH_REQUIRED', '로그인이 필요합니다.');
}
```

### `src/__tests__/api/proxy.test.ts`
- 기존 `expect([200, 401]).toContain(...)` → `expect(401).toBe(...)` + `'AUTH_REQUIRED'` 코드 검증
- 신규 case: 빈 문자열 user.id → 401 차단
- 신규 case: id가 string이 아닌 타입(number) → 401 차단

## 진단 출처 + Plan 검토

- A2 진단 #1, #5 — proxy 다중값 허용 어설션 + 안전성 TODO
- Plan 에이전트 Critical Review: **"테스트만 좁히면 빨간 빌드"** 경고에 따라 **라우트 가드와 동시 머지** (Option A 선택)

## Test plan

- [x] `pnpm test` — 1394 → 1396 tests 모두 통과 (+2 신규 case)
- [x] `pnpm type-check` — 통과
- [x] `pnpm lint` — 통과
- [x] proxy 보안 테스트 좁혀진 어설션으로 회귀 방지 확인

## 후속 PR 예정

- PR-3 (env vars 추출): `ANTHROPIC_TIMEOUT_MS`, `MAX_CONCURRENT_RATE_LIMIT_USERS`, rate limit 60회/분 상수 통합
- PR-4 (CDN/도메인 중앙화)
- PR-5 (qualityLoop silent skip 가시화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEkkQ6FGXoLrFphzUnNKs3)_