### PR TITLE
fix: 회고 발견 버그 4건 수정 — 타임아웃 가드·proxyCache size·ADR·토큰

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ pnpm test:coverage    # 커버리지 리포트
 - `QUALITY_LOOP_ET_ITERATION_TIMEOUT_MS` — ET 활성화 시 Quality Loop 반복당 타임아웃 (기본: 200000ms = 200초). ET 응답이 최대 150초 소요되므로 일반 타임아웃(`QUALITY_LOOP_ITERATION_TIMEOUT_MS`)과 별도 설정
 - `QUALITY_LOOP_MAX_ITERATIONS` — Quality Loop 최대 반복 횟수 (기본: 2회, 상한: 3회)
 - `QUALITY_LOOP_STRICT_ADOPTION` — Quality Loop retry 채택 가드 (기본: `true`. `false`로 설정 시 한쪽 점수 향상만으로도 채택하는 기존 OR 로직 복원 — 운영 데이터 비교용 롤백 스위치)
+- `PIPELINE_MAX_DURATION_MS` — 파이프라인 총 허용 시간 (기본: 290000ms = 290초). Quality Loop 시작 시 `경과 시간 + iterationTimeout > 이 값`이면 반복을 건너뜀. Railway 300초 한도를 고려한 안전 마진 확보용
 - `QC_QUALITY_THRESHOLD`, `QC_MOBILE_THRESHOLD` — Quality Loop 재시도 트리거 점수 임계값 (각 기본: 60)
 - `RATE_LIMIT_BYPASS_USER_IDS` — 쉼표 구분 userId 목록. 포함된 계정은 일일 생성 한도 검사 스킵 (관리자/개발자 우회용)
 - 전체 환경변수 목록은 [docs/reference/env-vars.md](docs/reference/env-vars.md) 참조
@@ -224,13 +225,16 @@ pnpm test:coverage    # 커버리지 리포트
 1. **Railway 배포 상태** — `railway deployment list --json` (최신 배포 status·커밋 확인)
 2. **SonarCloud 품질 상태** — 아래 우선순위로 확인:
    - **(기본)** SonarQube MCP 도구로 `xzawed_CustomWebService` 프로젝트 이슈·품질 게이트 조회
-   - **(차선 — MCP 미로드 시)** SonarCloud REST API로 대체:
+   - **(차선 — MCP 미로드 시)** SonarCloud REST API로 대체 (`SONARCLOUD_TOKEN` 환경변수 또는 `~/.sonar-token` 파일에서 읽기):
      ```bash
+     # 토큰 설정: echo "토큰값" > ~/.sonar-token && chmod 600 ~/.sonar-token
+     # 또는: export SONARCLOUD_TOKEN=토큰값
+     SONAR_TOKEN="${SONARCLOUD_TOKEN:-$(cat ~/.sonar-token 2>/dev/null)}"
      # 품질 게이트
-     curl -s -u "d9298987059a0e9855b0876cf17e2ad5357b9cb6:" \
+     curl -s -u "$SONAR_TOKEN:" \
        "https://sonarcloud.io/api/qualitygates/project_status?projectKey=xzawed_CustomWebService"
      # 신규 이슈
-     curl -s -u "d9298987059a0e9855b0876cf17e2ad5357b9cb6:" \
+     curl -s -u "$SONAR_TOKEN:" \
        "https://sonarcloud.io/api/issues/search?projectKeys=xzawed_CustomWebService&resolved=false&ps=5"
      ```
 

--- a/docs/decisions/2026-05-04-unsplash-attribution-auto-injection.md
+++ b/docs/decisions/2026-05-04-unsplash-attribution-auto-injection.md
@@ -43,7 +43,7 @@ Unsplash URL이 없는 HTML은 함수가 원본 그대로 반환하며 성능 �
 - AI가 생성한 HTML에는 드물게 `</body>` 태그가 중첩되거나 잘못된 위치에 나타날 수 있음
 - `lastIndexOf`는 실제 문서의 마지막 `</body>` 위치를 보장하여 항상 body 끝에 삽입됨
 
