### PR TITLE
chore: API 카탈로그 즉시 사용 가능 기준 정리 (58개 → 23개 활성)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ pnpm test:coverage    # 커버리지 리포트
 | 코드 생성/재생성 작업 **(필수)** | [docs/guides/qc-process.md](docs/guides/qc-process.md) |
 | 테스트 전략·검증 항목 | [docs/guides/testing.md](docs/guides/testing.md) |
 | API 엔드포인트 목록 | [docs/reference/api-endpoints.md](docs/reference/api-endpoints.md) |
-| 골든셋 API 목록 (검증된 6개) | [docs/reference/golden-api-set.md](docs/reference/golden-api-set.md) |
+| 골든셋 API 목록 (검증된 10개, 즉시 사용 가능) | [docs/reference/golden-api-set.md](docs/reference/golden-api-set.md) |
 | 보안 인시던트 대응 절차 | [docs/security/incident-response.md](docs/security/incident-response.md) |
 | 환경변수 목록 | [docs/reference/env-vars.md](docs/reference/env-vars.md) |
 | 에러 클래스 참조 | [docs/reference/error-codes.md](docs/reference/error-codes.md) |
@@ -137,6 +137,8 @@ pnpm test:coverage    # 커버리지 리포트
 | 보안·접근성·커버리지 수정 ADR (PR #49·#50) | [docs/decisions/2026-04-26-sonarcloud-security-a11y-coverage.md](docs/decisions/2026-04-26-sonarcloud-security-a11y-coverage.md) |
 | 생성 성공률 개선 ADR (Phase 2, PR #58) | [docs/decisions/2026-04-29-generation-success-rate-improvement.md](docs/decisions/2026-04-29-generation-success-rate-improvement.md) |
 | 정확도 게이트 회귀 방지·가시화·개선 통합 ADR | [docs/decisions/2026-04-30-accuracy-gate-and-visibility.md](docs/decisions/2026-04-30-accuracy-gate-and-visibility.md) |
+| API 카탈로그 전수 검증 ADR (62개, 2026-05-01) | [docs/decisions/2026-05-01-api-catalog-verification.md](docs/decisions/2026-05-01-api-catalog-verification.md) |
+| API 카탈로그 즉시 사용 가능 기준 정리 ADR (23개 활성, 2026-05-01) | [docs/decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md](docs/decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md) |
 
 - [README.md](README.md) — 프로젝트 전체 개요
 - [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) — PR 템플릿

--- a/docs/decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md
+++ b/docs/decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md
@@ -1,0 +1,104 @@
+# API 카탈로그 즉시 사용 가능 기준 정리 ADR (2026-05-01)
+
+## 컨텍스트
+
+API 카탈로그 전수 검증(2026-05-01) 완료 후, 플랫폼 사용 목적에 부합하는 API만 활성 유지하기로 결정.
+
+**정리 기준:**
+1. **즉시 사용 가능** — 사용자가 계정 생성·이메일 인증·API 키 신청 등 어떤 사전 작업 없이 바로 호출 가능
+2. **지속 가능한 무료** — 6개월 타임아웃, 신용카드 요구, 향후 유료화 위험 없음
+3. **서비스 안정** — rate limit 불안정·공유 IP 고갈·비상업적 IP 차단 등 생성된 서비스를 불안정하게 만드는 위험 없음
+
+**배경**: AI가 생성한 서비스에서 API 키 미설정 또는 rate limit 초과 오류가 발생하면 사용자 서비스가 즉시 실패. 플랫폼 신뢰도 직결 문제.
+
+---
+
+## 조치 결과
+
+### 완전 삭제 (DELETE) — 15개
+
+**기존 비활성 4개 (복구 불가):**
+
+| API | 사유 |
+|-----|------|
+| NewsAPI.org | 서버사이드 호출 시 약관 위반 (426 응답) |
+| LibreTranslate | 2024년부터 공개 인스턴스 무료 키 발급 중단 |
+| Cat Facts | 403 Forbidden 지속 반환 |
+| 네이버 지도 | 2025-03-24 신규 가입 차단 |
+
+**신규 삭제 11개 (활성 → 삭제):**
+
+| API | 사유 |
+|-----|------|
+| SpaceX API | 메인테이너 공식 종료 선언, `/v4/launches/latest` 2022-10 데이터 고정 |
+| BigDataCloud | 무료 엔드포인트는 사용자 현재 위치 전용, 임의 좌표 → 402 차단. AI 생성 시나리오 구조 부적합 |
+| ipapi.co | 직접 접속 ECONNREFUSED — 서비스 자체 불안정 |
+| ODsay 대중교통 길찾기 | 6개월 무료 후 유료 Standard 플랜 전환 필수 — **지속 가능한 무료 기준 위반** |
+| CoinGecko | 키 없이 5~30 req/min 가변 (트래픽에 따라 급감) — 생성된 서비스 응답 불안정 |
+| Open-Meteo | **비상업적 전용** — 사용자 생성 서비스 상업화 시 IP 차단 위험. 플랫폼이 상업성 통제 불가 |
+| Free Dictionary API | creator 본인이 AWS 비용 압박 공개 언급. 중단 위험 현실적 |
+| Bored API | 원 서비스 종료 후 App Brewery 교육용 클론. 프로덕션 안정성 보장 없음 |
+| Agify.io | 키 없이 100건/일 — 프록시 서버 공유 IP 기준으로 다수 사용자 동시 사용 시 즉시 고갈 |
+| Genderize.io | 동일 사유 (Demografix ApS 동일 정책 전환) |
+| Nationalize.io | 동일 사유 |
+
+---
+
+### 비활성화 (is_active = false) — 24개
+
+API 키 등록 필요 → 즉시 사용 불가 기준 미달. 나중에 "사용자 제공 키" 기능 추가 시 재활성화 가능하도록 데이터 보존.
+
+**한국 공공 (data.go.kr, 17개):**
+기상청 단기예보, 기상청 중기예보, 에어코리아 대기오염정보, 공휴일 정보, 국립중앙도서관, 서울 열린데이터광장, NEIS 학교급식, 국토부 아파트 전월세, 아파트 실거래가, 한국관광공사 TourAPI, TAGO 전국 대중교통, 서울시 버스 도착정보, 서울시 지하철, HIRA 병원정보, 식약처 식품영양성분, 한국은행 ECOS, KOPIS 공연예술
+
+**한국 플랫폼 (2개):**
+카카오 로컬, 카카오 검색
+
+**글로벌 api_key (5개):**
+TMDB, RAWG, Unsplash, OpenWeatherMap, WeatherAPI.com
+
+---
+
+### 특별 처리 (유지 + 수정)
+
+| API | 조치 | 상세 |
+|-----|------|------|
+| **The Cat API** | auth_type `api_key → none` | 키 없이 `/v1/images/search` 즉시 호출 가능 실측 확인 (응답 헤더 `authenticated: false`). rate_limit `10/분`으로 갱신. |
+| **NASA 오늘의 천문 사진** | 유지 | `DEMO_KEY`가 공개 키로 등록 없이 즉시 사용 가능. auth_config의 `default_key` 자동 삽입. 50건/일 제한은 데모·PoC에 충분. |
+| **ZenQuotes** | cors_supported/requires_proxy 수정 | CORS 헤더 비활성화 실측 확인 → `cors_supported=false`, `requires_proxy=true`로 수정. 프록시 경유로 정상 동작. |
+
+---
+
+## 최종 현황
+
+- **활성 API: 23개** (즉시 사용 가능 + 지속 가능한 무료 기준 충족)
+- **비활성 API: 24개** (키 등록 필요, 데이터 보존)
+- **총 DB 레코드: 47개** (이전 62개 → 15개 삭제)
+
+**활성 23개 목록:**
+
+| 카테고리 | API |
+|---------|-----|
+| data | JSONPlaceholder, Random User, REST Countries, Wikipedia, Open Library |
+| entertainment | JokeAPI, Open Trivia DB, PokéAPI |
+| fun | TheMealDB, icanhazdadjoke |
+| image | Dog API, Lorem Picsum, The Cat API, NASA 오늘의 천문 사진 |
+| news | Hacker News API, Spaceflight News API |
+| finance | ExchangeRate-API, Frankfurter |
+| utility | QR Code Generator, Sunrise-Sunset, The Color API, wheretheiss.at |
+| fun | ZenQuotes |
+
+---
+
+## 골든셋 변경
+
+TMDB·RAWG → 비활성화로 제거. The Cat API(auth_type 재분류)·NASA DEMO_KEY 신규 추가.
+상세: [docs/reference/golden-api-set.md](../reference/golden-api-set.md)
+
+---
+
+## 향후 고려사항
+
+- **한국 공공 API 재활성화**: 사용자가 자신의 API 키를 프로젝트에 등록하는 "Bring Your Own Key" 기능 구현 시, 비활성화된 24개 API를 즉시 재활성화할 수 있도록 데이터 보존.
+- **SpaceX API 대체**: 실시간 우주 정보가 필요하면 Spaceflight News API가 대안.
+- **날씨 API 공백**: 즉시 사용 가능한 날씨 API가 현재 없음. Open-Meteo 비상업적 제한 해결 또는 다른 제로-키 날씨 API 발굴 필요.

--- a/docs/decisions/2026-05-01-api-catalog-verification.md
+++ b/docs/decisions/2026-05-01-api-catalog-verification.md
@@ -1,0 +1,130 @@
+# API 카탈로그 전수 검증 ADR (2026-05-01)
+
+## 컨텍스트
+
+62개 전체 API에 대해 4개 에이전트 병렬 검증을 수행했다. 검증 항목:
+- 서비스 운영 상태 (DNS, HTTP 응답)
+- 무료 여부 및 신규 키 발급 가능성
+- base_url HTTPS 지원 여부
+- rate_limit 실제값과 DB 등록값 일치 여부
+- 2024~2025년 정책 변경 사항
+
+---
+
+## 조치 결과
+
+### 비활성화 (is_active = false)
+
+| API | 사유 |
+|-----|------|
+| **NewsAPI.org** | 무료 Developer 플랜은 localhost 전용. 서버사이드(Railway 프록시) 호출 시 약관 위반(426). 프로덕션 플랜 $449/월~ |
+| **LibreTranslate** | 공개 인스턴스 무료 API 키 발급 중단(2024~). Pro 플랜 $29/월~ 필요 |
+| **Cat Facts** | 403 Forbidden 지속 반환. 서비스 불안정 |
+| **네이버 지도 (Geocoding)** | 2025-03-24부터 신규 이용 신청 차단 (gov-ncloud.com 공지 499번). 기존 계정 유지만 가능 |
+
+### 데이터 오류 수정
+
+| API | 변경 내용 |
+|-----|-----------|
+| **카카오 검색** | `cors_supported: false → true`, `requires_proxy: true → false` (실측: `Access-Control-Allow-Origin: *` 확인) |
+| **국립중앙도서관** | `base_url` `/NL/search/openApi` → `/NL/search/openApi/search.do` (기존 경로 404 반환) |
+
+### HTTP → HTTPS 전환 (7개)
+
+`apis.data.go.kr`는 공식 문서가 HTTP 표기이지만 실서버는 HTTPS TLS 연결 수락 확인됨.
+
+| API | 변경 전 → 후 |
+|-----|------------|
+| 기상청 단기예보 | `http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0` → `https://` |
+| 기상청 중기예보 | `http://apis.data.go.kr/1360000/MidFcstInfoService` → `https://` |
+| 에어코리아 대기오염 | `http://apis.data.go.kr/B552584/ArpltnInforInqireSvc` → `https://` |
+| 공휴일 정보 | `http://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService` → `https://` |
+| TAGO 전국 대중교통 | `http://apis.data.go.kr/1613000` → `https://` |
+| 아파트 실거래가 | `http://apis.data.go.kr/1613000/RTMSDataSvcAptTradeDev` → `https://` |
+| 한국관광공사 TourAPI | `http://apis.data.go.kr/B551011/KorService1` → `https://` |
+
+> HTTP 전용 유지 (서버 자체가 HTTPS 미지원): 서울 열린데이터광장(8088포트), 서울시 버스 도착정보, 서울시 지하철.
+> 세 API 모두 `requires_proxy=true`라 서버사이드 호출이 기본 — Mixed Content 문제 없음.
+
+### Rate Limit 수정
+
+| API | 이전 | 수정 후 |
+|-----|------|---------|
+| WeatherAPI.com | `"500"` | `"100000/월"` |
+| Bored API | `"300"` | `"7/분(100req/15분)"` |
+| Open Trivia DB | `"50"` | `"12/분(5초 간격)"` |
+| The Cat API | `"100"` | `"10000/월"` |
+| RAWG | `null` | `"20000/월"` |
+| TMDB | `"40"` | `null` (2019년 rate limit 폐지) |
+| Agify.io | `"100"` | `"1000/일"` |
+| Genderize.io | `"100"` | `"1000/일"` |
+| Nationalize.io | `"100"` | `"1000/일"` |
+| 에어코리아 | `"300"` | `"500/일"` ← 타 공공API의 1/20 |
+
+### Description / Note 업데이트
+
+| API | 내용 |
+|-----|------|
+| ODsay | "6개월 무료, 이후 유료 Standard 플랜 전환 필수" 경고 추가 |
+| 에어코리아 | 개발계정 500건/일 낮은 한도 경고 추가 |
+| TheMealDB | 무료 키(v1/1) 기능 제한(100건, v2 미지원) 명시 |
+| 한국은행 ECOS | 키 발급 경로가 data.go.kr이 아닌 ecos.bok.or.kr 자체 가입임 명시 |
+| CoinGecko | Demo 키 권고 정책 변경 안내 |
+| 아파트 실거래가 | "Dev"는 개발용이 아닌 "상세 자료" 버전 정식명임 명시 |
+| TAGO | base_url /1613000은 기관코드 prefix. 실사용 시 서비스 경로 추가 필요 명시 |
+| 서울시 3개 | HTTP 전용 서버 확인, requires_proxy=true로 프록시 경유 정상 동작 명시 |
+
+---
+
+## 신규 추가 API (이번 세션, Step 2)
+
+골든셋에 검증 완료 상태로 추가:
+
+| API | 카테고리 | 인증 | 비고 |
+|-----|---------|------|------|
+| TMDB | entertainment | api_key | 신용카드 불필요, 한국어 지원 |
+| TheMealDB | fun | none | 테스트 키 "1" 무료, v2는 유료 |
+| The Color API | utility | none | 사실상 무제한 무료 |
+| RAWG | entertainment | api_key | 월 20,000건, 비상업 무료 |
+| NEIS 학교급식 | public | api_key | open.neis.go.kr |
+| 카카오 검색 | search | api_key | CORS 지원, 프록시 불필요 |
+| 식약처 식품영양성분 | health | api_key | data.go.kr |
+| HIRA 병원정보 | health | api_key | data.go.kr |
+| 국토부 아파트 전월세 | public | api_key | data.go.kr |
+| KOPIS 공연예술 | entertainment | api_key | XML 전용 응답 |
+| ZenQuotes | fun | none | Quotable 대체 |
+
+---
+
+## 교체된 API (이번 세션, Step 1)
+
+| 기존 | 교체/수정 | 사유 |
+|------|----------|------|
+| CoinDesk BPI | 삭제 | DNS 실패 |
+| Numbers API | 삭제 | HTTPS 미지원, project_count=0 |
+| Quotable | 삭제 → ZenQuotes로 대체 | mirror 서비스 종료 |
+| IP-API | ipapi.co로 교체 | HTTP→HTTPS, 동일 기능 |
+| Open Notify | wheretheiss.at으로 교체 | 서비스 종료 |
+| Frankfurter | base_url: `api.frankfurter.app` → `api.frankfurter.dev/v1` | 도메인 이전 |
+| LibreTranslate | auth_type: `none` → `api_key` | 실제 키 필수로 정정 |
+
+---
+
+## 중복 검토 결론
+
+| 쌍 | 결론 |
+|----|------|
+| 카카오 로컬 vs 카카오 검색 | 기능 완전히 다름 (지도 vs 웹/이미지/뉴스). 모두 유지 |
+| ExchangeRate-API vs Frankfurter | 구조·사용 패턴 다름. 모두 유지 |
+| 기상청 단기 vs 중기 | 예보 기간·좌표 체계 다름. 모두 유지 |
+| 아파트 실거래가 vs 전월세 | 매매 vs 임대차 — 상호보완. 모두 유지 |
+| 네이버 지도 vs 카카오 로컬 | 네이버 신규 가입 차단 → 비활성화. 카카오 로컬 단독 유지 |
+
+---
+
+## 최종 현황
+
+- 활성 API: **58개**
+- 비활성 API: **4개** (NewsAPI.org, LibreTranslate, Cat Facts, 네이버 지도)
+- 오늘 verified_at 갱신: **29개**
+- HTTP 전용 유지(변경 불가): 서울시 3개 (서버 HTTPS 미지원)

--- a/docs/reference/golden-api-set.md
+++ b/docs/reference/golden-api-set.md
@@ -1,10 +1,14 @@
 # 골든셋 API 목록
 
-검증 날짜: **2026-04-16**
-검증 방법: `scripts/verifyCatalog.ts` 자동 검증 스크립트
+검증 날짜: **2026-05-01** (전수 재검증 + 즉시 사용 가능 기준 정리)
+검증 방법: 4개 에이전트 병렬 WebFetch/WebSearch + DB 직접 확인
 
-골든셋은 실제 HTTP 요청으로 동작이 확인된 API들의 집합입니다.
-이 API들은 `verification_status = 'verified'`로 표시되며, AI 코드 생성 시 우선 추천됩니다.
+골든셋은 실제 동작이 확인된 API들의 집합입니다.
+`verification_status = 'verified'`로 표시되며, AI 코드 생성 시 우선 추천됩니다.
+
+> **2026-05-01 업데이트 (즉시 사용 가능 기준 정리)**: API 키 등록 없이 즉시 사용 가능한 API만 활성 유지.
+> TMDB·RAWG → is_active=false (키 등록 필요). The Cat API(auth_type→none 재분류)·NASA DEMO_KEY 신규 추가.
+> 전체 정리 내역: [docs/decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md](../decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md)
 
 ---
 
@@ -15,9 +19,13 @@
 | 1 | Random User | `6890346f-fa79-483c-bce2-f841ad3420fd` | data | GET /api/ |
 | 2 | JSONPlaceholder | `04e79764-c27c-46d8-b63c-2794fbe5a3f7` | data | GET /posts, /todos, /users |
 | 3 | PokéAPI | `02cea7ab-d89a-4e51-b9c5-32ed0fd00338` | entertainment | GET /api/v2/pokemon |
-| 4 | Open Notify (ISS) | `9a04cd18-15bb-4424-a4f1-10ddf728749b` | science | GET /iss-now.json, /astros.json |
+| 4 | wheretheiss.at | `9a04cd18-15bb-4424-a4f1-10ddf728749b` | utility | GET /v1/satellites/25544 |
 | 5 | Hacker News API | `de8f5375-22dc-4573-9a64-2903c150fece` | news | GET /v0/topstories.json |
 | 6 | Spaceflight News API | `8461e4de-ba6d-4a4d-ae24-35bd7c47c0c7` | news | GET /v4/articles/ |
+| 7 | The Cat API | `f1b6d26f-4cb4-4ea7-844b-8c6ba3b29a8a` | image | GET /v1/images/search |
+| 8 | TheMealDB | `da2e14a4-e8c6-4164-835e-6ce8b212d59b` | fun | GET /random.php |
+| 9 | The Color API | `522f7158-7de0-4447-80bb-ea71a8e56b50` | utility | GET /id?hex=FF5733 |
+| 10 | NASA 오늘의 천문 사진 | `7b66ab19-4d00-4d39-a4f9-2c2b6c6367a4` | image | GET /planetary/apod |
 
 ---
 
@@ -47,17 +55,8 @@ const items = data.results; // [{name, email, picture, location, ...}]
 - **responseDataPath**: 없음 (direct array)
 
 ```js
-// /posts
 const res = await fetch('/api/v1/proxy?apiId=04e79764-c27c-46d8-b63c-2794fbe5a3f7&proxyPath=%2Fposts');
 const items = await res.json(); // [{id, userId, title, body}]
-
-// /todos
-const res = await fetch('/api/v1/proxy?apiId=04e79764-c27c-46d8-b63c-2794fbe5a3f7&proxyPath=%2Ftodos');
-const items = await res.json(); // [{id, userId, title, completed}]
-
-// /users
-const res = await fetch('/api/v1/proxy?apiId=04e79764-c27c-46d8-b63c-2794fbe5a3f7&proxyPath=%2Fusers');
-const items = await res.json(); // [{id, name, username, email, address, phone, website, company}]
 ```
 
 ---
@@ -78,22 +77,20 @@ const items = data.results; // [{name, url}]
 
 ---
 
-### 4. Open Notify (ISS)
+### 4. wheretheiss.at (구: Open Notify)
 
-- **baseUrl**: `http://api.open-notify.org`
-- **requiresProxy**: true (HTTP only, CORS 없음)
-- **검증 엔드포인트**: `GET /iss-now.json`, `GET /astros.json`
+- **baseUrl**: `https://api.wheretheiss.at`
+- **requiresProxy**: true (CORS 미지원)
+- **검증 엔드포인트**: `GET /v1/satellites/25544`
+- **응답 구조**: `{ latitude, longitude, altitude, velocity, timestamp, ... }`
+
+> Open Notify는 2024년 서비스 종료. 동일 UUID로 wheretheiss.at으로 교체됨.
 
 ```js
 // ISS 현재 위치
-const res = await fetch('/api/v1/proxy?apiId=9a04cd18-15bb-4424-a4f1-10ddf728749b&proxyPath=%2Fiss-now.json');
+const res = await fetch('/api/v1/proxy?apiId=9a04cd18-15bb-4424-a4f1-10ddf728749b&proxyPath=%2Fv1%2Fsatellites%2F25544');
 const data = await res.json();
-// data.iss_position.latitude, data.iss_position.longitude
-
-// 우주 비행사 목록
-const res = await fetch('/api/v1/proxy?apiId=9a04cd18-15bb-4424-a4f1-10ddf728749b&proxyPath=%2Fastros.json');
-const data = await res.json();
-const items = data.people; // [{name, craft}]  ← responseDataPath: "people"
+// data.latitude, data.longitude, data.altitude, data.velocity
 ```
 
 ---
@@ -124,7 +121,71 @@ const storyIds = await res.json(); // [integer IDs]
 ```js
 const res = await fetch('/api/v1/proxy?apiId=8461e4de-ba6d-4a4d-ae24-35bd7c47c0c7&proxyPath=%2Fv4%2Farticles%2F');
 const data = await res.json();
-const items = data.results; // [{id, title, url, imageUrl, newsSite, summary, publishedAt}]
+const items = data.results;
+```
+
+---
+
+### 7. The Cat API
+
+- **baseUrl**: `https://api.thecatapi.com`
+- **authType**: none (키 없이 기본 호출 가능 — 2026-05-01 실측 확인)
+- **requiresProxy**: false, **corsSupported**: true
+- **rate limit**: 10건/분 (키 없이)
+- **검증 엔드포인트**: `GET /v1/images/search`
+- **응답 구조**: `[{id, url, width, height}]` (배열 직접 반환)
+
+```js
+const res = await fetch('/api/v1/proxy?apiId=f1b6d26f-4cb4-4ea7-844b-8c6ba3b29a8a&proxyPath=%2Fv1%2Fimages%2Fsearch&limit=10');
+const images = await res.json(); // [{id, url, width, height}]
+```
+
+---
+
+### 8. TheMealDB
+
+- **baseUrl**: `https://www.themealdb.com/api/json/v1/1`
+- **authType**: none (키 "1"은 공개 테스트 키)
+- **requiresProxy**: false, **corsSupported**: true
+- **주의**: 무료 키(v1/1)는 100건 이하·단일 재료 필터·기본 기능만. v2 기능은 Patreon 키 필요.
+
+```js
+const res = await fetch('/api/v1/proxy?apiId=da2e14a4-e8c6-4164-835e-6ce8b212d59b&proxyPath=%2Frandom.php');
+const data = await res.json();
+const meal = data.meals[0]; // {strMeal, strCategory, strInstructions, strMealThumb}
+```
+
+---
+
+### 9. The Color API
+
+- **baseUrl**: `https://www.thecolorapi.com`
+- **authType**: none
+- **requiresProxy**: false, **corsSupported**: true
+- **rate limit**: 없음 (공식 명시 없음, 사실상 무제한)
+
+```js
+const res = await fetch('/api/v1/proxy?apiId=522f7158-7de0-4447-80bb-ea71a8e56b50&proxyPath=%2Fid&hex=FF5733');
+const data = await res.json();
+// data.name.value, data.rgb, data.hsl
+```
+
+---
+
+### 10. NASA 오늘의 천문 사진
+
+- **baseUrl**: `https://api.nasa.gov`
+- **authType**: api_key — **DEMO_KEY 공개 키 사용 (계정 등록 불필요)**
+- **requiresProxy**: false, **corsSupported**: true
+- **rate limit**: 시간당 30건/IP, 일 50건/IP (DEMO_KEY 기준)
+- **검증 엔드포인트**: `GET /planetary/apod`
+- **응답 구조**: `{ date, title, explanation, url, hdurl, media_type }`
+- **주의**: DEMO_KEY는 auth_config의 default_key로 자동 삽입됨. 신용카드·가입 불필요.
+
+```js
+const res = await fetch('/api/v1/proxy?apiId=7b66ab19-4d00-4d39-a4f9-2c2b6c6367a4&proxyPath=%2Fplanetary%2Fapod');
+const data = await res.json();
+// data.title, data.explanation, data.url (이미지 URL), data.date
 ```
 
 ---
@@ -132,8 +193,8 @@ const items = data.results; // [{id, title, url, imageUrl, newsSite, summary, pu
 ## DB 반영 방법
 
 `scripts/backfillGoldenSet.sql`을 Supabase SQL 에디터에서 실행하면
-위 6개 API의 `verification_status`, `verified_at`, `last_verification_note`, `endpoints[*].example_call`, `endpoints[*].response_data_path`가 업데이트됩니다.
+위 API들의 `verification_status`, `verified_at`, `last_verification_note` 등이 업데이트됩니다.
 
 - SQL은 `jsonb_array_elements` + `CASE WHEN` 패턴으로 기존 endpoint 필드를 보존한 채 새 필드만 병합합니다.
 - 엔드포인트 path가 DB에 저장된 값과 다를 경우 해당 UPDATE는 NOOP으로 처리됩니다 (기존 데이터 손실 없음).
-- 실행 후 스크립트 말미의 `SELECT` 쿼리로 6개 행의 `verification_status`가 `verified`인지 확인하세요.
+- 실행 후 스크립트 말미의 `SELECT` 쿼리로 `verification_status`가 `verified`인지 확인하세요.


### PR DESCRIPTION
## Summary

- **즉시 사용 가능 + 지속 가능한 무료** 기준으로 API 카탈로그 전면 정리
- DB 변경은 이미 Supabase에 반영됨 (이 PR은 문서 동기화)
- 3개 에이전트 병렬 검증 후 사용자 승인을 받아 실행

## 변경 내용

### DB 변경 (Supabase — 이미 적용)

| 구분 | 수량 | 대상 |
|------|------|------|
| DELETE | 15개 | 기존 비활성 4개 + SpaceX(종료)·BigDataCloud(구조 부적합)·ipapi.co(불안정)·ODsay(6개월 타임폭탄)·CoinGecko(rate 불안정)·Open-Meteo(비상업적 제한)·Free Dictionary(재정 위기)·Bored API(교육 클론)·Agify/Genderize/Nationalize(100건/일 공유 IP 즉시 고갈) |
| is_active=false | 24개 | 한국 공공 17개 + 한국 플랫폼 2개 + 글로벌 api_key 5개 (키 등록 필요, 데이터 보존) |
| 특별 수정 | 3개 | The Cat API(auth_type→none), NASA(DEMO_KEY 노트), ZenQuotes(CORS/proxy 수정) |

**최종 활성: 23개** — 전부 즉시 사용 가능 + 지속 가능한 무료

### 문서 변경

- `docs/reference/golden-api-set.md` — TMDB·RAWG 제거, The Cat API·NASA DEMO_KEY 신규 추가
- `docs/decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md` — 신규 ADR
- `docs/decisions/2026-05-01-api-catalog-verification.md` — 전수 검증 ADR (누락 파일 추가)
- `CLAUDE.md` — 문서 참조 테이블 갱신

## Test plan

- [ ] 활성 API 23개 확인: `SELECT name FROM api_catalog WHERE is_active = true ORDER BY name`
- [ ] 비활성 API 24개 확인: `SELECT name FROM api_catalog WHERE is_active = false ORDER BY name`
- [ ] The Cat API auth_type=none 확인
- [ ] ZenQuotes cors_supported=false, requires_proxy=true 확인
- [ ] 골든셋 문서 #7(The Cat API), #10(NASA) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)