### PR TITLE
fix: 서비스 불가 버그 2건 — regenerate rate limit 보상·status fallback result 누락

### DIFF
--- a/src/app/api/v1/generate/regenerate/route.ts
+++ b/src/app/api/v1/generate/regenerate/route.ts
@@ -31,6 +31,8 @@ import { runGenerationPipeline } from '@/lib/ai/generationPipeline';
 import { generationTracker } from '@/lib/ai/generationTracker';
 
 export async function POST(request: Request): Promise<Response> {
+  let pendingDecrement: (() => Promise<void>) | undefined;
+
   try {
     const user = await getAuthUser();
     if (!user) throw new AuthRequiredError();
@@ -53,6 +55,7 @@ export async function POST(request: Request): Promise<Response> {
 
     const rateLimitService = createRateLimitService(supabase);
     await rateLimitService.checkAndIncrementDailyLimit(user.id);
+    pendingDecrement = () => rateLimitService.decrementDailyLimit(user.id);
 
     const projectService = createProjectService(supabase);
     const [project, apiIds] = await Promise.all([
@@ -139,6 +142,7 @@ export async function POST(request: Request): Promise<Response> {
       },
     });
   } catch (error) {
+    await pendingDecrement?.().catch(() => {});
     return handleApiError(error);
   }
 }

--- a/src/app/api/v1/generate/status/[projectId]/route.ts
+++ b/src/app/api/v1/generate/status/[projectId]/route.ts
@@ -29,7 +29,17 @@ export async function GET(
       const codeRepo = createCodeRepository(supabase);
       const latestCode = await codeRepo.findByProject(projectId);
       if (latestCode) {
-        return Response.json({ success: true, data: { status: 'completed' } });
+        return Response.json({
+          success: true,
+          data: {
+            status: 'completed',
+            result: {
+              projectId,
+              version: latestCode.version,
+              previewUrl: `/api/v1/preview/${projectId}`,
+            },
+          },
+        });
       }
       return Response.json({ success: true, data: { status: 'not_found' } });
     }


### PR DESCRIPTION
## 요약

**서비스 장애 원인 조사 결과 확인된 2개 버그 수정.**

### Bug 1: `regenerate/route.ts` — rate limit 카운터 보상 누락
- `checkAndIncrementDailyLimit` 호출 후 라우트 레벨에서 예외 발생 시(인증 실패, 프로젝트 조회 실패 등) 카운터가 감소되지 않고 영구 소모되던 문제
- `pendingDecrement` 클로저 패턴 적용 (PR #69이 `generate/route.ts`에 적용한 것과 동일)

### Bug 2: `status/[projectId]/route.ts` — fallback 경로에서 `result` 누락
- `generationTracker` TTL 만료(완료: 10분) 또는 서버 재시작으로 인메모리 tracker가 없을 때, DB fallback이 `{ status: 'completed' }` 만 반환하고 `result` 없이 응답하던 문제
- 이로 인해 클라이언트가 "완료"로 처리했지만 실제 생성 결과를 받지 못해 이전 코드를 유지하거나 빈 상태로 표시됨
- 수정: `latestCode`에서 `version`과 `previewUrl`을 추출해 `result` 포함 응답

## 장애 원인 요약

Supabase `platform_events` 조회로 확인된 실제 원인:
- 생성 시간이 350~430초로 Railway HTTP 300초 컷을 항상 초과
- CI/CD 배포(docs 업데이트 포함) 중 진행 중인 생성이 강제 종료됨
- SSE 끊김 후 폴링으로 전환 시 tracker TTL 만료 경로의 `result` 누락이 "이전 작업으로 되돌아가는" UX를 유발

> **현재 생성은 정상 완료되어 DB에 저장됨** — 서비스 중단은 아니며 클라이언트 측 결과 수신 경로 버그

## 테스트 계획

- [x] `pnpm type-check` 통과
- [x] `pnpm test --run` 1412건 통과
- [ ] `status` API: tracker TTL 만료 후 폴링 시 `result.version` 포함 여부 확인
- [ ] `regenerate` API: 라우트 레벨 실패 후 `user_daily_limits` 카운터 감소 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)