### PR TITLE
fix: 생성 페이지 디자인 미적용 버그 수정 — assembleHtml CDN 재주입

### DIFF
--- a/src/lib/ai/codeParser.test.ts
+++ b/src/lib/ai/codeParser.test.ts
@@ -242,4 +242,61 @@ describe('assembleHtml', () => {
     expect(result).not.toContain('https://evil.example.com');
     expect(result).toContain('<p>safe</p>');
   });
+
+  // ── CDN 재주입 테스트 (DOMPurify가 제거한 CDN을 assembleHtml이 복원하는지 검증) ──
+
+  it('Tailwind CDN script 태그를 </head> 앞에 재주입한다 (풀 문서)', () => {
+    const html = '<html><head></head><body><p class="bg-blue-500">Hello</p></body></html>';
+    const result = assembleHtml({ html, css: '', js: '' });
+    expect(result).toContain('cdn.tailwindcss.com');
+    const tailwindIdx = result.indexOf('cdn.tailwindcss.com');
+    const headCloseIdx = result.indexOf('</head>');
+    expect(tailwindIdx).toBeGreaterThan(-1);
+    expect(tailwindIdx).toBeLessThan(headCloseIdx);
+  });
+
+  it('tailwind.config 인라인 스크립트를 재주입한다 (풀 문서)', () => {
+    const html = '<html><head></head><body></body></html>';
+    const result = assembleHtml({ html, css: '', js: '' });
+    expect(result).toContain('tailwind.config');
+    expect(result).toContain('pretendard');
+  });
+
+  it('Pretendard 폰트 CDN link 태그를 재주입한다 (풀 문서)', () => {
+    const html = '<html><head></head><body></body></html>';
+    const result = assembleHtml({ html, css: '', js: '' });
+    expect(result).toContain('cdn.jsdelivr.net');
+    expect(result).toContain('pretendardvariable-dynamic-subset');
+  });
+
+  it('Font Awesome CDN link 태그를 재주입한다 (풀 문서)', () => {
+    const html = '<html><head></head><body></body></html>';
+    const result = assembleHtml({ html, css: '', js: '' });
+    expect(result).toContain('font-awesome');
+    expect(result).toContain('cdnjs.cloudflare.com');
+  });
+
+  it('Tailwind CDN이 이미 있으면 중복 주입하지 않는다', () => {
+    const html =
+      '<html><head><script src="https://cdn.tailwindcss.com"></script></head><body></body></html>';
+    const result = assembleHtml({ html, css: '', js: '' });
+    const count = (result.match(/cdn\.tailwindcss\.com/g) ?? []).length;
+    expect(count).toBe(1);
+  });
+
+  it('비-풀 문서 HTML에서도 Tailwind CDN을 주입한다', () => {
+    const result = assembleHtml({ html: '<p class="text-blue-500">Hello</p>', css: '', js: '' });
+    expect(result).toContain('cdn.tailwindcss.com');
+    expect(result).toContain('tailwind.config');
+    expect(result).toContain('pretendardvariable-dynamic-subset');
+    expect(result).toContain('font-awesome');
+  });
+
+  it('악성 도메인 script는 제거되고 화이트리스트 CDN은 재주입된다', () => {
+    const html =
+      '<html><head><script src="https://evil.com/payload.js"></script></head><body></body></html>';
+    const result = assembleHtml({ html, css: '', js: '' });
+    expect(result).not.toContain('evil.com');
+    expect(result).toContain('cdn.tailwindcss.com');
+  });
 });

--- a/src/lib/ai/codeParser.ts
+++ b/src/lib/ai/codeParser.ts
@@ -5,6 +5,27 @@ DOMPurify.addHook('uponSanitizeAttribute', (_el, data) => {
   if (/^(x-|:|@)/.test(data.attrName)) data.forceKeepAttr = true;
 });
 
