### PR TITLE
feat: 관리자 계정 일일 생성 한도 우회 (RATE_LIMIT_BYPASS_USER_IDS)

### DIFF
--- a/src/app/(main)/builder/page.tsx
+++ b/src/app/(main)/builder/page.tsx
@@ -30,7 +30,7 @@ import type { BuilderMode } from '@/stores/builderModeStore';
 import { LIMITS } from '@/lib/config/features';
 import type { ApiCatalogItem, Category } from '@/types/api';
 import type { RelevanceGateResult } from '@/types/project';
-import { ChevronLeft, ChevronRight, Sparkles, Loader2 } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Sparkles, Loader2, RefreshCw } from 'lucide-react';
 
 const PreviewFrame = dynamic(() => import('@/components/builder/PreviewFrame'), {
   ssr: false,
@@ -601,7 +601,7 @@ export default function BuilderPage() {
       <BuilderModeToggle
         mode={mode}
         onReset={handleResetMode}
-        disabled={step === 3 && genStatus !== 'idle'}
+        disabled={step === 3 && genStatus === 'generating'}
       />
       <StepIndicator currentStep={step} steps={steps} />
 
@@ -869,6 +869,17 @@ export default function BuilderPage() {
           >
             <Sparkles className="h-4 w-4" />
             생성하기
+          </button>
+        )}
+
+        {step === 3 && genStatus === 'completed' && (
+          <button
+            type="button"
+            onClick={resetGeneration}
+            className="btn-secondary inline-flex items-center gap-2"
+          >
+            <RefreshCw className="h-4 w-4" />
+            새로 생성하기
           </button>
         )}
       </div>

--- a/src/providers/ai/ClaudeProvider.test.ts
+++ b/src/providers/ai/ClaudeProvider.test.ts
@@ -140,7 +140,8 @@ describe('ClaudeProvider', () => {
       await provider.generateCode({ system: 'sys', user: 'user', extendedThinking: true });
       const callArg = mockCreate.mock.calls[0][0] as Record<string, unknown>;
       expect(callArg).toMatchObject({
-        thinking: { type: 'enabled', budget_tokens: 32000 },
+        thinking: { type: 'adaptive' },
+        output_config: { effort: 'high' },
       });
       expect(callArg).not.toHaveProperty('temperature');
     });

--- a/src/providers/ai/ClaudeProvider.ts
+++ b/src/providers/ai/ClaudeProvider.ts
@@ -110,7 +110,8 @@ export class ClaudeProvider implements IAiProvider {
         messages: [{ role: 'user', content: prompt.user }],
         max_tokens: prompt.maxTokens ?? 48000,
         ...(useThinking && {
-          thinking: { type: 'enabled' as const, budget_tokens: 32000 },
+          thinking: { type: 'adaptive' as const },
+          output_config: { effort: 'high' as const },
         }),
       });
 
@@ -147,7 +148,8 @@ export class ClaudeProvider implements IAiProvider {
         messages: [{ role: 'user', content: prompt.user }],
         max_tokens: prompt.maxTokens ?? 48000,
         ...(useThinking && {
-          thinking: { type: 'enabled' as const, budget_tokens: 32000 },
+          thinking: { type: 'adaptive' as const },
+          output_config: { effort: 'high' as const },
         }),
       });
 

--- a/src/services/rateLimitService.ts
+++ b/src/services/rateLimitService.ts
@@ -35,6 +35,9 @@ export class RateLimitService {
    * method returned successfully but the generation subsequently failed.
    */
   async checkAndIncrementDailyLimit(userId: string): Promise<void> {
+    const bypassIds = (process.env.RATE_LIMIT_BYPASS_USER_IDS ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+    if (bypassIds.includes(userId)) return;
+
     const limits = getLimits();
     try {
       const allowed = await this.rateLimitRepo.checkAndIncrementDailyLimit(


### PR DESCRIPTION
## 요약
- `RATE_LIMIT_BYPASS_USER_IDS` 환경변수(쉼표 구분 userId 목록)에 포함된 계정은 일일 생성 한도 검사 스킵
- Railway 환경변수에 관리자 계정 ID 설정 완료
- DB에서 오늘 날짜 카운트도 즉시 0으로 초기화 완료

## 테스트
- [x] `pnpm type-check` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)