### PR TITLE
feat: 관리자 전용 사이트 생성 부하 테스트 엔드포인트 추가

### DIFF
--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -890,3 +890,78 @@ QC 통계 조회
 | `QC_DISABLED` | 400 | `ENABLE_RENDERING_QC`가 활성화되지 않음 |
 | `NOT_FOUND` | 404 | 해당 프로젝트의 생성된 코드 없음 |
 | `INVALID_INPUT` | 400 | `projectId` 누락 |
+
+### POST /api/v1/admin/test-generation
+관리자 전용 생성 파이프라인 부하/안정성 테스트 엔드포인트. 인증된 사용자 세션 없이 `ADMIN_API_KEY`만으로 전체 코드 생성 파이프라인(Stage1·2·3 + Quality Loop)을 한 번 실행하고 결과를 JSON으로 반환합니다.
+
+> 일일 생성 한도(`MAX_DAILY_GENERATIONS`)·프로젝트 수 한도(`MAX_PROJECTS_PER_USER`)를 우회합니다. 일반 사용자 흐름 검증이 아닌, 관리자가 수동/스크립트 호출로 안정성을 측정하는 용도입니다.
+
+**Request:**
+```http
+POST /api/v1/admin/test-generation
+Authorization: Bearer <ADMIN_API_KEY>
+Content-Type: application/json
+```
+
+**Request Body:**
+```json
+{
+  "userId": "11111111-...",
+  "apiIds": ["uuid1", "uuid2", "uuid3"],
+  "context": "선택 사항. 사용자 서비스 설명 (20~2000자, 기본값 있음)",
+  "projectName": "선택 사항. 기본값: [자동테스트] YYYY-MM-DD HH:MM:SS",
+  "cleanup": true
+}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| `userId` | UUID | ✅ | 테스트 프로젝트의 소유자 (DB에 존재하는 사용자) |
+| `apiIds` | UUID[] | ✅ | 카탈로그 API ID 3~5개 |
+| `context` | string | ❌ | 서비스 설명 (20~2000자) |
+| `projectName` | string | ❌ | 프로젝트 이름 (1~100자) |
+| `cleanup` | boolean | ❌ | `true`(기본)면 파이프라인 완료 후 프로젝트 자동 삭제. `false`면 보존 |
+
+**성공 응답 (HTTP 200):**
+```json
+{
+  "success": true,
+  "data": {
+    "projectId": "uuid",
+    "cleanedUp": true,
+    "durationMs": 92345,
+    "apiIds": ["..."],
+    "complete": {
+      "projectId": "uuid",
+      "version": 1,
+      "previewUrl": "/api/v1/preview/uuid",
+      "qcResult": { "score": 82, "passed": true, "issues": [] }
+    },
+    "progressEvents": [{"step": "analyzing", "progress": 5, "message": "..."}]
+  }
+}
+```
+
+**파이프라인 실패 응답 (HTTP 200, success: false):**
+```json
+{
+  "success": false,
+  "data": {
+    "projectId": "uuid",
+    "cleanedUp": true,
+    "durationMs": 4567,
+    "apiIds": ["..."],
+    "error": { "message": "Stage 1 실패: ..." },
+    "progressEvents": [...]
+  }
+}
+```
+
+**에러 응답 형식:** 표준 `{ success: false, error: { code, message } }`
+
+| 에러 코드 | HTTP | 설명 |
+|-----------|------|------|
+| `FORBIDDEN` | 403 | `Authorization` 누락 / 잘못된 `ADMIN_API_KEY` / IP 분당 한도 초과 |
+| `INVALID_INPUT` | 400 | Zod 검증 실패 (`apiIds` 3개 미만, UUID 형식 오류, 길이 초과 등) |
+
+**연관 스크립트:** [scripts/runGenerationLoadTest.ts](../../scripts/runGenerationLoadTest.ts) — 골든셋 API 무작위 조합으로 N회 반복 호출하여 성공률·평균 응답 시간 집계.

--- a/scripts/runGenerationLoadTest.ts
+++ b/scripts/runGenerationLoadTest.ts
@@ -1,0 +1,211 @@
+#!/usr/bin/env tsx
+/**
+ * 사이트 생성 파이프라인 부하/안정성 테스트 스크립트.
+ *
+ * 사용법:
+ *   ADMIN_API_KEY=... TEST_USER_ID=... BASE_URL=https://xzawed.xyz \
+ *     pnpm tsx scripts/runGenerationLoadTest.ts [--iterations=20] [--concurrency=4]
+ *
+ * 골든셋 API에서 3~5개를 무작위로 조합해 `POST /api/v1/admin/test-generation`을
+ * 호출하고 성공·실패·평균 응답 시간·실패 사유를 집계합니다.
+ *
+ * 동작 모드:
+ *   - 기본은 `cleanup: true` — 생성된 프로젝트는 즉시 삭제됩니다.
+ *   - `--keep` 옵션을 주면 생성된 프로젝트를 남깁니다 (수동 검사용).
+ */
+
+const GOLDEN_SET = [
+  { id: '6890346f-fa79-483c-bce2-f841ad3420fd', name: 'Random User' },
+  { id: '04e79764-c27c-46d8-b63c-2794fbe5a3f7', name: 'JSONPlaceholder' },
+  { id: '02cea7ab-d89a-4e51-b9c5-32ed0fd00338', name: 'PokéAPI' },
+  { id: '9a04cd18-15bb-4424-a4f1-10ddf728749b', name: 'wheretheiss.at' },
+  { id: 'de8f5375-22dc-4573-9a64-2903c150fece', name: 'Hacker News API' },
+  { id: '8461e4de-ba6d-4a4d-ae24-35bd7c47c0c7', name: 'Spaceflight News' },
+  { id: 'f1b6d26f-4cb4-4ea7-844b-8c6ba3b29a8a', name: 'The Cat API' },
+  { id: 'da2e14a4-e8c6-4164-835e-6ce8b212d59b', name: 'TheMealDB' },
+  { id: '522f7158-7de0-4447-80bb-ea71a8e56b50', name: 'The Color API' },
+  { id: '7b66ab19-4d00-4d39-a4f9-2c2b6c6367a4', name: 'NASA APOD' },
+];
+
+const CONTEXTS = [
+  '연결된 API 데이터를 보기 좋게 카드 그리드로 나열하고 새로고침 버튼을 제공하는 한 페이지짜리 대시보드를 만들어주세요.',
+  'API에서 받은 데이터를 검색·필터링할 수 있고 모바일에서도 잘 보이는 단일 페이지 서비스를 만들어주세요.',
+  '랜덤하게 데이터를 가져와 큰 카드로 보여주고, 상세 정보 모달을 띄울 수 있는 인터랙티브 페이지를 만들어주세요.',
+  '연결된 API의 데이터를 깔끔한 리스트와 통계 카드로 보여주는 대시보드를 만들어주세요. 다크 모드 지원.',
+];
+
+interface RunResult {
+  index: number;
+  apis: string[];
+  success: boolean;
+  durationMs: number;
+  projectId?: string;
+  errorMessage?: string;
+  qcPassed?: boolean;
+  qcScore?: number;
+}
+
+function parseArgs(): { iterations: number; concurrency: number; keep: boolean } {
+  const args = process.argv.slice(2);
+  const get = (k: string, def: number) => {
+    const a = args.find((x) => x.startsWith(`--${k}=`));
+    return a ? parseInt(a.split('=')[1], 10) : def;
+  };
+  return {
+    iterations: get('iterations', 20),
+    concurrency: get('concurrency', 4),
+    keep: args.includes('--keep'),
+  };
+}
+
+function pickRandomApis(): string[] {
+  const count = 3 + Math.floor(Math.random() * 3); // 3..5
+  const pool = [...GOLDEN_SET];
+  const out: typeof GOLDEN_SET = [];
+  for (let i = 0; i < count; i++) {
+    const idx = Math.floor(Math.random() * pool.length);
+    out.push(pool[idx]);
+    pool.splice(idx, 1);
+  }
+  return out.map((a) => a.id);
+}
+
+async function runOne(index: number, baseUrl: string, adminKey: string, userId: string, keep: boolean): Promise<RunResult> {
+  const apis = pickRandomApis();
+  const context = CONTEXTS[Math.floor(Math.random() * CONTEXTS.length)];
+  const startedAt = Date.now();
+  console.log(`[#${index}] start apis=${apis.length} ctx="${context.slice(0, 30)}…"`);
+
+  try {
+    const res = await fetch(`${baseUrl}/api/v1/admin/test-generation`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${adminKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ userId, apiIds: apis, context, cleanup: !keep }),
+      signal: AbortSignal.timeout(330_000), // 5.5분 (Railway 한도 + 여유)
+    });
+    const body = (await res.json().catch(() => ({}))) as {
+      success?: boolean;
+      data?: {
+        projectId?: string;
+        durationMs?: number;
+        error?: { message?: string };
+        complete?: { qcResult?: { passed?: boolean; score?: number } };
+      };
+      error?: { code?: string; message?: string };
+    };
+    const durationMs = Date.now() - startedAt;
+
+    if (res.status !== 200 || body.success !== true) {
+      return {
+        index,
+        apis,
+        success: false,
+        durationMs,
+        projectId: body.data?.projectId,
+        errorMessage: body.error?.message ?? body.data?.error?.message ?? `HTTP ${res.status}`,
+      };
+    }
+
+    return {
+      index,
+      apis,
+      success: true,
+      durationMs,
+      projectId: body.data?.projectId,
+      qcPassed: body.data?.complete?.qcResult?.passed,
+      qcScore: body.data?.complete?.qcResult?.score,
+    };
+  } catch (err) {
+    return {
+      index,
+      apis,
+      success: false,
+      durationMs: Date.now() - startedAt,
+      errorMessage: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function withConcurrency<T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: concurrency }, async () => {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+async function main(): Promise<void> {
+  const { iterations, concurrency, keep } = parseArgs();
+  const baseUrl = process.env.BASE_URL ?? 'https://xzawed.xyz';
+  const adminKey = process.env.ADMIN_API_KEY;
+  const userId = process.env.TEST_USER_ID;
+
+  if (!adminKey) {
+    console.error('ADMIN_API_KEY 환경변수가 필요합니다.');
+    process.exit(1);
+  }
+  if (!userId) {
+    console.error('TEST_USER_ID 환경변수가 필요합니다.');
+    process.exit(1);
+  }
+
+  console.log(`== Generation Load Test ==`);
+  console.log(`Base URL    : ${baseUrl}`);
+  console.log(`Iterations  : ${iterations}`);
+  console.log(`Concurrency : ${concurrency}`);
+  console.log(`Cleanup     : ${keep ? 'NO (projects retained)' : 'YES (auto-delete)'}\n`);
+
+  const indices = Array.from({ length: iterations }, (_, i) => i + 1);
+  const t0 = Date.now();
+  const results = await withConcurrency(indices, concurrency, (i) => runOne(i, baseUrl, adminKey, userId, keep));
+  const totalMs = Date.now() - t0;
+
+  const passed = results.filter((r) => r.success);
+  const failed = results.filter((r) => !r.success);
+  const avgMs = results.reduce((s, r) => s + r.durationMs, 0) / results.length;
+  const successRate = (passed.length / results.length) * 100;
+
+  console.log('\n== 결과 ==');
+  console.log(`전체 ${results.length}회 / 성공 ${passed.length}회 / 실패 ${failed.length}회`);
+  console.log(`성공률      : ${successRate.toFixed(1)}%`);
+  console.log(`평균 응답   : ${(avgMs / 1000).toFixed(1)}초`);
+  console.log(`총 실행 시간: ${(totalMs / 1000).toFixed(1)}초`);
+  const qcSamples = passed.filter((r) => typeof r.qcScore === 'number');
+  if (qcSamples.length > 0) {
+    const avgQc = qcSamples.reduce((s, r) => s + (r.qcScore ?? 0), 0) / qcSamples.length;
+    const qcPassRate = (qcSamples.filter((r) => r.qcPassed).length / qcSamples.length) * 100;
+    console.log(`평균 QC     : ${avgQc.toFixed(1)} (Fast QC 통과 ${qcPassRate.toFixed(1)}%)`);
+  }
+
+  if (failed.length > 0) {
+    console.log('\n== 실패 사례 ==');
+    for (const r of failed) {
+      console.log(`#${r.index} (${(r.durationMs / 1000).toFixed(1)}s) — ${r.errorMessage ?? '(no message)'}`);
+    }
+    const errorCounts = new Map<string, number>();
+    for (const r of failed) {
+      const key = (r.errorMessage ?? 'unknown').slice(0, 80);
+      errorCounts.set(key, (errorCounts.get(key) ?? 0) + 1);
+    }
+    console.log('\n에러 유형 빈도:');
+    for (const [msg, count] of [...errorCounts.entries()].sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${count}회: ${msg}`);
+    }
+  }
+
+  console.log('\n== Raw JSON ==');
+  console.log(JSON.stringify({ iterations, concurrency, successRate, results }, null, 2));
+
+  process.exit(failed.length > 0 ? 2 : 0);
+}
+
+void main();

--- a/src/__tests__/api/admin-test-generation.test.ts
+++ b/src/__tests__/api/admin-test-generation.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const VALID_ADMIN_KEY = 'test-admin-secret-key';
+const VALID_USER_ID = '6890346f-fa79-483c-bce2-f841ad3420fd';
+const API_ID_1 = '04e79764-c27c-46d8-b63c-2794fbe5a3f7';
+const API_ID_2 = '02cea7ab-d89a-4e51-b9c5-32ed0fd00338';
+const API_ID_3 = '9a04cd18-15bb-4424-a4f1-10ddf728749b';
+
+const mockCreatedProject = {
+  id: 'aaaaaaaa-1111-1111-1111-111111111111',
+  userId: VALID_USER_ID,
+  organizationId: null,
+  name: '[자동테스트] 2026-05-21 00:00:00',
+  context: 'test context',
+  status: 'draft' as const,
+  slug: null,
+  deployUrl: null,
+  deployPlatform: null,
+  repoUrl: null,
+  previewUrl: null,
+  metadata: { test: true },
+  currentVersion: 0,
+  apis: [],
+  publishedAt: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const projectRepoMock = {
+  create: vi.fn().mockResolvedValue(mockCreatedProject),
+  insertProjectApis: vi.fn().mockResolvedValue(undefined),
+  delete: vi.fn().mockResolvedValue(undefined),
+  findById: vi.fn().mockResolvedValue(mockCreatedProject),
+  updateStatus: vi.fn().mockResolvedValue(mockCreatedProject),
+};
+
+const catalogServiceMock = {
+  getByIds: vi.fn().mockResolvedValue([
+    { id: API_ID_1, name: 'API 1' },
+    { id: API_ID_2, name: 'API 2' },
+    { id: API_ID_3, name: 'API 3' },
+  ]),
+};
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServiceClient: vi.fn().mockResolvedValue({ from: vi.fn() }),
+}));
+
+vi.mock('@/services/factory', () => ({
+  createCatalogService: vi.fn(() => catalogServiceMock),
+  createProjectService: vi.fn(() => ({ updateStatus: vi.fn().mockResolvedValue(undefined) })),
+}));
+
+vi.mock('@/repositories/factory', () => ({
+  createCodeRepository: vi.fn(() => ({})),
+  createProjectRepository: vi.fn(() => projectRepoMock),
+}));
+
+vi.mock('@/lib/ai/promptBuilder', () => ({
+  buildStage1SystemPrompt: vi.fn(() => 'sys1'),
+  buildStage1UserPrompt: vi.fn(() => 'user1'),
+  buildStage2SystemPrompt: vi.fn(() => 'sys2'),
+  buildStage2UserPrompt: vi.fn(() => 'user2'),
+  buildStage2FunctionSystemPrompt: vi.fn(() => 'sys2fn'),
+  buildStage2FunctionUserPrompt: vi.fn(() => 'user2fn'),
+}));
+
+const pipelineMock = vi.fn();
+vi.mock('@/lib/ai/generationPipeline', () => ({
+  runGenerationPipeline: pipelineMock,
+}));
+
+function makeRequest(body: unknown, key: string | null = VALID_ADMIN_KEY) {
+  const headers: Record<string, string> = { 'x-real-ip': '127.0.0.1', 'Content-Type': 'application/json' };
+  if (key !== null) headers['Authorization'] = `Bearer ${key}`;
+  return new Request('http://localhost/api/v1/admin/test-generation', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/v1/admin/test-generation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env.ADMIN_API_KEY = VALID_ADMIN_KEY;
+    projectRepoMock.create.mockResolvedValue(mockCreatedProject);
+    projectRepoMock.insertProjectApis.mockResolvedValue(undefined);
+    projectRepoMock.delete.mockResolvedValue(undefined);
+    catalogServiceMock.getByIds.mockResolvedValue([
+      { id: API_ID_1 },
+      { id: API_ID_2 },
+      { id: API_ID_3 },
+    ]);
+  });
+
+  it('Authorization 헤더 없음 → 403', async () => {
+    const { POST } = await import('@/app/api/v1/admin/test-generation/route');
+    const res = await POST(makeRequest({ userId: VALID_USER_ID, apiIds: [API_ID_1, API_ID_2, API_ID_3] }, null));
+    expect(res.status).toBe(403);
+  });
+
+  it('잘못된 admin 키 → 403', async () => {
+    const { POST } = await import('@/app/api/v1/admin/test-generation/route');
+    const res = await POST(makeRequest({ userId: VALID_USER_ID, apiIds: [API_ID_1, API_ID_2, API_ID_3] }, 'bad-key'));
+    expect(res.status).toBe(403);
+  });
+
+  it('apiIds 3개 미만 → 400/422', async () => {
+    const { POST } = await import('@/app/api/v1/admin/test-generation/route');
+    const res = await POST(makeRequest({ userId: VALID_USER_ID, apiIds: [API_ID_1, API_ID_2] }));
+    expect([400, 422]).toContain(res.status);
+  });
+
+  it('userId 누락 → 400/422', async () => {
+    const { POST } = await import('@/app/api/v1/admin/test-generation/route');
+    const res = await POST(makeRequest({ apiIds: [API_ID_1, API_ID_2, API_ID_3] }));
+    expect([400, 422]).toContain(res.status);
+  });
+
+  it('파이프라인 complete 이벤트 → success: true', async () => {
+    pipelineMock.mockImplementation(async (_input, sse) => {
+      sse.send('progress', { step: 'analyzing', progress: 5 });
+      sse.send('complete', { projectId: mockCreatedProject.id, version: 1, previewUrl: '/api/v1/preview/x' });
+    });
+    const { POST } = await import('@/app/api/v1/admin/test-generation/route');
+    const res = await POST(makeRequest({ userId: VALID_USER_ID, apiIds: [API_ID_1, API_ID_2, API_ID_3] }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.projectId).toBe(mockCreatedProject.id);
+    expect(body.data.complete).toMatchObject({ version: 1 });
+    expect(body.data.cleanedUp).toBe(true);
+    expect(projectRepoMock.delete).toHaveBeenCalledWith(mockCreatedProject.id);
+  });
+
+  it('파이프라인 error 이벤트 → success: false (HTTP 200)', async () => {
+    pipelineMock.mockImplementation(async (_input, sse) => {
+      sse.send('error', { message: 'Stage 1 실패' });
+    });
+    const { POST } = await import('@/app/api/v1/admin/test-generation/route');
+    const res = await POST(makeRequest({ userId: VALID_USER_ID, apiIds: [API_ID_1, API_ID_2, API_ID_3] }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.data.error).toMatchObject({ message: 'Stage 1 실패' });
+  });
+
+  it('cleanup: false → 프로젝트 삭제 안 함', async () => {
+    pipelineMock.mockImplementation(async (_input, sse) => {
+      sse.send('complete', { projectId: mockCreatedProject.id, version: 1 });
+    });
+    const { POST } = await import('@/app/api/v1/admin/test-generation/route');
+    const res = await POST(
+      makeRequest({ userId: VALID_USER_ID, apiIds: [API_ID_1, API_ID_2, API_ID_3], cleanup: false }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.cleanedUp).toBe(false);
+    expect(projectRepoMock.delete).not.toHaveBeenCalled();
+  });
+
+  it('파이프라인 throw → handleApiError + 생성된 프로젝트 cleanup', async () => {
+    pipelineMock.mockRejectedValue(new Error('Pipeline crashed'));
+    const { POST } = await import('@/app/api/v1/admin/test-generation/route');
+    const res = await POST(makeRequest({ userId: VALID_USER_ID, apiIds: [API_ID_1, API_ID_2, API_ID_3] }));
+
+    expect([400, 500]).toContain(res.status);
+    expect(projectRepoMock.delete).toHaveBeenCalledWith(mockCreatedProject.id);
+  });
+
+  it('OPTIONS preflight → 204', async () => {
+    const { OPTIONS } = await import('@/app/api/v1/admin/test-generation/route');
+    const res = await OPTIONS();
+    expect([200, 204]).toContain(res.status);
+  });
+});

--- a/src/app/api/v1/admin/test-generation/route.ts
+++ b/src/app/api/v1/admin/test-generation/route.ts
@@ -1,0 +1,158 @@
+import { z } from 'zod';
+import { createServiceClient } from '@/lib/supabase/server';
+import { adminCorsHeaders, verifyAdminKey, withAdminCors } from '@/lib/utils/adminAuth';
+import { handleApiError, jsonResponse, ValidationError } from '@/lib/utils/errors';
+import { createCatalogService, createProjectService } from '@/services/factory';
+import {
+  createCodeRepository,
+  createProjectRepository,
+} from '@/repositories/factory';
+import {
+  buildStage1SystemPrompt,
+  buildStage1UserPrompt,
+  buildStage2SystemPrompt,
+  buildStage2UserPrompt,
+  buildStage2FunctionSystemPrompt,
+  buildStage2FunctionUserPrompt,
+} from '@/lib/ai/promptBuilder';
+import { runGenerationPipeline } from '@/lib/ai/generationPipeline';
+import type { SseWriter } from '@/lib/ai/sseWriter';
+import type { Project, ProjectMetadata } from '@/types/project';
+import type { ApiCatalogItem } from '@/types/api';
+import { getCorrelationId } from '@/lib/utils/correlationId';
+
+const bodySchema = z.object({
+  userId: z.string().uuid(),
+  apiIds: z.array(z.string().uuid()).min(3).max(5),
+  context: z.string().min(20).max(2000).optional(),
+  projectName: z.string().min(1).max(100).optional(),
+  cleanup: z.boolean().optional(),
+});
+
+const DEFAULT_CONTEXT =
+  'API 카탈로그 통합 테스트용 자동 생성 서비스입니다. 연결된 API의 데이터를 사용자에게 보여주고 기본적인 인터랙션(필터·검색·새로고침 등)을 제공하는 단일 페이지를 생성해주세요.';
+
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, { status: 204, headers: adminCorsHeaders });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const res = await (async () => {
+    let createdProjectId: string | null = null;
+    try {
+      verifyAdminKey(request);
+      const body = await request.json();
+      const { userId, apiIds, context: ctx, projectName, cleanup } = bodySchema.parse(body);
+      const projectContext = ctx ?? DEFAULT_CONTEXT;
+      const shouldCleanup = cleanup ?? true;
+
+      const supabase = await createServiceClient();
+      const catalogService = createCatalogService(supabase);
+      const projectRepo = createProjectRepository(supabase);
+
+      const apis = await catalogService.getByIds(apiIds);
+      if (apis.length !== apiIds.length) {
+        throw new ValidationError(`유효하지 않은 API ID가 포함되어 있습니다 (요청 ${apiIds.length}, 조회 ${apis.length})`);
+      }
+
+      const startMs = Date.now();
+      const project = await projectRepo.create({
+        userId,
+        organizationId: null,
+        name: projectName ?? `[자동테스트] ${new Date().toISOString().slice(0, 19).replace('T', ' ')}`,
+        context: projectContext,
+        status: 'draft',
+        deployUrl: null,
+        deployPlatform: null,
+        repoUrl: null,
+        previewUrl: null,
+        metadata: { test: true, source: 'admin/test-generation' } as ProjectMetadata,
+        currentVersion: 0,
+        apis: [] as ApiCatalogItem[],
+        slug: null,
+        publishedAt: null,
+      } as Omit<Project, 'id' | 'createdAt' | 'updatedAt'>);
+      createdProjectId = project.id;
+      await projectRepo.insertProjectApis(project.id, apiIds);
+
+      const events: Array<{ event: string; data: unknown }> = [];
+      const writer: SseWriter = {
+        send: (event, data) => { events.push({ event, data }); },
+        isCancelled: () => false,
+      };
+
+      const projectService = createProjectService(supabase);
+      const noopRateLimit = { decrementDailyLimit: async (): Promise<void> => {} };
+
+      await runGenerationPipeline(
+        {
+          projectId: project.id,
+          userId,
+          correlationId: getCorrelationId(request),
+          apis,
+          projectContext,
+          stage1SystemPrompt: buildStage1SystemPrompt(),
+          stage1UserPrompt: buildStage1UserPrompt(apis, projectContext, project.id),
+          stage2FunctionSystemPrompt: buildStage2FunctionSystemPrompt(),
+          buildStage2FunctionUserPrompt,
+          stage2SystemPrompt: buildStage2SystemPrompt(),
+          buildStage2UserPrompt,
+          extraMetadata: { test: true },
+        },
+        writer,
+        {
+          codeRepo: createCodeRepository(supabase),
+          projectService,
+          rateLimitService: noopRateLimit,
+          projectRepo,
+        },
+      );
+
+      const durationMs = Date.now() - startMs;
+      const completeEvent = events.find((e) => e.event === 'complete');
+      const errorEvent = events.find((e) => e.event === 'error');
+
+      if (shouldCleanup) {
+        await projectRepo.delete(project.id).catch(() => {});
+      }
+
+      if (errorEvent) {
+        return jsonResponse({
+          success: false,
+          data: {
+            projectId: project.id,
+            cleanedUp: shouldCleanup,
+            durationMs,
+            apiIds,
+            error: errorEvent.data,
+            progressEvents: events.filter((e) => e.event === 'progress').map((e) => e.data),
+          },
+        });
+      }
+
+      return jsonResponse({
+        success: true,
+        data: {
+          projectId: project.id,
+          cleanedUp: shouldCleanup,
+          durationMs,
+          apiIds,
+          complete: completeEvent?.data ?? null,
+          progressEvents: events.filter((e) => e.event === 'progress').map((e) => e.data),
+        },
+      });
+    } catch (error) {
+      if (createdProjectId) {
+        try {
+          const supabase = await createServiceClient();
+          const projectRepo = createProjectRepository(supabase);
+          await projectRepo.delete(createdProjectId);
+        } catch {
+          // best-effort cleanup
+        }
+      }
+      return handleApiError(error);
+    }
+  })();
+  return withAdminCors(res);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
         'src/app/**/callback/route.ts',
         'src/app/**/login/page.tsx',
         'src/app/layout.tsx',
+        'src/app/api/v1/admin/**/route.ts',
         'src/hooks/**',
         'src/lib/**',
         'src/services/**',


### PR DESCRIPTION
## Summary

- `POST /api/v1/admin/test-generation` — `ADMIN_API_KEY` 인증으로 인증 사용자 세션 없이 전체 생성 파이프라인(Stage1·2·3 + Quality Loop)을 동기 실행하고 결과를 JSON으로 반환하는 관리자 전용 테스트 엔드포인트
- `scripts/runGenerationLoadTest.ts` — 골든셋 API 10개에서 무작위 3~5개를 조합해 N회(기본 20회) 동시 호출하고 성공률·평균 응답 시간·실패 사유를 집계하는 부하 테스트 스크립트
- 기본적으로 `cleanup: true` — 테스트 생성 후 프로젝트 자동 삭제. `MAX_DAILY_GENERATIONS`·`MAX_PROJECTS_PER_USER` 한도를 우회

## Why

프로덕션 사이트 생성 성공률을 정량적으로 측정·모니터링하기 위해, 인증·UI 흐름 없이 파이프라인 자체의 신뢰도를 검증할 수단이 필요합니다. 이 엔드포인트로 관리자가 임의 시점에 N회 부하 테스트를 돌리고 회귀를 빠르게 감지할 수 있습니다.

## 사용법

```bash
# 단발 호출 (curl)
curl -X POST https://xzawed.xyz/api/v1/admin/test-generation \
  -H "Authorization: Bearer $ADMIN_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "userId": "<test-user-uuid>",
    "apiIds": ["<uuid1>", "<uuid2>", "<uuid3>"]
  }'

# 부하 테스트 (20회, 동시성 4)
ADMIN_API_KEY=... TEST_USER_ID=... BASE_URL=https://xzawed.xyz \
  pnpm tsx scripts/runGenerationLoadTest.ts --iterations=20 --concurrency=4
```

## Test plan

- [x] `pnpm type-check` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test` — 1749 tests pass (135 files), 새 endpoint 9 케이스 포함
- [ ] 배포 후 프로덕션에서 부하 테스트 스크립트 실행 → 성공률 보고

## Risks / Notes

- 관리자 키만 있으면 임의 사용자 ID로 프로젝트 생성·삭제가 가능 — `ADMIN_API_KEY`는 절대 노출 금지
- `cleanup: false`로 호출 시 `MAX_PROJECTS_PER_USER` 한도까지만 누적 → 정리 필요
- 인메모리 rate limit(`verifyAdminKey` 분당 한도)은 그대로 적용됨

https://claude.ai/code/session_01PaHjFntk6Q9Ev2goJ6iGqk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaHjFntk6Q9Ev2goJ6iGqk)_