-`</body>` 태그가 없는 HTML 단편(fragment)의 경우: 문자열 끝에 귀속 문구를 추가한다.
+`</body>` 태그가 없는 HTML의 경우: 원본을 그대로 반환한다(삽입하지 않음). `</body>` 없이 끝에 강제 삽입하면 HTML 구조가 더 손상될 수 있으므로, 이 경우는 안전하게 건너뛴다.
 
 ---
 
@@ -113,7 +113,7 @@ AI에게 귀속 문구를 직접 삽입하지 말도록 명시적으로 안내�
 - **다른 이미지 소스**: 현재 Unsplash만 처리. Pexels, Pixabay 등 다른 무료 이미지 소스도 귀속이 필요한 경우 별도 처리 필요
 - **Tailwind 없는 HTML**: Tailwind CDN이 없는 HTML에서는 클래스가 적용되지 않지만 귀속 문구 텍스트 자체는 정상 표시됨
 - **빌더 미리보기**: 미리보기 경로(`preview/[projectId]/route.ts`)와 게시 경로(`site/[slug]/route.ts`) 모두 `codeParser.ts`를 통하므로 양쪽에 동일하게 적용됨
-- **이미 게시된 서비스**: 기존에 게시된 HTML은 재생성하지 않으면 귀속 문구가 없을 수 있음. 향후 마이그레이션 또는 서빙 시 실시간 주입 검토 가능
+- **이미 게시된 서비스**: `site/[slug]/route.ts`는 서빙 시마다 DB의 raw 파트(`codeHtml`, `codeCss`, `codeJs`)를 `assembleHtml()`로 재조합하므로, `injectUnsplashAttribution()`이 기존 서비스에도 자동 적용됨. 별도 마이그레이션 불필요
 
 ---
 

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -123,6 +123,7 @@
 | `QUALITY_LOOP_ET_ITERATION_TIMEOUT_MS` | `200000` | ✅ **`200000` 운영 중** | Extended Thinking 활성 시 품질 루프 반복당 타임아웃 (ms). ET 활성 조건(API ≥ 3개 또는 컨텍스트 ≥ 500자)에서만 사용. 미설정 시 기본값 200000(200초). ET 응답은 90~150초 소요되므로 `QUALITY_LOOP_ITERATION_TIMEOUT_MS`와 별도 관리 |
 | `QUALITY_LOOP_MAX_ITERATIONS` | `2` | ✅ **`1` 운영 중** | 품질 루프 최대 반복 횟수. 기본 2회 (최대 3회 상한). **현재 1회 — ET 타임아웃 분리 후 Quality Loop 재활성화. 운영 안정성 확인 후 2회 상향 예정.** 낮출수록 총 생성 시간 단축 — Railway 300초 타임아웃 초과 방지용 |
 | `QUALITY_LOOP_STRICT_ADOPTION` | `true` | ➖ | 채택 가드: `true`(기본)는 한 점수 향상 + 다른 점수 동등 이상일 때만 retry 채택(시소 진동 방지). `false`로 설정 시 기존 OR 로직(한쪽 향상) 복원 — 운영 데이터 비교용 롤백 스위치 |
+| `PIPELINE_MAX_DURATION_MS` | `290000` | ➖ | 파이프라인 총 허용 시간(ms). Quality Loop 시작 전 `경과 시간 + iterationTimeout > 이 값`이면 반복 스킵. Railway 300초 한도를 고려해 기본값 290초(10초 여유). 미설정 시 290000 자동 사용 |
 | `QC_QUALITY_THRESHOLD` | `60` | ➖ | 정적 QC 구조 점수 재시도 트리거 임계값. 이 값 미만이면 Quality Loop 재시도 수행 |
 | `QC_MOBILE_THRESHOLD` | `60` | ➖ | 정적 QC 모바일 점수 재시도 트리거 임계값. 이 값 미만이면 Quality Loop 재시도 수행 |
 | `QC_FAST_PASS_THRESHOLD` | `60` | ➖ | Fast QC 통과 기준 점수. 이 값 미만이면 Fast QC 실패로 판정 |

