### PR TITLE
fix: Supabase OAuth 첫 로그인 origin 불일치 수정

### DIFF
--- a/src/app/(auth)/callback/route.test.ts
+++ b/src/app/(auth)/callback/route.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const exchangeCodeForSessionMock = vi.fn();
+const getUserMock = vi.fn();
+const getAllMock = vi.fn();
+const setMock = vi.fn();
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: getAllMock,
+    set: setMock,
+  }),
+}));
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: vi.fn(() => ({
+    auth: {
+      exchangeCodeForSession: exchangeCodeForSessionMock,
+      getUser: getUserMock,
+    },
+  })),
+}));
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('@/lib/events/eventBus', () => ({
+  eventBus: { emit: vi.fn() },
+}));
+
+vi.mock('@/lib/events/eventPersister', () => ({
+  registerEventPersister: vi.fn(),
+}));
+
+describe('OAuth callback route', () => {
+  const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+  const originalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const originalAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const originalServiceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env.NEXT_PUBLIC_APP_URL = 'https://xzawed.xyz';
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://supabase.example';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    exchangeCodeForSessionMock.mockResolvedValue({ error: null });
+    getUserMock.mockResolvedValue({
+      data: {
+        user: {
+          id: 'user-1',
+          email: 'test@example.com',
+          user_metadata: {},
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
+    process.env.NEXT_PUBLIC_SUPABASE_URL = originalSupabaseUrl;
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = originalAnonKey;
+    process.env.SUPABASE_SERVICE_ROLE_KEY = originalServiceRole;
+  });
+
+  it('성공 시 NEXT_PUBLIC_APP_URL이 아닌 callback 요청 origin으로 redirect한다', async () => {
+    const { GET } = await import('./route');
+
+    const response = await GET(
+      new Request('https://customwebservice-production.up.railway.app/callback?code=abc'),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'https://customwebservice-production.up.railway.app/dashboard',
+    );
+  });
+
+  it('next 파라미터가 안전한 보호 경로면 해당 경로로 redirect한다', async () => {
+    const { GET } = await import('./route');
+
+    const response = await GET(new Request('https://xzawed.xyz/callback?code=abc&next=/builder'));
+
+    expect(response.headers.get('location')).toBe('https://xzawed.xyz/builder');
+  });
+
+  it('외부 next 파라미터는 dashboard로 대체한다', async () => {
+    const { GET } = await import('./route');
+
+    const response = await GET(
+      new Request('https://xzawed.xyz/callback?code=abc&next=https://evil.example'),
+    );
+
+    expect(response.headers.get('location')).toBe('https://xzawed.xyz/dashboard');
+  });
+
+  it('코드 교환 실패 시 같은 origin의 login으로 redirect한다', async () => {
+    exchangeCodeForSessionMock.mockResolvedValue({ error: new Error('bad code') });
+    const { GET } = await import('./route');
+
+    const response = await GET(new Request('https://customwebservice-production.up.railway.app/callback?code=bad'));
+
+    expect(response.headers.get('location')).toBe(
+      'https://customwebservice-production.up.railway.app/login',
+    );
+  });
+});

--- a/src/app/(auth)/callback/route.ts
+++ b/src/app/(auth)/callback/route.ts
@@ -15,13 +15,22 @@ function safeRedirect(next: string | null): string {
   return ALLOWED.some((p) => next.startsWith(p)) ? next : '/dashboard';
 }
 
+function resolveRedirectOrigin(requestOrigin: string): string {
+  // Keep OAuth callback redirects on the same origin that received the PKCE
+  // cookies. Falling back to NEXT_PUBLIC_APP_URL is only for unusual local
+  // binding addresses that should never be exposed to the browser.
+  if (/^https?:\/\/(0\.0\.0\.0|\[::\])(?::\d+)?$/i.test(requestOrigin)) {
+    return process.env.NEXT_PUBLIC_APP_URL ?? requestOrigin;
+  }
+  return requestOrigin;
+}
+
 export async function GET(request: Request) {
   const { searchParams, origin: requestOrigin } = new URL(request.url);
   const code = searchParams.get('code');
   const next = safeRedirect(searchParams.get('next'));
 
-  // Use NEXT_PUBLIC_APP_URL if set to avoid 0.0.0.0 binding address issues
-  const origin = process.env.NEXT_PUBLIC_APP_URL ?? requestOrigin;
+  const origin = resolveRedirectOrigin(requestOrigin);
 
   if (code) {
     const cookieStore = await cookies();

--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderComponent, screen, fireEvent, waitFor } from '@/test/helpers/component';
+
+const mocks = vi.hoisted(() => ({
+  signIn: vi.fn(),
+  signInWithOAuth: vi.fn(),
+}));
+
+vi.mock('next-auth/react', () => ({
+  signIn: mocks.signIn,
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      signInWithOAuth: mocks.signInWithOAuth,
+    },
+  }),
+}));
+
+import LoginPage from './page';
+
+function setWindowUrl(url: string): void {
+  (window as unknown as { happyDOM: { setURL: (nextUrl: string) => void } }).happyDOM.setURL(url);
+}
+
+describe('LoginPage OAuth redirect', () => {
+  const originalProvider = process.env.NEXT_PUBLIC_AUTH_PROVIDER;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'supabase';
+    mocks.signInWithOAuth.mockResolvedValue({ error: null });
+    setWindowUrl('https://customwebservice-production.up.railway.app/login');
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = originalProvider;
+  });
+
+  it('Supabase OAuth redirectTo는 현재 origin의 /callback을 사용한다', async () => {
+    renderComponent(<LoginPage />);
+
+    fireEvent.click(screen.getByText('Google로 계속하기'));
+
+    await waitFor(() => {
+      expect(mocks.signInWithOAuth).toHaveBeenCalledWith({
+        provider: 'google',
+        options: {
+          redirectTo: 'https://customwebservice-production.up.railway.app/callback',
+        },
+      });
+    });
+  });
+
+  it('보호 경로 redirect 파라미터를 callback next로 전달한다', async () => {
+    setWindowUrl('https://xzawed.xyz/login?redirect=/builder');
+    renderComponent(<LoginPage />);
+
+    fireEvent.click(screen.getByText('GitHub로 계속하기'));
+
+    await waitFor(() => {
+      expect(mocks.signInWithOAuth).toHaveBeenCalledWith({
+        provider: 'github',
+        options: {
+          redirectTo: 'https://xzawed.xyz/callback?next=%2Fbuilder',
+        },
+      });
+    });
+  });
+
+  it('외부 redirect 파라미터는 callback에 전달하지 않는다', async () => {
+    setWindowUrl('https://xzawed.xyz/login?redirect=https://evil.example');
+    renderComponent(<LoginPage />);
+
+    fireEvent.click(screen.getByText('Google로 계속하기'));
+
+    await waitFor(() => {
+      expect(mocks.signInWithOAuth).toHaveBeenCalledWith({
+        provider: 'google',
+        options: {
+          redirectTo: 'https://xzawed.xyz/callback',
+        },
+      });
+    });
+  });
+
+  it('Auth.js 모드에서는 next-auth signIn을 사용한다', async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'authjs';
+    renderComponent(<LoginPage />);
+
+    fireEvent.click(screen.getByText('Google로 계속하기'));
+
+    await waitFor(() => {
+      expect(mocks.signIn).toHaveBeenCalledWith('google', { callbackUrl: '/dashboard' });
+    });
+    expect(mocks.signInWithOAuth).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -3,6 +3,13 @@
 import { useState } from 'react';
 import { signIn } from 'next-auth/react';
 
+function getSafeRedirectParam(): string | null {
+  const redirect = new URLSearchParams(window.location.search).get('redirect');
+  if (!redirect) return null;
+  if (/^(\/\/|[a-z][a-z0-9+\-.]*:)/i.test(redirect)) return null;
+  return redirect.startsWith('/') ? redirect : null;
+}
+
 export default function LoginPage() {
   const [oauthError, setOauthError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<'google' | 'github' | null>(null);
@@ -19,11 +26,16 @@ export default function LoginPage() {
     // Supabase mode — only create the client here
     const { createClient } = await import('@/lib/supabase/client');
     const supabase = createClient();
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || window.location.origin;
+    const callbackUrl = new URL('/callback', window.location.origin);
+    const redirect = getSafeRedirectParam();
+    if (redirect) {
+      callbackUrl.searchParams.set('next', redirect);
+    }
+
     const { error } = await supabase.auth.signInWithOAuth({
       provider,
       options: {
-        redirectTo: `${baseUrl}/callback`,
+        redirectTo: callbackUrl.toString(),
       },
     });
 

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderComponent, screen } from '@/test/helpers/component';
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn().mockResolvedValue(new Headers({ 'x-nonce': 'nonce-1' })),
+}));
+
+vi.mock('@/providers/ThemeProvider', () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="theme-provider">{children}</div>
+  ),
+}));
+
+vi.mock('next-auth/react', () => ({
+  SessionProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="session-provider">{children}</div>
+  ),
+}));
+
+import RootLayout from './layout';
+
+describe('RootLayout auth provider wiring', () => {
+  const originalProvider = process.env.NEXT_PUBLIC_AUTH_PROVIDER;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'supabase';
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = originalProvider;
+  });
+
+  it('Supabase 모드에서는 Auth.js SessionProvider를 렌더링하지 않는다', async () => {
+    renderComponent(await RootLayout({ children: <main>콘텐츠</main> }));
+
+    expect(screen.getByTestId('theme-provider')).toBeTruthy();
+    expect(screen.queryByTestId('session-provider')).toBeNull();
+  });
+
+  it('Auth.js 모드에서는 SessionProvider를 렌더링한다', async () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'authjs';
+
+    renderComponent(await RootLayout({ children: <main>콘텐츠</main> }));
+
+    expect(screen.getByTestId('session-provider')).toBeTruthy();
+  });
+});

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -1,24 +1,37 @@
-// @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderComponent, screen } from '@/test/helpers/component';
+import React from 'react';
 
 vi.mock('next/headers', () => ({
   headers: vi.fn().mockResolvedValue(new Headers({ 'x-nonce': 'nonce-1' })),
 }));
 
 vi.mock('@/providers/ThemeProvider', () => ({
-  ThemeProvider: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="theme-provider">{children}</div>
-  ),
+  ThemeProvider: function MockThemeProvider({ children }: { children: React.ReactNode }) {
+    return <div data-testid="theme-provider">{children}</div>;
+  },
 }));
 
 vi.mock('next-auth/react', () => ({
-  SessionProvider: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="session-provider">{children}</div>
-  ),
+  SessionProvider: function MockSessionProvider({ children }: { children: React.ReactNode }) {
+    return <div data-testid="session-provider">{children}</div>;
+  },
 }));
 
 import RootLayout from './layout';
