### PR TITLE
docs: Claude 작업 문서 최신화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ pnpm test:coverage    # 커버리지 리포트
 - **slug 충돌 처리**: `assignUniqueSlug()` in `projectService.ts` — base → base-2 → … → base-10 → timestamp fallback; 23505 unique 위반 시 1회 재시도
 - **generationTracker 단일 인스턴스**: `src/lib/ai/generationTracker.ts`의 `generationTracker`는 모듈 레벨 싱글톤. TTL 차등: `generating` 30분, `completed`/`failed` 10분. Railway 단일 인스턴스 환경에서만 동작 — 멀티 인스턴스 배포 시 Redis 등 외부 저장소로 교체 필요
 - **모듈 레벨 상태가 있는 파일 테스트**: `let registered = false` 같은 모듈 레벨 플래그가 있는 파일은 테스트 간 상태 누출이 발생한다. `vi.resetModules()` + 매 테스트마다 `await import(...)` 동적 임포트로 격리한다 (`eventPersister.ts` 참고)
-- **SonarCloud vs Codecov 지표 불일치**: Codecov는 `vitest.config.ts`의 `coverage.include` 범위(lib/services/providers/repositories, ~10,601 lines)만 측정. SonarCloud는 전체 TypeScript(~21,980 lines) 측정. 두 숫자는 구조적으로 차이가 날 수밖에 없으며, 이는 설정 문제가 아님
+- **SonarCloud vs Codecov 지표 불일치**: Codecov/Vitest는 `vitest.config.ts`의 `coverage.include` 범위(`src/lib/**`, `src/services/**`, `src/providers/**`, `src/repositories/**`, `src/components/**`)를 측정. SonarCloud는 전체 TypeScript를 더 넓게 측정할 수 있어 두 숫자는 구조적으로 차이가 날 수 있으며, 단순 설정 오류로 단정하지 않는다.
 - **temperature deprecated (Claude 4.x)**: Claude 4.x 모델(`claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-opus-4-7`)은 `temperature` 파라미터를 지원하지 않음. ClaudeProvider에서 완전히 제거됨 (Extended Thinking 포함). `IAiPrompt.temperature` 필드는 legacy 호환용으로 유지하나 실제 API 호출에 사용하지 않음
 - **인메모리 rate limit 한계**: proxy의 Map 기반 리밋은 서버 재시작 시 초기화됨 (분당 카운터라 보안 영향 낮음). Railway 단일 인스턴스 전제 — 멀티 인스턴스 전환 시 Redis 등 외부 저장소 필요 (generationTracker와 동일 제약)
 