+// CDN whitelist re-injection constants.
+// DOMPurify strips <script src> and <link> tags by design (XSS prevention).
+// These known-safe CDN tags are re-injected explicitly after sanitization —
+// same pattern as Alpine.js injection. Keep URLs in sync with promptBuilder.ts.
+const TAILWIND_CDN_TAG = '  <script src="https://cdn.tailwindcss.com"></script>';
+const TAILWIND_CONFIG_TAG = [
+  '  <script>',
+  '    tailwind.config = {',
+  '      theme: { extend: {',
+  "        fontFamily: { pretendard: ['Pretendard Variable', 'Pretendard', 'sans-serif'] },",
+  '      } },',
+  '    };',
+  '  </script>',
+].join('\n');
+const PRETENDARD_CDN_TAG = [
+  '  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>',
+  '  <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/packages/pretendard/dist/web/variable/pretendardvariable-dynamic-subset.min.css" rel="stylesheet">',
+].join('\n');
+const FONT_AWESOME_CDN_TAG =
+  '  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">';
+
 export interface ParsedCode {
   html: string;
   css: string;
@@ -225,6 +246,35 @@ export function assembleHtml(parsed: ParsedCode): string {
       }
     }
 
+    // Re-inject Tailwind CDN + config (DOMPurify strips <script src> by design)
+    if (!assembled.includes('cdn.tailwindcss.com')) {
+      const idx = assembled.lastIndexOf('</head>');
+      assembled =
+        assembled.slice(0, idx) +
+        TAILWIND_CDN_TAG + '\n' +
+        TAILWIND_CONFIG_TAG + '\n' +
+        assembled.slice(idx);
+    }
+
+    // Re-inject Pretendard font CDN (check CDN URL, not just the word "pretendard"
+    // which already appears inside TAILWIND_CONFIG_TAG's fontFamily definition)
+    if (!assembled.includes('pretendardvariable-dynamic-subset')) {
+      const idx = assembled.lastIndexOf('</head>');
+      assembled =
+        assembled.slice(0, idx) +
+        PRETENDARD_CDN_TAG + '\n' +
+        assembled.slice(idx);
+    }
+
+    // Re-inject Font Awesome CDN
+    if (!assembled.includes('font-awesome')) {
+      const idx = assembled.lastIndexOf('</head>');
+      assembled =
+        assembled.slice(0, idx) +
+        FONT_AWESOME_CDN_TAG + '\n' +
+        assembled.slice(idx);
+    }
+
     // Inject Alpine.js CDN before </head> (skip if already present)
     if (!assembled.includes('alpinejs')) {
       const alpineTag =
@@ -276,6 +326,10 @@ export function assembleHtml(parsed: ParsedCode): string {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${title}</title>
+${TAILWIND_CDN_TAG}
+${TAILWIND_CONFIG_TAG}
+${PRETENDARD_CDN_TAG}
+${FONT_AWESOME_CDN_TAG}
   ${headInjections}
 ${alpineScript}</head>
 <body>

--- a/src/lib/ai/codeValidator.ts
+++ b/src/lib/ai/codeValidator.ts
@@ -116,6 +116,9 @@ export interface QualityMetrics {
   hasJsonParse: boolean;
   placeholderCount: number;
   hardcodedArrayCount: number;
+  // Informational: did the AI include Tailwind CDN in the raw HTML?
+  // assembleHtml() always re-injects it regardless, so this does not affect scoring.
+  hasTailwindCdn: boolean;
   details: string[];
 }
 
@@ -283,6 +286,8 @@ export function evaluateQuality(html: string, _css: string, js: string): Quality
   const mobileChecks = [hasResponsiveClasses, hasAdequateResponsive, noFixedOverflow, hasImageProtection, hasMobileNav];
   const mobileScore = Math.round((mobileChecks.filter(Boolean).length / mobileChecks.length) * 100);
 
+  const hasTailwindCdn = /cdn\.tailwindcss\.com/.test(html);
+
   return {
     structuralScore,
     mobileScore,
@@ -301,6 +306,7 @@ export function evaluateQuality(html: string, _css: string, js: string): Quality
     hasJsonParse,
     placeholderCount,
     hardcodedArrayCount,
+    hasTailwindCdn,
     details,
   };
 }

--- a/src/lib/ai/generationSaver.test.ts
+++ b/src/lib/ai/generationSaver.test.ts
@@ -153,6 +153,7 @@ const mockQuality: QualityMetrics = {
   hasJsonParse: false,
   placeholderCount: 0,
   hardcodedArrayCount: 0,
+  hasTailwindCdn: true,
   details: [],
 };
 

--- a/src/lib/ai/qualityLoop.adoption.test.ts
+++ b/src/lib/ai/qualityLoop.adoption.test.ts
@@ -32,6 +32,7 @@ const baseMetrics: QualityMetrics = {
   hasImageProtection: true, hasMobileNav: true, hasFooter: true, hasImgAlt: true,
   fetchCallCount: 1, hasProxyCall: true, hasJsonParse: true, placeholderCount: 0,
   hardcodedArrayCount: 0,
+  hasTailwindCdn: true,
   details: [],
 };
 

--- a/src/lib/ai/qualityLoop.test.ts
+++ b/src/lib/ai/qualityLoop.test.ts
@@ -17,6 +17,7 @@ const baseMetrics: QualityMetrics = {
   hasImageProtection: true, hasMobileNav: true, hasFooter: true, hasImgAlt: true,
   fetchCallCount: 1, hasProxyCall: true, hasJsonParse: true, placeholderCount: 0,
   hardcodedArrayCount: 0,
+  hasTailwindCdn: true,
   details: [],
 };
 

--- a/src/lib/qc/renderingQc.test.ts
+++ b/src/lib/qc/renderingQc.test.ts
@@ -42,6 +42,7 @@ function makeHighQualityMetrics(overrides: Partial<QualityMetrics> = {}): Qualit
     hasJsonParse: true,
     placeholderCount: 0,
     hardcodedArrayCount: 0,
+    hasTailwindCdn: true,
     details: [],
     ...overrides,
   };