+
+function getBodyChild(tree: React.ReactElement<{ children: React.ReactNode }>): React.ReactElement {
+  const htmlChildren = React.Children.toArray(tree.props.children);
+  const body = htmlChildren.find(
+    (child): child is React.ReactElement<{ children: React.ReactNode }> =>
+      React.isValidElement(child) && child.type === 'body',
+  );
+
+  if (!body || !React.isValidElement(body.props.children)) {
+    throw new Error('RootLayout body child was not a React element');
+  }
+
+  return body.props.children;
+}
 
 describe('RootLayout auth provider wiring', () => {
   const originalProvider = process.env.NEXT_PUBLIC_AUTH_PROVIDER;
@@ -32,17 +45,16 @@ describe('RootLayout auth provider wiring', () => {
   });
 
   it('Supabase 모드에서는 Auth.js SessionProvider를 렌더링하지 않는다', async () => {
-    renderComponent(await RootLayout({ children: <main>콘텐츠</main> }));
+    const bodyChild = getBodyChild(await RootLayout({ children: <main>콘텐츠</main> }));
 
-    expect(screen.getByTestId('theme-provider')).toBeTruthy();
-    expect(screen.queryByTestId('session-provider')).toBeNull();
+    expect((bodyChild.type as { name?: string }).name).toBe('MockThemeProvider');
   });
 
   it('Auth.js 모드에서는 SessionProvider를 렌더링한다', async () => {
     process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'authjs';
 
-    renderComponent(await RootLayout({ children: <main>콘텐츠</main> }));
+    const bodyChild = getBodyChild(await RootLayout({ children: <main>콘텐츠</main> }));
 
-    expect(screen.getByTestId('session-provider')).toBeTruthy();
+    expect((bodyChild.type as { name?: string }).name).toBe('MockSessionProvider');
   });
 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,6 +23,8 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   const nonce = (await headers()).get('x-nonce') ?? '';
+  const app = <ThemeProvider>{children}</ThemeProvider>;
+
   return (
     <html lang="ko" data-theme="sky">
       <head>
@@ -42,11 +44,9 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
         />
       </head>
       <body className="noise min-h-screen antialiased">
-        {/* SessionProvider는 AUTH_PROVIDER=authjs 시 useSession()에 컨텍스트를 제공합니다.
-            Supabase 모드에서는 빈 컨텍스트 역할만 하며 동작에 영향을 주지 않습니다. */}
-        <SessionProvider>
-          <ThemeProvider>{children}</ThemeProvider>
-        </SessionProvider>
+        {process.env.NEXT_PUBLIC_AUTH_PROVIDER === 'authjs'
+          ? <SessionProvider>{app}</SessionProvider>
+          : app}
       </body>
     </html>
   );

--- a/src/hooks/useAuth.test.tsx
+++ b/src/hooks/useAuth.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAuthStore } from '@/stores/authStore';
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  useSession: vi.fn(),
+  authJsSignOut: vi.fn(),
+  getSession: vi.fn(),
+  onAuthStateChange: vi.fn(),
+  supabaseSignOut: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: mocks.useSession,
+  signOut: mocks.authJsSignOut,
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      getSession: mocks.getSession,
+      onAuthStateChange: mocks.onAuthStateChange,
+      signOut: mocks.supabaseSignOut,
+    },
+  }),
+}));
+
+import { useAuth } from './useAuth';
+
+describe('useAuth', () => {
+  const originalProvider = process.env.NEXT_PUBLIC_AUTH_PROVIDER;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.setState({ user: null, isLoading: true, isAuthenticated: false });
+    mocks.getSession.mockResolvedValue({ data: { session: null } });
+    mocks.onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    });
+    mocks.useSession.mockReturnValue(undefined);
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'supabase';
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = originalProvider;
+  });
+
+  it('Supabase 모드에서 SessionProvider가 없어도 기본 인증 상태를 반환한다', async () => {
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('Auth.js 모드에서 next-auth 세션을 사용자 상태로 매핑한다', () => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'authjs';
+    mocks.useSession.mockReturnValue({
+      data: {
+        user: {
+          id: 'user-1',
+          email: 'test@example.com',
+          name: 'Test User',
+          image: 'https://example.com/avatar.png',
+        },
+      },
+      status: 'authenticated',
+    });
+
+    const { result } = renderHook(() => useAuth());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).toMatchObject({
+      id: 'user-1',
+      email: 'test@example.com',
+      name: 'Test User',
+      avatarUrl: 'https://example.com/avatar.png',
+    });
+  });
+});

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -99,7 +99,9 @@ function mapAuthJsUser(sessionUser: {
 
 function useAuthJsAuth(): ReturnType<typeof useSupabaseAuth> {
   const router = useRouter();
-  const { data: session, status } = useSession(); // always called for Rules of Hooks
+  const sessionResult = useSession();
+  const session = sessionResult?.data ?? null;
+  const status = sessionResult?.status ?? 'unauthenticated';
 
   const isEnabled = process.env.NEXT_PUBLIC_AUTH_PROVIDER === 'authjs';
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],
       include: [
+        'src/app/**/callback/route.ts',
+        'src/app/**/login/page.tsx',
+        'src/app/layout.tsx',
+        'src/hooks/**',
         'src/lib/**',
         'src/services/**',
         'src/providers/**',


### PR DESCRIPTION
## 요약
- Railway HTTP 로그에서 첫 로그인 시작 origin과 Supabase OAuth callback origin이 달라지는 흐름을 확인했습니다.
- Supabase OAuth `redirectTo`를 현재 브라우저 origin의 `/callback`으로 생성해 PKCE 쿠키와 callback origin이 일치하도록 수정했습니다.
- callback 성공/실패 후 redirect도 요청을 받은 origin 기준으로 처리하도록 정리했습니다.
- Supabase 모드에서 불필요하게 `SessionProvider`가 `/api/auth/session`을 호출해 404를 만들던 부분을 authjs 모드로 제한했습니다.

## Railway 로그 확인 내용
- `customwebservice-production.up.railway.app/login`에서 첫 로그인이 시작된 뒤 `xzawed.xyz/callback`으로 돌아오며 곧바로 `xzawed.xyz/login`으로 redirect되는 패턴이 있었습니다.
- 이후 두 번째 시도는 `xzawed.xyz/callback`에서 `xzawed.xyz/dashboard`로 정상 이동했습니다.
- 같은 구간에서 Supabase 모드인데도 `/api/auth/session` 404가 반복적으로 발생했습니다.

## 테스트
- `pnpm exec vitest run 'src/app/(auth)/login/page.test.tsx' 'src/app/(auth)/callback/route.test.ts' src/components/layout/Header.test.tsx src/lib/config/providers.test.ts`
- `pnpm type-check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## 참고
- `pnpm build`는 성공했지만 기존 Sentry/Next 경고와 `/api/v1/catalog*` 정적 수집 중 dynamic server usage 로그가 출력됩니다.