--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 [![status](https://img.shields.io/badge/status-v1.0.0%20Live-brightgreen?style=flat-square)](https://xzawed.xyz)
 [![Next.js](https://img.shields.io/badge/Next.js-16+-black?style=flat-square&logo=next.js)](https://nextjs.org)
 [![AI](https://img.shields.io/badge/AI-Claude%20Opus%204.7-blueviolet?style=flat-square)](https://anthropic.com)
-[![Tests](https://img.shields.io/badge/Tests-475%20passed-success?style=flat-square)](./docs/guides/testing.md)
+[![Tests](https://img.shields.io/badge/Vitest-1725%20listed-success?style=flat-square)](./docs/guides/testing.md)
 [![Deploy](https://img.shields.io/badge/Deploy-Railway-8A2BE2?style=flat-square&logo=railway)](https://railway.app)
 
 **🌐 Live**: [xzawed.xyz](https://xzawed.xyz) &nbsp;|&nbsp; 🇰🇷 [한국어](./README.md)
@@ -113,7 +113,7 @@ CustomWebService lets anyone — without coding knowledge — build and publish 
 ```
 src/
 ├── app/
-│   ├── api/v1/          # 🔌 REST API endpoints (22 routes)
+│   ├── api/v1/          # 🔌 REST API route.ts files (23)
 │   ├── (auth)/          # 🔐 Auth pages
 │   ├── (main)/          # 🏠 Main pages (builder, catalog, dashboard)
 │   └── site/[slug]/     # 🌐 Subdomain serving
@@ -137,11 +137,11 @@ src/
 
 | Item | Details |
 |------|---------|
-| ✅ Total tests | **475** (unit · integration · component · E2E) |
+| ✅ Test inventory | **1,725 Vitest tests + 33 Playwright tests** (`vitest list`, `playwright test --list`) |
 | 🔬 Unit tests | Vitest + happy-dom — AI pipeline, security validation, rate limiting, Circuit Breaker |
 | 🔗 Integration tests | Vitest + MSW — API route auth, input validation, permissions, business logic |
 | 🌐 E2E tests | Playwright — 3 device types (mobile · tablet · desktop) |
-| 📊 Coverage thresholds | branches 50% · functions/lines/statements 60% |
+| 📊 Coverage | **85%+ lines** for `lib/services/providers/repositories/components`; CI thresholds are lower guardrails |
 
 ```bash
 pnpm test              # Run all tests

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![status](https://img.shields.io/badge/status-v1.0.0%20Live-brightgreen?style=flat-square)](https://xzawed.xyz)
 [![Next.js](https://img.shields.io/badge/Next.js-16+-black?style=flat-square&logo=next.js)](https://nextjs.org)
 [![AI](https://img.shields.io/badge/AI-Claude%20Opus%204.7-blueviolet?style=flat-square)](https://anthropic.com)
-[![Tests](https://img.shields.io/badge/Tests-1078%20passed-success?style=flat-square)](./docs/guides/testing.md)
-[![Coverage](https://img.shields.io/badge/Coverage-71%25-yellow?style=flat-square)](./docs/guides/testing.md)
+[![Tests](https://img.shields.io/badge/Vitest-1725%20listed-success?style=flat-square)](./docs/guides/testing.md)
+[![Coverage](https://img.shields.io/badge/Coverage-85%25%2B-yellow?style=flat-square)](./docs/guides/testing.md)
 [![Deploy](https://img.shields.io/badge/Deploy-Railway-8A2BE2?style=flat-square&logo=railway)](https://railway.app)
 
 **🌐 서비스 URL**: [xzawed.xyz](https://xzawed.xyz) &nbsp;|&nbsp; 🇺🇸 [English](./README.en.md)
@@ -114,7 +114,7 @@ CustomWebService는 비개발자도 몇 분 안에 자신만의 웹서비스를 
 ```
 src/
 ├── app/
-│   ├── api/v1/          # 🔌 REST API 엔드포인트 (22개)
+│   ├── api/v1/          # 🔌 REST API route.ts 파일 (23개)
 │   ├── (auth)/          # 🔐 인증 페이지
 │   ├── (main)/          # 🏠 메인 페이지 (빌더, 카탈로그, 대시보드)
 │   └── site/[slug]/     # 🌐 서브도메인 서빙
@@ -138,11 +138,11 @@ src/
 
 | 항목 | 내용 |
 |------|------|
-| ✅ 총 테스트 수 | **1,078개** (단위 · 통합 · 컴포넌트 · E2E) |
+| ✅ 테스트 목록 | **Vitest 1,725개 + Playwright 33개** (`vitest list`, `playwright test --list` 기준) |
 | 🔬 단위 테스트 | Vitest + happy-dom — AI 파이프라인, 보안 검증, 레이트리밋, Circuit Breaker, 배포 서비스 등 |
 | 🔗 통합 테스트 | Vitest + MSW — API 라우트 인증·입력·권한·비즈니스 로직 전 경로 |
 | 🌐 E2E 테스트 | Playwright — 3종 디바이스 (모바일 · 태블릿 · 데스크톱) |
-| 📊 커버리지 | **71% lines** (lib/services/providers/repositories 대상) · Codecov + SonarCloud 연동 |
+| 📊 커버리지 | **85%+ lines** (lib/services/providers/repositories/components 대상) · Codecov + SonarCloud 연동 |
 
 ```bash
 pnpm test              # 전체 테스트

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # 문서
 
-이 프로젝트의 문서는 다음 4개 폴더로 구성됩니다.
+이 프로젝트의 문서는 다음 폴더로 구성됩니다.
 
 | 폴더 | 내용 |
 |------|------|
@@ -8,5 +8,7 @@
 | [guides/](guides/) | 개발, 배포, QC 프로세스, 운영 |
 | [reference/](reference/) | API 엔드포인트, 환경변수, 에러 코드 |
 | [decisions/](decisions/) | 설계 결정 배경 (ADR) |
+| [security/](security/) | 보안 인시던트 대응 절차 |
+| [superpowers/](superpowers/) | 구현 계획과 설계 초안. 과거 시점의 작업 기록이므로 현재 상태 확인은 `architecture/`, `guides/`, `reference/`, 루트 `CLAUDE.md`를 우선합니다. |
 
 Claude Code를 사용 중이라면 루트의 `CLAUDE.md`를 참조하세요.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,7 +1,7 @@
 # 시스템 아키텍처
 
 > **최종 업데이트:** 2026-05-05  
-> **구현 상태:** 운영 중 (1,716개 테스트 통과)
+> **구현 상태:** 운영 중 (2026-05-08 기준 Vitest 목록 1,725개, Playwright 목록 33개)
 
 ---
 
@@ -130,7 +130,8 @@ src/
 │   │   ├── popular-services/route.ts
 │   │   ├── user-api-keys/route.ts
 │   │   ├── admin/                # 관리자 전용
-│   │   │   └── qc-stats/route.ts
+│   │   │   ├── qc-stats/route.ts
+│   │   │   └── trigger-qc/route.ts # POST
 │   │   └── health/route.ts       # GET
 │   ├── layout.tsx
 │   └── page.tsx                  # 랜딩 페이지

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -20,7 +20,9 @@
        ──────────────────
 ```
 
-**총 129개 Vitest 파일, 1,716개 테스트 + 3개 Playwright E2E 파일**
+**현재 테스트 목록:** 132개 Vitest 파일, 1,725개 Vitest 테스트 + 3개 Playwright E2E 파일, 33개 Playwright 프로젝트별 테스트
+
+> 확인 명령: `pnpm exec vitest list`, `pnpm exec playwright test --list` (2026-05-08 기준). 실제 통과 여부는 `pnpm test`와 `pnpm test:e2e` 실행 결과를 기준으로 판단합니다.
 
 ### 핵심 원칙
 
@@ -371,7 +373,7 @@ lint (ESLint)
   ↓
 type-check (tsc --noEmit)
   ↓
-test (pnpm test — 1,716개)
+test (pnpm test — Vitest 목록 1,725개 기준)
   ↓
 커버리지 업로드 (Codecov + SonarCloud)
   ↓
@@ -388,9 +390,9 @@ build (Next.js standalone)
 
 ## 6. 커버리지 기준
 
-**대상 디렉터리**: `src/lib/**`, `src/services/**`, `src/providers/**`, `src/repositories/**`
+**대상 디렉터리**: `src/lib/**`, `src/services/**`, `src/providers/**`, `src/repositories/**`, `src/components/**`
 
-**현재 달성값** (로컬 기준):
+**현재 달성값** (최근 문서화 기준):
 
 | 지표 | 달성값 |
 |------|--------|

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -810,7 +810,7 @@ API 키 삭제
 
 ## 14. 관리자 API (Admin)
 
-> `ADMIN_API_KEY` 헤더(`X-Admin-Key`) 필수. 일반 사용자 접근 불가.
+> `Authorization: Bearer {ADMIN_API_KEY}` 헤더 필수. 일반 사용자 접근 불가.
 
 ### GET /api/v1/admin/qc-stats
 QC 통계 조회


### PR DESCRIPTION
## 변경 사항

- README/README.en의 테스트 수, 커버리지, API route 수를 현재 확인 가능한 값으로 최신화
- docs README에 security/superpowers 문서 폴더 용도와 현재 문서 우선순위 추가
- testing/architecture/API reference/CLAUDE.md의 오래된 수치와 인증 헤더 설명 정정

## 변경 유형

- [ ] 새로운 기능 (기존 기능에 영향을 주지 않는 변경)
- [ ] 버그 수정 (기존 기능에 영향을 주지 않는 문제 해결)
- [ ] 리팩토링 (기능 변경 없는 코드 개선)
- [ ] 스타일 변경 (UI/UX 관련 변경)
- [x] 문서 수정 (문서만 변경)
- [ ] 성능 개선
- [ ] 테스트 추가/수정
- [ ] 빌드/CI 설정 변경
- [ ] 기타 (아래에 설명):

## 테스트

- [x] 로컬에서 정상 동작 확인
- [ ] 기존 테스트 통과 확인
- [ ] 새로운 테스트 추가 (필요한 경우)
- [ ] 다양한 브라우저에서 테스트 (필요한 경우)
- [ ] 모바일 반응형 테스트 (필요한 경우)

확인 명령:
- `pnpm exec vitest list` → 1,725개 목록 확인
- `pnpm exec playwright test --list` → 33개 목록 확인
- `git diff --check` 통과

전체 테스트는 문서만 변경되어 실행하지 않았습니다.

## 체크리스트

- [x] 코드가 프로젝트의 스타일 가이드를 따릅니다
- [x] 셀프 코드 리뷰를 완료했습니다
- [ ] 주석이 필요한 부분에 주석을 추가했습니다
- [x] 관련 문서를 업데이트했습니다 (필요한 경우)
- [x] 변경 사항이 다른 기능에 영향을 주지 않습니다
- [ ] TypeScript 타입 체크를 통과합니다
- [ ] ESLint 검사를 통과합니다