### PR DESCRIPTION
## 버그 요약

**모든 생성 페이지에 Tailwind CSS 스타일링이 전혀 적용되지 않음** — 프로덕션 서비스 전체 영향.

## 루트 원인

`assembleHtml()` 내 `DOMPurify.sanitize()` 호출이 XSS 방지를 위해 `<script src>`, `<link>` 태그를 전면 제거합니다. Alpine.js는 sanitize 이후 화이트리스트로 재주입하는 코드가 있었지만, **Tailwind CDN은 동일한 처리를 받지 못했습니다.**

```
DB에 저장된 HTML (AI 정상 생성)         →  DOMPurify         →  브라우저 전달
────────────────────────────────────────────────────────────────
<script src="cdn.tailwindcss.com">       →  ❌ 제거  →  Tailwind 클래스 무효
<link href="Pretendard CDN">             →  ❌ 제거  →  폰트 fallback
<link href="Font Awesome CDN">           →  ❌ 제거  →  아이콘 미표시
<script>tailwind.config = {...}          →  ❌ 제거  →  커스텀 폰트 무효
class="bg-gray-50 grid-cols-3 ..."      →  ✅ 유지  →  클래스만 있고 처리 엔진 없음
```

## 수정 내용

**`assembleHtml()`에서 Alpine.js와 동일한 화이트리스트 재주입 패턴 적용:**
- Tailwind CDN `<script src>` 재주입
- `tailwind.config` (Pretendard fontFamily) inline script 재주입
- Pretendard 폰트 `<link>` 재주입
- Font Awesome `<link>` 재주입
- 풀 문서 분기 + 비-풀 문서 fallback 분기 **양쪽 모두 처리**
- 이미 존재하는 경우 중복 주입 방지

**DOMPurify 설정은 변경하지 않음** — 보안 수준 유지.

## 영향 범위

- 미리보기 (`/api/v1/preview/[projectId]`) — `assembleHtml()` 경유 → 즉시 복구
- 게시 서브도메인 (`slug.xzawed.xyz`) — `assembleHtml()` 경유 → 즉시 복구
- **기존 DB 저장 코드도 재배포만으로 복구** (서빙 시마다 assembleHtml 재조립)

## Test plan

- [x] `pnpm test src/lib/ai/codeParser.test.ts` — 35개 전체 통과 (CDN 재주입 7개 신규 포함)
- [x] `pnpm test` — 1,426개 전체 통과
- [ ] Railway 배포 후 생성 페이지 Tailwind 클래스 적용 여부 직접 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)