### PR TITLE
fix: 보안 감사 MEDIUM 항목 수정 7건 (버전 정리, 로깅, env 방어, QC 안정성)

### DIFF
--- a/docs/superpowers/specs/2026-04-27-component-test-design.md
+++ b/docs/superpowers/specs/2026-04-27-component-test-design.md
@@ -1,0 +1,257 @@
+# 설계 문서: React 컴포넌트 테스트 도입
+
+**날짜**: 2026-04-27  
+**상태**: 승인됨  
+**우선순위**: A안 첫 번째 항목 (안정성 우선)
+
+---
+
+## 1. 배경 및 목표
+
+### 현황
+
+- 컴포넌트 총 32개, 테스트 파일 2개 (PublishDialog, RePromptSection) — 커버리지 약 6%
+- `vitest.config.ts`의 `coverage.include`에서 `src/components/**` 제외됨
+- `@testing-library/react`는 이미 devDependency에 존재
+- 기존 1,129개 Vitest 테스트는 `node` 환경으로 안정적으로 운영 중
+
+### 목표
+
+- UI 회귀(regression) 방지 — 사용자가 경험하는 화면이 정확히 동작하는지 검증
+- SonarCloud 커버리지 측정 대상에 `src/components/**` 포함
+- 기존 1,129개 테스트에 영향 없이 컴포넌트 테스트 환경 추가
+
+### 범위 밖
+
+- `GenerationProgress`, `RePromptPanel`, `Header`, `ProjectGrid` — SSE·인증 복합 의존으로 단위 테스트 비효율. E2E 영역으로 분류
+- Playwright E2E 테스트 신규 작성 (별도 작업)
+- Storybook 도입 (별도 검토)
+
+---
+
+## 2. 접근법 결정
+
+### 검토한 세 가지 방식
+
+| 방식 | 설명 | 기존 테스트 영향 | 채택 여부 |
+|------|------|----------------|----------|
+| A. 전역 환경 변경 | `vitest.config.ts`의 `environment`를 `happy-dom`으로 변경 | 1,129개 재검증 필요 | ❌ |
+| **B. 파일별 지시자** | 각 테스트 파일 첫 줄에 `// @vitest-environment happy-dom` | **영향 없음** | ✅ |
+| C. Workspace 분리 | `vitest.workspace.ts`로 환경 분리 | 없음, 설정 복잡 | ❌ |
+
+### 선택: B (파일별 환경 지시자)
+
+- `PublishDialog.test.tsx`, `RePromptSection.test.tsx`에서 이미 검증된 패턴
+- 기존 API 라우트·lib·서비스·Repository 테스트 완전 보호
+- 추가 설정 파일 없이 기존 인프라 활용
+
+---
+
+## 3. 설정 변경
+
+### 3.1 vitest.config.ts
+
+```typescript
+coverage: {
+  include: [
+    'src/lib/**',
+    'src/services/**',
+    'src/providers/**',
+    'src/repositories/**',
+    'src/components/**',   // ← 추가
+  ],
+}
+```
+
+임계값은 현행 유지 (컴포넌트 커버리지는 측정 시작만 목표, 강제 임계값 미적용).
+
+### 3.2 신규 파일 3개
+
+#### `src/test/mocks/zustand.ts`
+Zustand store mock 팩토리. 컴포넌트 테스트에서 store를 주입할 때 사용.
+
+```typescript
+// 패턴 예시
+export function mockThemeStore(overrides = {}) {
+  return { theme: 'light', setTheme: vi.fn(), ...overrides };
+}
+export function mockContextStore(overrides = {}) {
+  return { designPreferences: null, setDesignPreferences: vi.fn(), ...overrides };
+}
+```
+
+#### `src/test/helpers/component.ts`
+`@testing-library/react`의 `render`를 래핑. 추후 Provider 추가 시 단일 지점 수정.
+
+```typescript
+import { render, type RenderOptions } from '@testing-library/react';
+import type { ReactElement } from 'react';
+
+export function renderComponent(ui: ReactElement, options?: RenderOptions) {
+  return render(ui, options);
+}
+
+export * from '@testing-library/react';
+```
+
+#### 파일 선두 지시자 규칙
+모든 `*.test.tsx` 파일 첫 줄:
+```typescript
+// @vitest-environment happy-dom
+```
+
+---
+
+## 4. 테스트 대상 컴포넌트
+
+### Phase 1 — 순수 UI (2주)
+
+외부 의존성이 최소이고 비즈니스 중요도가 높은 컴포넌트 우선.
+
+| 컴포넌트 | 위치 | 핵심 테스트 케이스 | Mock 필요 |
+|---------|------|-----------------|----------|
+| `StepIndicator` | `builder/` | 현재 단계 강조, 완료 체크마크, 연결선 색상 | 없음 |
+| `CategoryTabs` | `catalog/` | 활성 탭 스타일, 클릭 시 onCategoryChange 호출 | 없음 |
+| `ApiCard` | `catalog/` | 선택/미선택 상태, 배지 렌더링, onClick 콜백 | 없음 |
+| `GuideQuestions` | `builder/` | 토글 열림·닫힘, onInsert 콜백 | 없음 |
+| `ApiDetailModal` | `catalog/` | ESC 키 닫기, 배경 클릭 닫기, 엔드포인트 표시 | 없음 |
+| `ApiSearchBar` | `catalog/` | debounce 동작, clear 버튼, vi.useFakeTimers 사용 | 없음 |
+| `ContextSuggestions` | `builder/` | 로딩 skeleton, 추천 카드 렌더링, 선택 콜백 | 없음 |
+
+### Phase 2 — 상태 + 이벤트 (2주)
+
+상태 관리·Next.js router·clipboard 등 mock이 필요한 컴포넌트.
+
+| 컴포넌트 | 위치 | 핵심 테스트 케이스 | Mock 필요 |
+|---------|------|-----------------|----------|
+| `ProjectCard` | `dashboard/` | 상태 배지, clipboard 복사, buildPublishUrl | `next/navigation`, `navigator.clipboard` |
+| `ApiRecommendations` | `builder/` | 로딩·에러·추천 3분기 렌더링 | 없음 (props 기반) |
+| `BuilderModeToggle` | `builder/` | 모드 텍스트 표시, onReset 콜백 | 없음 |
+| `TemplateSelector` | `builder/` | 12개 템플릿 버튼, AI 배지 | 없음 |
+| `CatalogView` | `catalog/` | 검색어 필터링, 카테고리 필터, 모달 열기 | 없음 |
+| `ProjectPublishActions` | `dashboard/` | 슬러그 유무 분기, PublishDialog 열기 | `next/navigation`, `usePublish` hook |
+| `ApiKeyGuideModal` | `settings/` | 가이드 내용 렌더링, 닫기 버튼 | 없음 |
+
+### Phase 3+ (보류)
+
+| 컴포넌트 | 보류 이유 |
+|---------|----------|
+| `GenerationProgress` | SSE 스트림·interval 복합 상태 |
+| `RePromptPanel` | SSE 폴링·fetch mock 복잡 |
+| `Header` | useAuth·useAuthStore·useRouter 복합 |
+| `ProjectGrid` | DELETE fetch 통합 |
+| `PreviewFrame` | iframe sandbox 환경 |
+
+---
+
+## 5. Mock 전략
+
+### Next.js Navigation
+
+```typescript
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn(), back: vi.fn() }),
+  usePathname: () => '/dashboard',
+}));
+```
+
+### Zustand Store
+
+```typescript
+vi.mock('@/stores/themeStore', () => ({
+  useThemeStore: () => mockThemeStore(),
+}));
+```
+
+### Clipboard API
+
+```typescript
+beforeEach(() => {
+  vi.stubGlobal('navigator', {
+    clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
+});
+afterEach(() => { vi.unstubAllGlobals(); });
+```
+
+### 타이머 (ApiSearchBar debounce)
+
+```typescript
+beforeEach(() => { vi.useFakeTimers(); });
+afterEach(() => { vi.useRealTimers(); });
+
+it('300ms debounce 후 onChange 호출', async () => {
+  await userEvent.type(input, 'test');
+  expect(onChange).not.toHaveBeenCalled();
+  vi.advanceTimersByTime(300);
+  expect(onChange).toHaveBeenCalledWith('test');
+});
+```
+
+---
+
+## 6. 파일 구조 (완료 후)
+
+```
+src/
+├── test/
+│   ├── mocks/
+│   │   ├── handlers.ts          (기존)
+│   │   ├── server.ts            (기존)
+│   │   └── zustand.ts           ← 신규
+│   ├── helpers/
+│   │   └── component.ts         ← 신규
+│   └── setup.ts                 (기존)
+└── components/
+    ├── builder/
+    │   ├── StepIndicator.test.tsx       ← Phase 1
+    │   ├── GuideQuestions.test.tsx      ← Phase 1
+    │   ├── ContextSuggestions.test.tsx  ← Phase 1
+    │   ├── ApiRecommendations.test.tsx  ← Phase 2
+    │   ├── BuilderModeToggle.test.tsx   ← Phase 2
+    │   └── TemplateSelector.test.tsx    ← Phase 2
+    ├── catalog/
+    │   ├── CategoryTabs.test.tsx        ← Phase 1
+    │   ├── ApiCard.test.tsx             ← Phase 1
+    │   ├── ApiSearchBar.test.tsx        ← Phase 1
+    │   ├── ApiDetailModal.test.tsx      ← Phase 1
+    │   └── CatalogView.test.tsx         ← Phase 2
+    ├── dashboard/
+    │   ├── PublishDialog.test.tsx       (기존)
+    │   ├── RePromptSection.test.tsx     (기존)
+    │   ├── ProjectCard.test.tsx         ← Phase 2
+    │   └── ProjectPublishActions.test.tsx ← Phase 2
+    └── settings/
+        └── ApiKeyGuideModal.test.tsx    ← Phase 2
+```
+
+---
+
+## 7. 예상 성과
+
+| 지표 | 현재 | Phase 1 완료 | Phase 2 완료 |
+|------|------|-------------|-------------|
+| 컴포넌트 테스트 파일 | 2개 | 9개 | 16개 |
+| 전체 Vitest 테스트 수 | 1,129개 | ~1,150개 | ~1,185개 |
+| 컴포넌트 커버리지 (측정 시작) | 미측정 | 측정 시작 | ~50%+ |
+| SonarCloud 대상 | lib/services/providers/repositories | + components | + components |
+
+---
+
+## 8. 리스크 및 완화
+
+| 리스크 | 확률 | 완화 방안 |
+|--------|------|---------|
+| 기존 1,129개 테스트 회귀 | 낮음 | 파일별 지시자 방식으로 환경 격리 |
+| Zustand mock 누락으로 테스트 실패 | 중간 | `src/test/mocks/zustand.ts` 팩토리 선 작성 후 컴포넌트 테스트 시작 |
+| debounce/timer 테스트 flake | 중간 | `vi.useFakeTimers()` + `vi.useRealTimers()` afterEach 철저히 적용 |
+| `@vitest-environment` 지시자 누락 | 중간 | PR 체크리스트 항목으로 추가 |
+
+---
+
+## 9. 연관 결정 사항 (로드맵 조정)
+
+이번 설계 세션에서 확정된 로드맵 변경:
+
+- **Item 2 (RBAC/팀·조직)**: 조건부 보류 — 팀 기능 실사용자 요청이 발생할 때 재검토
+- **Item 3 (React/Vite + esbuild)**: 조건부 보류 — Alpine.js 한계 사례 월 50건 이상 또는 복잡한 상태 관리 필요 비율 10% 초과 시 재검토

