### PR TITLE
fix: Anthropic Extended Thinking API 마이그레이션 (enabled→adaptive)

### DIFF
--- a/src/providers/ai/ClaudeProvider.test.ts
+++ b/src/providers/ai/ClaudeProvider.test.ts
@@ -140,7 +140,8 @@ describe('ClaudeProvider', () => {
       await provider.generateCode({ system: 'sys', user: 'user', extendedThinking: true });
       const callArg = mockCreate.mock.calls[0][0] as Record<string, unknown>;
       expect(callArg).toMatchObject({
-        thinking: { type: 'enabled', budget_tokens: 32000 },
+        thinking: { type: 'adaptive' },
+        output_config: { effort: 'high' },
       });
       expect(callArg).not.toHaveProperty('temperature');
     });

--- a/src/providers/ai/ClaudeProvider.ts
+++ b/src/providers/ai/ClaudeProvider.ts
@@ -110,7 +110,8 @@ export class ClaudeProvider implements IAiProvider {
         messages: [{ role: 'user', content: prompt.user }],
         max_tokens: prompt.maxTokens ?? 48000,
         ...(useThinking && {
-          thinking: { type: 'enabled' as const, budget_tokens: 32000 },
+          thinking: { type: 'adaptive' as const },
+          output_config: { effort: 'high' as const },
         }),
       });
 
@@ -147,7 +148,8 @@ export class ClaudeProvider implements IAiProvider {
         messages: [{ role: 'user', content: prompt.user }],
         max_tokens: prompt.maxTokens ?? 48000,
         ...(useThinking && {
-          thinking: { type: 'enabled' as const, budget_tokens: 32000 },
+          thinking: { type: 'adaptive' as const },
+          output_config: { effort: 'high' as const },
         }),
       });
 


### PR DESCRIPTION
## 요약
- `claude-opus-4-7`에서 `thinking.type: 'enabled'` + `budget_tokens` 방식이 deprecated되어 프로덕션 코드 생성 전체 실패
- `thinking: { type: 'adaptive' }` + `output_config: { effort: 'high' }` 신규 방식으로 마이그레이션
- `generateCode()`, `generateCodeStream()` 양쪽 모두 적용
- 테스트 mock expectation도 함께 업데이트

## 영향 범위
- `src/providers/ai/ClaudeProvider.ts` — Extended Thinking 파라미터 구조 변경
- `src/providers/ai/ClaudeProvider.test.ts` — mock 기대값 업데이트

## 테스트
- [x] `pnpm type-check` 통과
- [x] ClaudeProvider 단위 테스트 36/36 통과
- [x] 전체 테스트 스위트 1508/1508 통과

## 긴급도
**프로덕션 크리티컬** — Extended Thinking 활성화 시 모든 코드 생성 요청 실패

🤖 Generated with [Claude Code](https://claude.com/claude-code)