### PR TITLE
refactor: PR-4 — 사용자 페이지 CSP/CDN 단일 출처화

### DIFF
--- a/src/app/api/v1/preview/[projectId]/route.ts
+++ b/src/app/api/v1/preview/[projectId]/route.ts
@@ -4,6 +4,7 @@ import { getAuthUser } from '@/lib/auth/index';
 import { createProjectRepository, createCodeRepository } from '@/repositories/factory';
 import { assembleHtml } from '@/lib/ai/codeParser';
 import { AuthRequiredError, ForbiddenError, NotFoundError, ValidationError, handleApiError } from '@/lib/utils/errors';
+import { PREVIEW_CSP } from '@/lib/constants/cdn';
 
 export async function GET(
   request: Request,
@@ -56,16 +57,8 @@ export async function GET(
         'Cache-Control': 'no-cache',
         'X-Content-Type-Options': 'nosniff',
         'Cross-Origin-Opener-Policy': 'same-origin-allow-popups',
-        'Content-Security-Policy': [
-          "default-src 'self'",
-          // Allow inline scripts + common CDNs used by AI-generated pages (Tailwind, Chart.js, Font Awesome, etc.)
-          "script-src 'unsafe-inline' 'unsafe-eval' https://cdn.tailwindcss.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://kit.fontawesome.com https://use.fontawesome.com https://stackpath.bootstrapcdn.com https://unpkg.com",
-          "style-src 'unsafe-inline' https://fonts.googleapis.com https://cdn.tailwindcss.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://stackpath.bootstrapcdn.com https://unpkg.com",
-          'font-src https://fonts.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://use.fontawesome.com https://kit.fontawesome.com data:',
-          'img-src * data: blob:',
-          'connect-src *',
-          "frame-ancestors 'self'",
-        ].join('; '),
+        // CSP 정책은 src/lib/constants/cdn.ts에서 단일 출처 관리 (사용자 페이지와 동일 정책)
+        'Content-Security-Policy': PREVIEW_CSP,
       },
     });
   } catch (error) {

--- a/src/app/site/[slug]/route.ts
+++ b/src/app/site/[slug]/route.ts
@@ -4,16 +4,7 @@ import { CodeRepository } from '@/repositories/codeRepository';
 import { assembleHtml } from '@/lib/ai/codeParser';
 import { isValidSlug, RESERVED_SLUGS } from '@/lib/utils/slugify';
 import { notFoundHtml, preparingHtml } from '@/lib/templates/siteError';
-
-const SITE_CSP = [
-  "default-src 'self'",
-  "script-src 'unsafe-inline' 'unsafe-eval' https://cdn.tailwindcss.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://kit.fontawesome.com https://use.fontawesome.com https://stackpath.bootstrapcdn.com https://unpkg.com",
-  "style-src 'unsafe-inline' https://fonts.googleapis.com https://cdn.tailwindcss.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://stackpath.bootstrapcdn.com https://unpkg.com",
-  'font-src https://fonts.gstatic.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://use.fontawesome.com https://kit.fontawesome.com data:',
-  'img-src * data: blob:',
-  'connect-src *',
-  "frame-ancestors 'none'",
-].join('; ');
+import { SITE_CSP } from '@/lib/constants/cdn';
 
 export async function GET(
   _request: Request,

--- a/src/lib/constants/cdn.test.ts
+++ b/src/lib/constants/cdn.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SITE_SCRIPT_CDNS,
+  SITE_STYLE_CDNS,
+  SITE_FONT_CDNS,
+  SITE_CSP,
+  PREVIEW_CSP,
+  buildSiteCsp,
+} from './cdn';
+
+describe('CDN constants', () => {
+  it('script CDNs은 모두 https로 시작한다', () => {
+    for (const url of SITE_SCRIPT_CDNS) {
+      expect(url.startsWith('https://')).toBe(true);
+    }
+  });
+
+  it('style CDNs은 모두 https로 시작한다', () => {
+    for (const url of SITE_STYLE_CDNS) {
+      expect(url.startsWith('https://')).toBe(true);
+    }
+  });
+
+  it('font CDNs은 모두 https로 시작한다', () => {
+    for (const url of SITE_FONT_CDNS) {
+      expect(url.startsWith('https://')).toBe(true);
+    }
+  });
+
+  it('주요 CDN(tailwind, jsdelivr, fontawesome)이 script-src에 포함된다', () => {
+    expect(SITE_SCRIPT_CDNS).toContain('https://cdn.tailwindcss.com');
+    expect(SITE_SCRIPT_CDNS).toContain('https://cdn.jsdelivr.net');
+    expect(SITE_SCRIPT_CDNS).toContain('https://cdnjs.cloudflare.com');
+    expect(SITE_SCRIPT_CDNS).toContain('https://kit.fontawesome.com');
+  });
+
+  it('Google Fonts가 style-src와 font-src에 포함된다', () => {
+    expect(SITE_STYLE_CDNS).toContain('https://fonts.googleapis.com');
+    expect(SITE_FONT_CDNS).toContain('https://fonts.gstatic.com');
+  });
+});
+
+describe('buildSiteCsp()', () => {
+  it("frame-ancestors 'none' 옵션 적용", () => {
+    const csp = buildSiteCsp("'none'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).not.toContain("frame-ancestors 'self'");
+  });
+
+  it("frame-ancestors 'self' 옵션 적용", () => {
+    const csp = buildSiteCsp("'self'");
+    expect(csp).toContain("frame-ancestors 'self'");
+    expect(csp).not.toContain("frame-ancestors 'none'");
+  });
+
+  it('Alpine.js 호환을 위해 unsafe-inline + unsafe-eval 포함 (script-src)', () => {
+    const csp = buildSiteCsp("'none'");
+    expect(csp).toContain("'unsafe-inline'");
+    expect(csp).toContain("'unsafe-eval'");
+  });
+
+  it('default-src self / img-src 와일드카드 / connect-src 와일드카드 포함', () => {
+    const csp = buildSiteCsp("'none'");
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain('img-src * data: blob:');
+    expect(csp).toContain('connect-src *');
+  });
+});
+
+describe('SITE_CSP / PREVIEW_CSP', () => {
+  it('SITE_CSP는 frame-ancestors none을 사용한다 (외부 임베드 차단)', () => {
+    expect(SITE_CSP).toContain("frame-ancestors 'none'");
+  });
+
+  it('PREVIEW_CSP는 frame-ancestors self를 사용한다 (메인 앱 iframe 허용)', () => {
+    expect(PREVIEW_CSP).toContain("frame-ancestors 'self'");
+  });
+
+  it('SITE_CSP와 PREVIEW_CSP는 frame-ancestors만 다르고 나머지는 동일', () => {
+    const siteWithoutFrame = SITE_CSP.replace(/frame-ancestors '[a-z]+'/, '');
+    const previewWithoutFrame = PREVIEW_CSP.replace(/frame-ancestors '[a-z]+'/, '');
+    expect(siteWithoutFrame).toBe(previewWithoutFrame);
+  });
+});

--- a/src/lib/constants/cdn.ts
+++ b/src/lib/constants/cdn.ts
@@ -1,0 +1,65 @@
+/**
+ * 공용 CDN 호스트 목록.
+ *
+ * AI가 생성한 사용자 페이지가 의존하는 외부 CDN을 단일 출처에 모은다.
+ * `site/[slug]/route.ts`, `preview/[projectId]/route.ts`, `promptBuilder.ts`가
+ * 동일 목록을 참조하도록 보장 — CDN 추가/제거 시 한 곳만 수정.
+ *
+ * **주의**: 메인 앱(`/`, `/builder` 등)의 CSP는 `middleware.ts`에서 관리되며
+ * 다른 정책(nonce 기반 script-src)을 사용하므로 이 상수와 별개다.
+ */
+
+/** Tailwind, Font Awesome, Pretendard 등 사용자 페이지 script-src 화이트리스트 */
+export const SITE_SCRIPT_CDNS = [
+  'https://cdn.tailwindcss.com',
+  'https://cdn.jsdelivr.net',
+  'https://cdnjs.cloudflare.com',
+  'https://kit.fontawesome.com',
+  'https://use.fontawesome.com',
+  'https://stackpath.bootstrapcdn.com',
+  'https://unpkg.com',
+] as const;
+
+/** 사용자 페이지 style-src 화이트리스트 (Google Fonts 포함) */
+export const SITE_STYLE_CDNS = [
+  'https://fonts.googleapis.com',
+  'https://cdn.tailwindcss.com',
+  'https://cdn.jsdelivr.net',
+  'https://cdnjs.cloudflare.com',
+  'https://stackpath.bootstrapcdn.com',
+  'https://unpkg.com',
+] as const;
+
+/** 사용자 페이지 font-src 화이트리스트 (data: 포함) */
+export const SITE_FONT_CDNS = [
+  'https://fonts.gstatic.com',
+  'https://cdn.jsdelivr.net',
+  'https://cdnjs.cloudflare.com',
+  'https://use.fontawesome.com',
+  'https://kit.fontawesome.com',
+] as const;
+
+/**
+ * 사용자 페이지에 적용되는 CSP 문자열을 생성한다.
+ * Alpine.js x-data 등 인라인 속성 평가에 'unsafe-eval'이 필요하므로 nonce 정책 대신
+ * 화이트리스트 기반. `frameAncestors`만 호출처마다 다름:
+ * - 서브도메인 게시(`/site/[slug]`): `'none'` — 외부 임베드 차단
+ * - 미리보기(`/preview/[projectId]`): `'self'` — 메인 앱 iframe 허용
+ */
+export function buildSiteCsp(frameAncestors: "'none'" | "'self'"): string {
+  return [
+    "default-src 'self'",
+    `script-src 'unsafe-inline' 'unsafe-eval' ${SITE_SCRIPT_CDNS.join(' ')}`,
+    `style-src 'unsafe-inline' ${SITE_STYLE_CDNS.join(' ')}`,
+    `font-src ${SITE_FONT_CDNS.join(' ')} data:`,
+    'img-src * data: blob:',
+    'connect-src *',
+    `frame-ancestors ${frameAncestors}`,
+  ].join('; ');
+}
+
+/** 서브도메인 게시(`/site/[slug]`) 전용 CSP — frame-ancestors 'none' */
+export const SITE_CSP = buildSiteCsp("'none'");
+
+/** 미리보기(`/preview/[projectId]`) 전용 CSP — frame-ancestors 'self' */
+export const PREVIEW_CSP = buildSiteCsp("'self'");


### PR DESCRIPTION
## Summary

진단 보고서 A3-#4 (CDN 4곳 분산) 처리. 사용자 페이지 서빙 두 경로(서브도메인 + 미리보기)의 CSP가 중복 정의되어 있어, CDN 추가/제거 시 2곳을 동시에 수정해야 했고 정책 drift 위험이 있었음. 단일 출처로 통합.

## 변경 사항

### 신규: `src/lib/constants/cdn.ts`
- `SITE_SCRIPT_CDNS`, `SITE_STYLE_CDNS`, `SITE_FONT_CDNS` — 화이트리스트 단일 출처
- `buildSiteCsp(frameAncestors)` — `frame-ancestors`만 호출처마다 다른 점 추상화
- `SITE_CSP` — 서브도메인 게시용 (`frame-ancestors 'none'`, 외부 임베드 차단)
- `PREVIEW_CSP` — 미리보기용 (`frame-ancestors 'self'`, 메인 앱 iframe 허용)

### `src/app/site/[slug]/route.ts`
인라인 CSP 8줄 → `SITE_CSP` import

### `src/app/api/v1/preview/[projectId]/route.ts`
인라인 CSP 9줄 → `PREVIEW_CSP` import

### `src/lib/constants/cdn.test.ts` (신규, 12 cases)
- 모든 CDN URL `https://` 검증
- 주요 CDN(tailwind/jsdelivr/fontawesome/google fonts) 포함 확인
- `buildSiteCsp` 옵션별 동작
- **`SITE_CSP` vs `PREVIEW_CSP`는 frame-ancestors만 다르고 나머지 동일** (회귀 방지)

## 위험 평가

- CSP 문자열 비교 결과 동일 (frame-ancestors 제외) → **동작 변경 0건**
- `middleware.ts` CSP는 메인 앱용(nonce 기반)이라 별개 — 영향 없음
- `promptBuilder.ts` CDN 목록은 AI 시스템 프롬프트 내부 문자열이라 별도 관리 (이번 PR에서는 다루지 않음 — 추후 별도 PR 권장)

## CLAUDE.md "CSP / 보안 헤더 변경 시" 원칙 준수

> `middleware.ts`, `site/[slug]/route.ts`, `preview/[projectId]/route.ts` 3개 파일을 반드시 동시에 확인

세 파일 모두 검토:
- `middleware.ts` — 메인 앱 CSP, 이번 PR 변경 없음 (별도 정책)
- `site/[slug]/route.ts` — `SITE_CSP` import로 변경
- `preview/[projectId]/route.ts` — `PREVIEW_CSP` import로 변경

## Test plan

- [x] `pnpm test` — 1394 → 1406 tests 통과 (+12 신규)
- [x] `pnpm type-check` — 통과
- [x] `pnpm lint` — 통과
- [x] CSP 문자열 동등성 회귀 방지 테스트 추가

## 후속 PR

- PR-5 (qualityLoop silent skip 가시화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEkkQ6FGXoLrFphzUnNKs3)_