--- a/src/__tests__/api/admin.test.ts
+++ b/src/__tests__/api/admin.test.ts
@@ -214,11 +214,11 @@ describe('Rate Limit 심화', () => {
     expect(resA61.status).toBe(403);
   });
 
-  it('x-forwarded-for: 복수 IP → 첫 번째만 사용', async () => {
+  it('x-forwarded-for: 복수 IP → 마지막(신뢰된 프록시 추가) 값만 사용', async () => {
     const { GET } = await import('@/app/api/v1/admin/qc-stats/route');
 
-    // "10.0.0.1, 20.0.0.1" → 첫 번째 IP "10.0.0.1"을 rate limit 키로 사용
-    // 동일 첫번째 IP로 60회 이상 요청 시 차단
+    // Railway 환경: 신뢰된 프록시가 마지막 IP를 추가 → 마지막 값으로 rate limit
+    // "10.0.0.1(클라이언트), 20.0.0.1, 30.0.0.1(Railway 프록시)" → "30.0.0.1" 기준
     for (let i = 0; i < 60; i++) {
       const req = new Request('http://localhost/api/v1/admin/qc-stats', {
         headers: {
@@ -230,11 +230,11 @@ describe('Rate Limit 심화', () => {
       expect(res.status).toBe(200);
     }
 
-    // 61번째: 첫 번째 IP 10.0.0.1 기준으로 차단
+    // 61번째: 마지막 IP 30.0.0.1 기준으로 차단 (앞 IP는 달라도 마지막이 같으면 차단)
     const req61 = new Request('http://localhost/api/v1/admin/qc-stats', {
       headers: {
         Authorization: `Bearer ${VALID_ADMIN_KEY}`,
-        'x-forwarded-for': '10.0.0.1, 99.99.99.99',
+        'x-forwarded-for': '99.99.99.99, 30.0.0.1',
       },
     });
     const res61 = await GET(req61);

--- a/src/lib/ai/generationPipeline.ts
+++ b/src/lib/ai/generationPipeline.ts
@@ -55,12 +55,16 @@ export interface PipelineServices {
 function safeAssembleHtml(code: { html: string; css: string; js: string }): string | null {
   try {
     return assembleHtml(code);
-  } catch {
+  } catch (err) {
+    logger.warn('[Pipeline] assembleHtml failed — QC 스킵', {
+      error: err instanceof Error ? err.message : String(err),
+    });
     return null;
   }
 }
 
-const ET_THRESHOLD = Number(process.env.ET_COMPLEXITY_THRESHOLD ?? 35);
+const _etVal = Number.parseInt(process.env.ET_COMPLEXITY_THRESHOLD ?? '', 10);
+const ET_THRESHOLD = Number.isNaN(_etVal) || _etVal <= 0 ? 35 : _etVal;
 
 export function evaluateComplexityScore(apis: ApiCatalogItem[], context?: string): number {
   let score = 0;

--- a/src/lib/ai/qualityLoop.ts
+++ b/src/lib/ai/qualityLoop.ts
@@ -180,7 +180,8 @@ export async function runQualityLoop(
 
     try {
       const improvementPrompt = buildQualityImprovementPrompt(bestParsed, bestQuality, bestQcReport, userFeedback);
-      const iterationTimeoutMs = Number(process.env.QUALITY_LOOP_ITERATION_TIMEOUT_MS ?? 120_000);
+      const _loopVal = Number.parseInt(process.env.QUALITY_LOOP_ITERATION_TIMEOUT_MS ?? '', 10);
+      const iterationTimeoutMs = Number.isNaN(_loopVal) || _loopVal <= 0 ? 120_000 : _loopVal;
       const timeoutPromise = new Promise<never>((_, reject) =>
         setTimeout(
           () => reject(new Error(`Quality loop iteration timed out after ${iterationTimeoutMs}ms`)),

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -8,6 +8,9 @@ function getKey(): Buffer {
   if (buf.byteLength < 32) {
     throw new Error('ENCRYPTION_KEY 환경변수가 32바이트 이상이어야 합니다.');
   }
+  if (buf.byteLength > 32) {
+    console.warn(`[Encryption] ENCRYPTION_KEY가 ${buf.byteLength}바이트입니다. AES-256은 정확히 32바이트가 필요하므로 첫 32바이트만 사용합니다.`);
+  }
   return buf.subarray(0, 32);
 }
 

--- a/src/lib/qc/qcChecks.ts
+++ b/src/lib/qc/qcChecks.ts
@@ -492,10 +492,8 @@ async function subCheckFilterTab(page: Page): Promise<SubCheckResult> {
 export async function checkInteractiveBehavior(page: Page): Promise<QcCheckResult> {
   const start = Date.now();
   try {
-    const [sub1, sub2] = await Promise.all([
-      subCheckInputAction(page),
-      subCheckFilterTab(page),
-    ]);
+    const sub1 = await subCheckInputAction(page);
+    const sub2 = await subCheckFilterTab(page);
 
     const details: string[] = [];
     if (sub1.detail) details.push(`[입력플로우] ${sub1.detail}`);

--- a/src/lib/qc/renderingQc.ts
+++ b/src/lib/qc/renderingQc.ts
@@ -99,8 +99,7 @@ async function runFastQcInternal(html: string): Promise<QcReport> {
   const startTime = Date.now();
   const page: Page | null = await getPage();
   if (!page) {
-    logger.warn('[QC] Fast QC: could not acquire page from pool');
-    return buildReport([], QC_VIEWPORTS.FAST, startTime, QC_THRESHOLDS.FAST_PASS);
+    throw new Error('QC page pool unavailable');
   }
 
   try {
@@ -154,8 +153,7 @@ async function runDeepQcInternal(html: string): Promise<QcReport> {
   const startTime = Date.now();
   const page: Page | null = await getPage();
   if (!page) {
-    logger.warn('[QC] Deep QC: could not acquire page from pool');
-    return buildReport([], QC_VIEWPORTS.DEEP, startTime, QC_THRESHOLDS.DEEP_PASS);
+    throw new Error('QC page pool unavailable');
   }
 
   try {

--- a/src/lib/utils/adminAuth.ts
+++ b/src/lib/utils/adminAuth.ts
@@ -48,8 +48,9 @@ export function withAdminCors(response: Response): Response {
 
 export function verifyAdminKey(request: Request): void {
   // Rate limit check first
+  const forwarded = request.headers.get('x-forwarded-for');
   const ip =
-    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    (forwarded ? forwarded.split(',').at(-1)?.trim() : null) ??
     request.headers.get('x-real-ip') ??
     'unknown';
   checkRateLimit(ip);

--- a/src/repositories/codeRepository.ts
+++ b/src/repositories/codeRepository.ts
@@ -46,7 +46,7 @@ export class CodeRepository extends BaseRepository<GeneratedCode> implements ICo
       .select('id, version')
       .eq('project_id', projectId)
       .order('version', { ascending: false })
-      .range(keepCount, 999);
+      .range(keepCount, keepCount + 9999);
 
     if (error) throw error;
     if (!data || data.length === 0) return;


### PR DESCRIPTION
## Summary

코드베이스 전체 심층 감사에서 발견된 MEDIUM 항목 7건을 수정합니다.

- **[M1] codeRepository pruneOldVersions**: `.range(keepCount, 999)` → `.range(keepCount, keepCount + 9999)` — 프로젝트당 버전이 1000개를 초과하면 오래된 버전이 삭제되지 않는 버그 수정
- **[M2] safeAssembleHtml 로깅**: `generationPipeline.ts`의 `safeAssembleHtml`에 `logger.warn` 추가 — `qualityLoop.ts`와 로깅 일관성 확보, 운영 중 QC 스킵 원인 추적 가능
- **[M3] env var 빈 문자열 방어**: `Number("")` = `0` 엣지 케이스 수정. `ET_COMPLEXITY_THRESHOLD=""` 설정 시 Extended Thinking이 항상 활성화되는 문제, `QUALITY_LOOP_ITERATION_TIMEOUT_MS=""` 설정 시 0ms 타임아웃 문제 해결
- **[M4] qcChecks 병렬 DOM 조작**: `checkInteractiveBehavior`에서 `Promise.all([subCheckInputAction, subCheckFilterTab])` → 순차 `await`. 동일 `page` 인스턴스 위에서 두 서브체크가 동시에 DOM을 조작해 비결정적 결과가 발생하는 문제 해결
- **[M5] renderingQc 풀 획득 실패**: `getPage()` 실패 시 `buildReport([], ..., passed=false)` 반환 → `throw Error`로 변경. 호출자(`runFastQc`/`runDeepQc`)가 `null`을 반환하도록 해 QC 실패와 QC 불가 상태를 올바르게 구분
- **[M6] encryption silent truncation**: `ENCRYPTION_KEY > 32바이트`일 때 조용히 잘라내던 동작에 `console.warn` 추가 — 운영자가 키 설정 의도를 명확히 인지
- **[M7] adminAuth X-Forwarded-For**: 첫 번째 값(클라이언트 조작 가능) → 마지막 값(Railway 신뢰된 프록시가 추가한 실제 IP) 사용 — rate limit 우회 공격 차단

## Test plan

- [x] `pnpm type-check` — 타입 오류 없음
- [x] `pnpm test` — 1409 테스트 전체 통과 (admin.test.ts rate limit 테스트 동작 업데이트 포함)
- [ ] Railway 배포 후 QC 정상 동작 확인 (pool 실패 → null 반환, 재생성 불필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)