--- a/src/lib/ai/generationPipeline.ts
+++ b/src/lib/ai/generationPipeline.ts
@@ -329,6 +329,7 @@ export async function runGenerationPipeline(
   const { codeRepo, projectService, rateLimitService, projectRepo } = services;
 
   let aiProvider: IAiProvider | undefined;
+  const pipelineStartMs = Date.now();
 
   generationTracker.start(projectId, userId);
 
@@ -400,7 +401,7 @@ export async function runGenerationPipeline(
     const userFeedback = typeof extraMetadata?.userFeedback === 'string' ? extraMetadata.userFeedback : undefined;
     const { parsed: finalParsed, quality, qcReport, qualityLoopUsed } = await runQualityLoop(
       parsed, initialQuality, initialQcReport,
-      { stage2SystemPrompt: input.stage2SystemPrompt, stage2FunctionSystemPrompt: input.stage2FunctionSystemPrompt, aiProvider, sse, useET, projectId, userFeedback },
+      { stage2SystemPrompt: input.stage2SystemPrompt, stage2FunctionSystemPrompt: input.stage2FunctionSystemPrompt, aiProvider, sse, useET, projectId, userFeedback, pipelineStartMs },
     );
 
     // ── 저장 ─────────────────────────────────────────────────────────────────

--- a/src/lib/ai/qualityLoop.ts
+++ b/src/lib/ai/qualityLoop.ts
@@ -252,6 +252,13 @@ function applyAutoFixStep(
   return 'partial';
 }
 
+export function resolveIterationTimeoutMs(useET: boolean): number {
+  const timeoutEnvKey = useET ? 'QUALITY_LOOP_ET_ITERATION_TIMEOUT_MS' : 'QUALITY_LOOP_ITERATION_TIMEOUT_MS';
+  const defaultTimeoutMs = useET ? 200_000 : 120_000;
+  const v = Number.parseInt(process.env[timeoutEnvKey] ?? '', 10);
+  return Number.isNaN(v) || v <= 0 ? defaultTimeoutMs : v;
+}
+
 /**
  * LLM 재시도 한 회를 실행해 best 상태를 업데이트한다.
  * AI 호출 실패·빈 응답·채택 실패는 모두 조용히 처리한다.
@@ -262,18 +269,15 @@ async function runLlmRetryIteration(
     systemPrompt: string;
     userFeedback: string | undefined;
     aiProvider: IAiProvider;
+    iterationTimeoutMs: number;
     useET: boolean;
     projectId: string;
     attempt: number;
   },
 ): Promise<void> {
-  const { systemPrompt, userFeedback, aiProvider, useET, projectId, attempt } = options;
+  const { systemPrompt, userFeedback, aiProvider, iterationTimeoutMs, useET, projectId, attempt } = options;
   try {
     const improvementPrompt = buildQualityImprovementPrompt(state.parsed, state.quality, state.qcReport, userFeedback);
-    const timeoutEnvKey = useET ? 'QUALITY_LOOP_ET_ITERATION_TIMEOUT_MS' : 'QUALITY_LOOP_ITERATION_TIMEOUT_MS';
-    const defaultTimeoutMs = useET ? 200_000 : 120_000;
-    const _loopVal = Number.parseInt(process.env[timeoutEnvKey] ?? '', 10);
-    const iterationTimeoutMs = Number.isNaN(_loopVal) || _loopVal <= 0 ? defaultTimeoutMs : _loopVal;
     const timeoutPromise = new Promise<never>((_, reject) =>
       setTimeout(
         () => reject(new Error(`Quality loop iteration timed out after ${iterationTimeoutMs}ms`)),
@@ -324,7 +328,12 @@ export interface QualityLoopRunOptions {
   useET: boolean;
   projectId: string;
   userFeedback?: string;
+  /** Date.now() at pipeline entry — used for Railway 300s total budget guard */
+  pipelineStartMs?: number;
 }
+
+const _maxDurationEnvVal = Number.parseInt(process.env.PIPELINE_MAX_DURATION_MS ?? '', 10);
+const PIPELINE_BUDGET_MS = Number.isNaN(_maxDurationEnvVal) || _maxDurationEnvVal <= 0 ? 290_000 : _maxDurationEnvVal;
 
 /** 품질 기준 미달 시 최대 N회 재생성 시도, 최선 버전 반환 */
 export async function runQualityLoop(
@@ -333,7 +342,7 @@ export async function runQualityLoop(
   initialQcReport: QcReport | null,
   options: QualityLoopRunOptions,
 ): Promise<QualityLoopResult> {
-  const { stage2SystemPrompt, stage2FunctionSystemPrompt, aiProvider, sse, useET, projectId, userFeedback } = options;
+  const { stage2SystemPrompt, stage2FunctionSystemPrompt, aiProvider, sse, useET, projectId, userFeedback, pipelineStartMs } = options;
   const state: BestState = {
     parsed: initialParsed,
     quality: initialQuality,
@@ -344,6 +353,7 @@ export async function runQualityLoop(
 
   const maxIterations = resolveMaxIterations();
   const qualityLoopProgress = buildProgressSchedule(maxIterations);
+  const iterationTimeoutMs = resolveIterationTimeoutMs(useET);
 
   for (let attempt = 0; attempt < maxIterations; attempt++) {
     if (!shouldRetryGeneration(state.quality, state.qcReport)) break;
@@ -351,6 +361,17 @@ export async function runQualityLoop(
     // AutoFix: deterministic rules before LLM retry — saves tokens when fixable
     const autoFixOutcome = applyAutoFixStep(state, projectId, attempt);
     if (autoFixOutcome === 'resolved') break;
+
+    // Railway 300s 총 예산 가드 — elapsed + 이번 반복 예상 시간이 예산 초과 시 스킵
+    if (pipelineStartMs !== undefined) {
+      const elapsed = Date.now() - pipelineStartMs;
+      if (elapsed + iterationTimeoutMs > PIPELINE_BUDGET_MS) {
+        logger.warn('Quality loop iteration skipped — insufficient pipeline time budget', {
+          projectId, elapsed, iterationTimeoutMs, pipelineBudgetMs: PIPELINE_BUDGET_MS,
+        });
+        break;
+      }
+    }
 
     iterationsRun++;
 
@@ -369,7 +390,7 @@ export async function runQualityLoop(
     // function-fix prompt; design/layout issues use the design polish prompt.
     const systemPrompt = hasFunctionalIssue(state.quality) ? stage2FunctionSystemPrompt : stage2SystemPrompt;
 
-    await runLlmRetryIteration(state, { systemPrompt, userFeedback, aiProvider, useET, projectId, attempt });
+    await runLlmRetryIteration(state, { systemPrompt, userFeedback, aiProvider, iterationTimeoutMs, useET, projectId, attempt });
   }
 
   eventBus.emit({

--- a/src/lib/cache/proxyCache.ts
+++ b/src/lib/cache/proxyCache.ts
@@ -42,7 +42,12 @@ class ProxyCache {
   }
 
   get size(): number {
-    return this.cache.size;
+    const now = Date.now();
+    let count = 0;
+    for (const [, entry] of this.cache) {
+      if (now <= entry.expiresAt) count++;
+    }
+    return count;
   }
 }
 


### PR DESCRIPTION
## Summary

어제 회고에서 발견된 버그 및 불일치 4건을 수정합니다.

- **Railway 300s 타임아웃 가드**: Quality Loop 시작 전 `경과 시간 + iterationTimeout > PIPELINE_MAX_DURATION_MS(290s)` 조건으로 반복 스킵. 5월 3일 인시던트와 동일한 구조적 리스크 해소
- **proxyCache.size 버그**: Lazy eviction으로 expired 항목이 Map에 잔류하여 size가 부풀려지던 문제 수정 → 실제 live 항목만 계산
- **ADR 불일치 수정**: `injectUnsplashAttribution` no-body 동작 "문자열 끝 추가" → "원본 반환(안전하게 스킵)"으로 수정. 기존 서비스가 serve-time `assembleHtml` 재조합으로 이미 attribution 적용됨 명시
- **CLAUDE.md 토큰 노출**: 하드코딩된 SonarCloud 토큰 → `SONARCLOUD_TOKEN` 환경변수/파일 참조 방식으로 교체 (토큰은 SonarCloud에서 별도 rotate 필요)

## Test Plan

- [x] `pnpm type-check` 통과
- [x] `pnpm test` 1716개 전체 통과 (129 파일)
- [ ] Railway 배포 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)