### PR TITLE
fix: CDN 재주입 if 가드 제거 — SonarCloud new_coverage 개선

### DIFF
--- a/src/lib/ai/codeParser.test.ts
+++ b/src/lib/ai/codeParser.test.ts
@@ -276,7 +276,8 @@ describe('assembleHtml', () => {
     expect(result).toContain('cdnjs.cloudflare.com');
   });
 
-  it('Tailwind CDN이 이미 있으면 중복 주입하지 않는다', () => {
+  it('AI 생성 HTML에 Tailwind CDN이 있어도 DOMPurify 제거 후 재주입 — count=1', () => {
+    // DOMPurify removes the original <script src>, so we re-inject exactly once
     const html =
       '<html><head><script src="https://cdn.tailwindcss.com"></script></head><body></body></html>';
     const result = assembleHtml({ html, css: '', js: '' });

--- a/src/lib/ai/codeParser.ts
+++ b/src/lib/ai/codeParser.ts
@@ -246,34 +246,16 @@ export function assembleHtml(parsed: ParsedCode): string {
       }
     }
 
-    // Re-inject Tailwind CDN + config (DOMPurify strips <script src> by design)
-    if (!assembled.includes('cdn.tailwindcss.com')) {
-      const idx = assembled.lastIndexOf('</head>');
-      assembled =
-        assembled.slice(0, idx) +
-        TAILWIND_CDN_TAG + '\n' +
-        TAILWIND_CONFIG_TAG + '\n' +
-        assembled.slice(idx);
-    }
-
-    // Re-inject Pretendard font CDN (check CDN URL, not just the word "pretendard"
-    // which already appears inside TAILWIND_CONFIG_TAG's fontFamily definition)
-    if (!assembled.includes('pretendardvariable-dynamic-subset')) {
-      const idx = assembled.lastIndexOf('</head>');
-      assembled =
-        assembled.slice(0, idx) +
-        PRETENDARD_CDN_TAG + '\n' +
-        assembled.slice(idx);
-    }
-
-    // Re-inject Font Awesome CDN
-    if (!assembled.includes('font-awesome')) {
-      const idx = assembled.lastIndexOf('</head>');
-      assembled =
-        assembled.slice(0, idx) +
-        FONT_AWESOME_CDN_TAG + '\n' +
-        assembled.slice(idx);
-    }
+    // Re-inject Tailwind CDN + config (DOMPurify strips all <script src> and <link> tags by design;
+    // these whitelisted CDN tags are always re-injected unconditionally after sanitization)
+    const headIdx = assembled.lastIndexOf('</head>');
+    assembled =
+      assembled.slice(0, headIdx) +
+      TAILWIND_CDN_TAG + '\n' +
+      TAILWIND_CONFIG_TAG + '\n' +
+      PRETENDARD_CDN_TAG + '\n' +
+      FONT_AWESOME_CDN_TAG + '\n' +
+      assembled.slice(headIdx);
 
     // Inject Alpine.js CDN before </head> (skip if already present)
     if (!assembled.includes('alpinejs')) {


### PR DESCRIPTION
## 문제

PR #75 머지 후 SonarCloud `new_coverage = 75.8%` (임계값 80%) — 품질 게이트 ERROR.

## 원인

DOMPurify는 `<script src>` / `<link>` 태그를 **항상** 제거합니다. 따라서 CDN 재주입 시 사용한 `if (!assembled.includes(...))` 가드는 조건이 항상 `true`이며 `false` 브랜치는 절대 실행되지 않는 사장 코드(dead branch)입니다. SonarCloud가 미적용 브랜치로 집계해 커버리지를 낮췄습니다.

## 수정

4개의 `if` 가드를 제거하고 단일 `headIdx` 위치에 4개 CDN 태그를 한 번에 삽입하도록 단순화합니다.

```ts
// 수정 전 (4개 분기문)
if (!assembled.includes('cdn.tailwindcss.com')) { ... }
if (!assembled.includes('pretendardvariable-dynamic-subset')) { ... }
if (!assembled.includes('font-awesome')) { ... }

// 수정 후 (단순 삽입)
const headIdx = assembled.lastIndexOf('</head>');
assembled = assembled.slice(0, headIdx) + TAILWIND_CDN_TAG + '\n' + ... + assembled.slice(headIdx);
```

## Test plan

- [x] `pnpm type-check` 통과
- [x] `pnpm test` — 1,426개 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)