### PR TITLE
fix: 생성 파이프라인 안정성 개선 (Stage 2 fallback + 예산 abort + 타이밍 로그)

### DIFF
--- a/src/__tests__/api/generate.test.ts
+++ b/src/__tests__/api/generate.test.ts
@@ -96,6 +96,7 @@ vi.mock('@/lib/ai/categoryDesignMap', () => ({
 vi.mock('@/lib/ai/qualityLoop', () => ({
   shouldRetryGeneration: vi.fn().mockReturnValue(false),
   buildQualityImprovementPrompt: vi.fn().mockReturnValue('improvement prompt'),
+  resolvePipelineBudgetMs: vi.fn(() => 290_000),
   runQualityLoop: vi.fn().mockImplementation(async (parsed: unknown, quality: unknown, qcReport: unknown) => ({
     parsed,
     quality,

--- a/src/__tests__/lib/ai/generationPipeline.test.ts
+++ b/src/__tests__/lib/ai/generationPipeline.test.ts
@@ -2,6 +2,7 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { runGenerationPipeline, type PipelineInput, type PipelineServices } from '@/lib/ai/generationPipeline';
 import type { SseWriter } from '@/lib/ai/sseWriter';
 import { AiProviderFactory } from '@/providers/ai/AiProviderFactory';
+import { resolvePipelineBudgetMs } from '@/lib/ai/qualityLoop';
 
 vi.mock('@/providers/ai/AiProviderFactory', () => ({
   AiProviderFactory: { createForTask: vi.fn() },
@@ -195,5 +196,44 @@ describe('runGenerationPipeline (3-stage)', () => {
     const eventNames = (sse.send as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => c[0]);
     expect(eventNames).toContain('error');
     expect(mockAiProvider.generateCodeStream).toHaveBeenCalledTimes(1);
+  });
+
+  it('Stage 2 실패 시 Stage 1 결과로 fallback하고 파이프라인을 계속 실행한다', async () => {
+    // Stage 1 성공, Stage 2 실패, Stage 3 성공
+    mockAiProvider.generateCodeStream
+      .mockResolvedValueOnce({ content: '<div>stage1</div>', provider: 'claude', model: 'claude-sonnet-4-6', durationMs: 1000, tokensUsed: { input: 100, output: 200 } })
+      .mockRejectedValueOnce(new Error('Stage 2 AI 오류'))
+      .mockResolvedValueOnce({ content: '<div>stage3</div>', provider: 'claude', model: 'claude-sonnet-4-6', durationMs: 800, tokensUsed: { input: 80, output: 160 } });
+
+    const sse = makeSse();
+    await runGenerationPipeline(makeInput(), sse, makeServices());
+
+    const eventNames = (sse.send as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => c[0]);
+    // Stage 2 fallback → Stage 3까지 계속 → complete
+    expect(eventNames).toContain('complete');
+    expect(eventNames).not.toContain('error');
+
+    // stage2_fallback progress 이벤트 전송 확인
+    const progressSteps = (sse.send as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c: unknown[]) => c[0] === 'progress')
+      .map((c: unknown[]) => (c[1] as { step: string }).step);
+    expect(progressSteps).toContain('stage2_fallback');
+  });
+
+  it('pipelineBudgetMs - 20s 시점에 abort 콜백이 호출된다', async () => {
+    vi.useFakeTimers();
+    vi.mocked(resolvePipelineBudgetMs).mockReturnValueOnce(20_001); // abort timer = 1ms
+
+    const sse = makeSse();
+    const pipeline = runGenerationPipeline(makeInput(), sse, makeServices());
+
+    // 1ms 경과 → abort 콜백 실행
+    await vi.advanceTimersByTimeAsync(1);
+    await pipeline;
+
+    vi.useRealTimers();
+    // abort이 발생해도 Stage 2 fallback 덕분에 complete까지 정상 진행
+    const eventNames = (sse.send as ReturnType<typeof vi.fn>).mock.calls.map((c: unknown[]) => c[0]);
+    expect(eventNames).toContain('complete');
   });
 });

--- a/src/__tests__/lib/ai/generationPipeline.test.ts
+++ b/src/__tests__/lib/ai/generationPipeline.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/lib/ai/codeValidator', () => ({
 vi.mock('@/lib/ai/qualityLoop', () => ({
   shouldRetryGeneration: vi.fn(() => false),
   buildQualityImprovementPrompt: vi.fn(() => 'improve'),
+  resolvePipelineBudgetMs: vi.fn(() => 290_000),
   runQualityLoop: vi.fn().mockImplementation(async (parsed: unknown, quality: unknown, qcReport: unknown) => ({
     parsed,
     quality,

--- a/src/lib/ai/generationPipeline.integration.test.ts
+++ b/src/lib/ai/generationPipeline.integration.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/lib/ai/stageRunner', () => ({
 }));
 vi.mock('@/lib/ai/qualityLoop', () => ({
   runQualityLoop: vi.fn(),
+  resolvePipelineBudgetMs: vi.fn(() => 290_000),
 }));
 vi.mock('@/lib/ai/featureExtractor', () => ({
   extractFeatures: vi.fn(),

--- a/src/lib/ai/generationPipeline.ts
+++ b/src/lib/ai/generationPipeline.ts
@@ -2,7 +2,7 @@ import { AiProviderFactory } from '@/providers/ai/AiProviderFactory';
 import type { IAiProvider } from '@/providers/ai/IAiProvider';
 import { assembleHtml } from '@/lib/ai/codeParser';
 import { validateAll, evaluateQuality } from '@/lib/ai/codeValidator';
-import { runQualityLoop } from '@/lib/ai/qualityLoop';
+import { runQualityLoop, resolvePipelineBudgetMs } from '@/lib/ai/qualityLoop';
 import { runFastQc, isQcEnabled } from '@/lib/qc';
 import { eventBus } from '@/lib/events/eventBus';
 import { logger } from '@/lib/utils/logger';
@@ -137,17 +137,28 @@ async function resolveStage2(
   aiProvider: IAiProvider,
   sse: SseWriter,
   projectId: string,
+  abortSignal?: AbortSignal,
 ): Promise<StageResult> {
   if (needsStage2) {
-    return runStage2Function(
-      stage1Result.parsed,
-      input.stage2FunctionSystemPrompt,
-      input.buildStage2FunctionUserPrompt,
-      staticQcIssues,
-      stage1FastQcIssues,
-      aiProvider,
-      sse,
-    );
+    try {
+      return await runStage2Function(
+        stage1Result.parsed,
+        input.stage2FunctionSystemPrompt,
+        input.buildStage2FunctionUserPrompt,
+        staticQcIssues,
+        stage1FastQcIssues,
+        aiProvider,
+        sse,
+        abortSignal,
+      );
+    } catch (stage2Err) {
+      const stage2ErrMsg = stage2Err instanceof Error ? stage2Err.message : String(stage2Err);
+      logger.warn('Stage 2 (function fix) failed — falling back to Stage 1 result', { projectId, error: stage2ErrMsg });
+      eventBus.emit({ type: 'STAGE2_FALLBACK_USED', payload: { projectId, error: stage2ErrMsg } });
+      sse.send('progress', { step: 'stage2_fallback', progress: 65, message: '기능 검증 중 오류 — 1단계 결과로 진행합니다.' });
+      generationTracker.updateProgress(projectId, 65, 'stage2_fallback', '기능 검증 중 오류 — 1단계 결과로 진행합니다.');
+      return { ...stage1Result, durationMs: 0, tokensUsed: { input: 0, output: 0 } };
+    }
   }
   sse.send('progress', { step: 'stage1_complete', progress: 30, message: '구조 완성. 기능 검증 스킵 (품질 충분).' });
   generationTracker.updateProgress(projectId, 30, 'stage1_complete', '구조 완성. 기능 검증 스킵 (품질 충분).');
@@ -168,6 +179,7 @@ async function resolveStage3(
   aiProvider: IAiProvider,
   sse: SseWriter,
   projectId: string,
+  abortSignal?: AbortSignal,
 ): Promise<StageResult> {
   if (skipStage3) {
     sse.send('progress', { step: 'stage3_skipped', progress: 85, message: '디자인 검증 완료 — 품질 충분, 폴리시 스킵.' });
@@ -179,7 +191,7 @@ async function resolveStage3(
     return { ...stage2Result, durationMs: 0, tokensUsed: { input: 0, output: 0 }, userPrompt: '' };
   }
   try {
-    return await runStage3(stage2Result.parsed, input.stage2SystemPrompt, input.buildStage2UserPrompt, aiProvider, sse, !needsStage2);
+    return await runStage3(stage2Result.parsed, input.stage2SystemPrompt, input.buildStage2UserPrompt, aiProvider, sse, !needsStage2, abortSignal);
   } catch (stage3Err) {
     const stage3ErrMsg = stage3Err instanceof Error ? stage3Err.message : String(stage3Err);
     logger.warn('Stage 3 (design polish) failed — falling back to Stage 2 result', { projectId, error: stage3ErrMsg });
@@ -331,6 +343,16 @@ export async function runGenerationPipeline(
   let aiProvider: IAiProvider | undefined;
   const pipelineStartMs = Date.now();
 
+  // Railway 300s HTTP 컷 전 안전 종료: pipelineBudgetMs - 20s 시점에 Stage 2/3 API 호출을 abort.
+  // Stage 2/3는 abort 시 fallback(이전 Stage 결과)으로 graceful 처리됨.
+  // Stage 1은 fallback 없으므로 abort 대상에서 제외 (abort 이전에 완료되도록 충분한 마진).
+  const pipelineAbortController = new AbortController();
+  const pipelineAbortTimer = setTimeout(
+    () => pipelineAbortController.abort(),
+    resolvePipelineBudgetMs() - 20_000,
+  );
+  const pipelineSignal = pipelineAbortController.signal;
+
   generationTracker.start(projectId, userId);
 
   try {
@@ -350,8 +372,10 @@ export async function runGenerationPipeline(
     }
 
     // ── Stage 1: 구조·기능 생성 (5→28%) ───────────────────────────────────────
+    // Stage 1은 abort signal을 받지 않음 — fallback 없어 abort 시 파이프라인 전체 실패
     const stage1Result = await runStage1(stage1SystemPrompt, input.stage1UserPrompt, aiProvider, sse, useET);
     const stage1Code = stage1Result.parsed;
+    logger.info('Stage 1 completed', { projectId, useET, durationMs: stage1Result.durationMs, elapsedMs: Date.now() - pipelineStartMs });
 
     // Stage 1 정적 QC — stage2Function에 전달
     const stage1Validation = validateAll(stage1Code.html, stage1Code.css, stage1Code.js);
@@ -362,7 +386,10 @@ export async function runGenerationPipeline(
     logger.info('Stage 2 necessity evaluated', { projectId, needsStage2, fetchCallCount: stage1Quality.fetchCallCount, placeholderCount: stage1Quality.placeholderCount, hardcodedArrayCount: stage1Quality.hardcodedArrayCount, stage1FastQcPassed });
 
     // ── Stage 2: 기능 검증 (30→65%) ─────────────────────────────────────────
-    const stage2Result = await resolveStage2(stage1Result, needsStage2, input, staticQcIssues, stage1FastQcIssues, aiProvider, sse, projectId);
+    const stage2Result = await resolveStage2(stage1Result, needsStage2, input, staticQcIssues, stage1FastQcIssues, aiProvider, sse, projectId, pipelineSignal);
+    if (needsStage2) {
+      logger.info('Stage 2 completed', { projectId, durationMs: stage2Result.durationMs, elapsedMs: Date.now() - pipelineStartMs });
+    }
 
     // ── Stage 3: 디자인·폴리시 (65→90%) ────────────────────────────────────
     const preStage3Quality = evaluateQuality(stage2Result.parsed.html, stage2Result.parsed.css, stage2Result.parsed.js);
@@ -374,7 +401,10 @@ export async function runGenerationPipeline(
       !needsStage2;
     logger.info('Stage 3 necessity evaluated', { projectId, skipStage3, structuralScore: preStage3Quality.structuralScore, mobileScore: preStage3Quality.mobileScore });
 
-    const stage3Result = await resolveStage3(stage2Result, skipStage3, needsStage2, input, aiProvider, sse, projectId);
+    const stage3Result = await resolveStage3(stage2Result, skipStage3, needsStage2, input, aiProvider, sse, projectId, pipelineSignal);
+    if (!skipStage3) {
+      logger.info('Stage 3 completed', { projectId, durationMs: stage3Result.durationMs, elapsedMs: Date.now() - pipelineStartMs });
+    }
 
     // ── 검증 ────────────────────────────────────────────────────────────────
     sse.send('progress', { step: 'validating', progress: 85, message: '코드 검증 중...' });
@@ -424,5 +454,7 @@ export async function runGenerationPipeline(
       { rateLimitService },
       sse,
     );
+  } finally {
+    clearTimeout(pipelineAbortTimer);
   }
 }

--- a/src/lib/ai/stageRunner.ts
+++ b/src/lib/ai/stageRunner.ts
@@ -20,6 +20,7 @@ export async function runStage1(
   aiProvider: IAiProvider,
   sse: SseWriter,
   useET: boolean,
+  abortSignal?: AbortSignal,
 ): Promise<StageResult> {
   let lastProgressUpdate = Date.now();
   const streamStartTime = Date.now();
@@ -27,7 +28,7 @@ export async function runStage1(
   sse.send('progress', { step: 'stage1_generating', progress: 5, message: `1단계: 구조 및 기능 생성 중...${useET ? ' (심층 분석)' : ''}` });
 
   const response = await aiProvider.generateCodeStream(
-    { system: systemPrompt, user: userPrompt, extendedThinking: useET },
+    { system: systemPrompt, user: userPrompt, extendedThinking: useET, abortSignal },
     (_chunk: string, accumulated: string) => {
       if (sse.isCancelled()) return;
       const now = Date.now();
@@ -66,6 +67,7 @@ export async function runStage2Function(
   fastQcIssues: string[] | null,
   aiProvider: IAiProvider,
   sse: SseWriter,
+  abortSignal?: AbortSignal,
 ): Promise<StageResult> {
   sse.send('progress', { step: 'stage1_complete', progress: 30, message: '구조 완성. 기능 검증 중...' });
   sse.send('progress', { step: 'stage2_function_generating', progress: 35, message: '2단계: 기능 버그 수정 중...' });
@@ -75,7 +77,7 @@ export async function runStage2Function(
   const streamStartTime = Date.now();
 
   const response = await aiProvider.generateCodeStream(
-    { system: systemPrompt, user: userPrompt },
+    { system: systemPrompt, user: userPrompt, abortSignal },
     (_chunk: string, accumulated: string) => {
       if (sse.isCancelled()) return;
       const now = Date.now();
@@ -110,6 +112,7 @@ export async function runStage3(
   sse: SseWriter,
   /** Stage 2가 스킵되어 stage2_function_complete 이벤트가 이미 발행된 경우 true */
   stage2FunctionCompleteAlreadySent = false,
+  abortSignal?: AbortSignal,
 ): Promise<StageResult> {
   if (!stage2FunctionCompleteAlreadySent) {
     sse.send('progress', { step: 'stage2_function_complete', progress: 65, message: '기능 검증 완성. 디자인 적용 중...' });
@@ -122,7 +125,7 @@ export async function runStage3(
   const streamStartTime = Date.now();
 
   const response = await aiProvider.generateCodeStream(
-    { system: systemPrompt, user: userPrompt },
+    { system: systemPrompt, user: userPrompt, abortSignal },
     (_chunk: string, accumulated: string) => {
       if (sse.isCancelled()) return;
       const now = Date.now();

--- a/src/providers/ai/ClaudeProvider.test.ts
+++ b/src/providers/ai/ClaudeProvider.test.ts
@@ -123,17 +123,17 @@ describe('ClaudeProvider', () => {
 
     it('기본 max_tokens는 48000이다', async () => {
       await provider.generateCode({ system: 'sys', user: 'user' });
-      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ max_tokens: 48000 }));
+      const callArg = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(callArg).toHaveProperty('max_tokens', 48000);
     });
 
     it('system 프롬프트를 cache_control 블록 배열로 전달한다', async () => {
       await provider.generateCode({ system: 'test-system', user: 'test-user' });
-      expect(mockCreate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          system: [{ type: 'text', text: 'test-system', cache_control: { type: 'ephemeral' } }],
-          messages: [{ role: 'user', content: 'test-user' }],
-        })
-      );
+      const callArg = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(callArg).toMatchObject({
+        system: [{ type: 'text', text: 'test-system', cache_control: { type: 'ephemeral' } }],
+        messages: [{ role: 'user', content: 'test-user' }],
+      });
     });
 
     it('extendedThinking 활성화 시 thinking 파라미터가 전달된다', async () => {

--- a/src/providers/ai/ClaudeProvider.ts
+++ b/src/providers/ai/ClaudeProvider.ts
@@ -113,7 +113,7 @@ export class ClaudeProvider implements IAiProvider {
           thinking: { type: 'adaptive' as const },
           output_config: { effort: 'high' as const },
         }),
-      });
+      }, { signal: prompt.abortSignal });
 
       const textBlock = result.content.find(
         (b): b is Anthropic.TextBlock => b.type === 'text',
@@ -151,7 +151,7 @@ export class ClaudeProvider implements IAiProvider {
           thinking: { type: 'adaptive' as const },
           output_config: { effort: 'high' as const },
         }),
-      });
+      }, { signal: prompt.abortSignal });
 
       let accumulated = '';
 

--- a/src/providers/ai/IAiProvider.ts
+++ b/src/providers/ai/IAiProvider.ts
@@ -5,6 +5,8 @@ export interface AiPrompt {
   maxTokens?: number;
   /** Stage 1 구조 생성 시 확장 사고(extended thinking) 활성화 */
   extendedThinking?: boolean;
+  /** 파이프라인 전체 예산 초과 시 Railway 300s 컷 전 안전 종료용 AbortSignal */
+  abortSignal?: AbortSignal;
 }
 
 export interface AiResponse {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -54,6 +54,10 @@ export type DomainEvent =
       payload: { projectId: string; stage: 'fast' | 'deep'; error: string };
     }
   | {
+      type: 'STAGE2_FALLBACK_USED';
+      payload: { projectId: string; error: string };
+    }
+  | {
       type: 'STAGE3_FALLBACK_USED';
       payload: { projectId: string; error: string };
     }


### PR DESCRIPTION
## Summary

- **Stage 2 fallback 추가**: 기능 버그 수정(Stage 2)이 실패할 경우 Stage 1 결과로 graceful 처리 (기존에는 Stage 2 실패 = 전체 파이프라인 실패)
- **파이프라인 예산 AbortController**: `PIPELINE_MAX_DURATION_MS - 20s` 시점에 Stage 2/3 API 호출을 abort → Railway 300s HTTP 컷 직전 안전 종료, Stage 2/3는 fallback으로 처리, Stage 1은 abort 제외
- **단계별 타이밍 로그**: Stage 1/2/3 완료 시 `elapsedMs` 포함 로그 → Railway 로그에서 병목 Stage 실시간 식별 가능
- **AbortSignal 전파**: `IAiProvider.AiPrompt` → `ClaudeProvider` → `stageRunner` 전달
- **이벤트 타입 추가**: `STAGE2_FALLBACK_USED`

## 배경 (조사 결과)

- 운영 중 ~27% 생성 실패율 관측 (8개 샘플, 3회 실패)
- Railway CLI 미설치로 직접 로그 확인 불가
- 코드 분석 결과: Stage 2가 유일하게 fallback 없는 Stage — API 오류/rate limit 재시도 시 전체 실패
- ET Stage 1이 90-155s 소요 + Stage 2 재시도 시 Railway 300s 컷 초과 가능성 확인

## Test Plan

- [ ] 1740개 테스트 전체 통과 확인 (CI)
- [ ] Railway 배포 후 생성 실패율 추이 모니터링
- [ ] Railway 로그에서 `Stage 1/2/3 completed` 메시지로 병목 Stage 확인
- [ ] Stage 2 실패 시 `STAGE2_FALLBACK_USED` 이벤트 발행 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)