### PR TITLE
fix: playwright-core standalone 빌드 500 오류 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,9 @@ import { withSentryConfig } from '@sentry/nextjs';
 const nextConfig: NextConfig = {
   output: 'standalone',
   poweredByHeader: false,
+  // playwright-core is used only for rendering QC (ENABLE_RENDERING_QC=true).
+  // It must not be bundled by webpack — standalone mode copies it to node_modules.
+  serverExternalPackages: ['playwright-core'],
   images: {
     remotePatterns: [
       { protocol: 'https', hostname: '*.supabase.co' },

--- a/src/__tests__/api/admin-debug.test.ts
+++ b/src/__tests__/api/admin-debug.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const VALID_ADMIN_KEY = 'test-admin-secret-key';
+
+// createRequire mock — tryRequire 성공/실패 모두 테스트
+const requireMock = vi.fn();
+vi.mock('node:module', () => ({
+  createRequire: vi.fn(() => requireMock),
+}));
+
+vi.mock('@/lib/utils/adminAuth', () => ({
+  adminCorsHeaders: { 'Access-Control-Allow-Origin': '*' },
+  verifyAdminKey: vi.fn(),
+  withAdminCors: vi.fn((res: Response) => res),
+}));
+
+vi.mock('@/lib/utils/errors', async () => {
+  const { AuthRequiredError } = await import('@/lib/utils/errors');
+  return {
+    jsonResponse: vi.fn((data: unknown) =>
+      new Response(JSON.stringify(data), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ),
+    handleApiError: vi.fn((err: unknown) => {
+      if (err instanceof AuthRequiredError) {
+        return new Response(JSON.stringify({ error: { code: 'AUTH_REQUIRED' } }), { status: 401 });
+      }
+      return new Response(JSON.stringify({ error: { code: 'INTERNAL_ERROR' } }), { status: 500 });
+    }),
+    AuthRequiredError,
+  };
+});
+
+function makeRequest(method = 'GET') {
+  return new Request('http://localhost/api/v1/admin/debug', {
+    method,
+    headers: { Authorization: `Bearer ${VALID_ADMIN_KEY}` },
+  });
+}
+
+describe('GET /api/v1/admin/debug', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireMock.mockReturnValue({});
+  });
+
+  it('OPTIONS 요청에 204를 반환한다', async () => {
+    const { OPTIONS } = await import('@/app/api/v1/admin/debug/route');
+    const response = await OPTIONS();
+    expect(response.status).toBe(204);
+  });
+
+  it('인증된 요청에 모듈 진단 결과를 반환한다', async () => {
+    const { GET } = await import('@/app/api/v1/admin/debug/route');
+    const response = await GET(makeRequest());
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { success: boolean; data: { modules: Record<string, string> } };
+    expect(body.success).toBe(true);
+    expect(body.data.modules['playwright-core']).toBe('ok');
+    expect(body.data.modules['pg']).toBe('ok');
+    expect(body.data.modules['@anthropic-ai/sdk']).toBe('ok');
+  });
+
+  it('모듈 로드 실패 시 FAIL: 접두사 문자열을 반환한다', async () => {
+    requireMock.mockImplementation((id: string) => {
+      if (id === 'playwright-core') throw new Error('Cannot find module');
+    });
+
+    const { GET } = await import('@/app/api/v1/admin/debug/route');
+    const response = await GET(makeRequest());
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { data: { modules: Record<string, string> } };
+    expect(body.data.modules['playwright-core']).toMatch(/^FAIL:/);
+    expect(body.data.modules['pg']).toBe('ok');
+  });
+
+  it('환경 정보(nodeVersion, platform, arch, nodeEnv)를 포함한다', async () => {
+    const { GET } = await import('@/app/api/v1/admin/debug/route');
+    const response = await GET(makeRequest());
+
+    const body = await response.json() as {
+      data: { nodeVersion: string; platform: string; arch: string; nodeEnv: string | undefined }
+    };
+    expect(body.data.nodeVersion).toMatch(/^v\d+/);
+    expect(body.data.platform).toBeTruthy();
+    expect(body.data.arch).toBeTruthy();
+  });
+
+  it('어드민 키 검증 실패 시 handleApiError를 통해 처리된다', async () => {
+    const { verifyAdminKey } = await import('@/lib/utils/adminAuth');
+    const { AuthRequiredError } = await import('@/lib/utils/errors');
+    vi.mocked(verifyAdminKey).mockImplementationOnce(() => {
+      throw new AuthRequiredError();
+    });
+
+    const { GET } = await import('@/app/api/v1/admin/debug/route');
+    const response = await GET(makeRequest());
+
+    expect(response.status).toBe(401);
+  });
+
+  it('Error 인스턴스가 아닌 예외도 문자열로 변환된다', async () => {
+    requireMock.mockImplementation((id: string) => {
+      if (id === 'drizzle-orm') throw 'module not found string error';
+    });
+
+    const { GET } = await import('@/app/api/v1/admin/debug/route');
+    const response = await GET(makeRequest());
+
+    const body = await response.json() as { data: { modules: Record<string, string> } };
+    expect(body.data.modules['drizzle-orm']).toMatch(/^FAIL:/);
+  });
+});

--- a/src/app/api/v1/admin/debug/route.ts
+++ b/src/app/api/v1/admin/debug/route.ts
@@ -1,0 +1,50 @@
+import { createRequire } from 'node:module';
+import { adminCorsHeaders, verifyAdminKey, withAdminCors } from '@/lib/utils/adminAuth';
+import { handleApiError, jsonResponse } from '@/lib/utils/errors';
+
+const req = createRequire(import.meta.url);
+
+function tryRequire(id: string): string {
+  try {
+    req(id);
+    return 'ok';
+  } catch (e) {
+    return `FAIL: ${e instanceof Error ? e.message : String(e)}`.slice(0, 200);
+  }
+}
+
+/**
+ * 생성 파이프라인 모듈 로드 진단 엔드포인트.
+ * 500 오류 원인 규명용 — npm 패키지가 standalone node_modules에 존재하는지 확인.
+ */
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, { status: 204, headers: adminCorsHeaders });
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const res = await (async () => {
+    try {
+      verifyAdminKey(request);
+
+      return jsonResponse({
+        success: true,
+        data: {
+          nodeVersion: process.version,
+          platform: process.platform,
+          arch: process.arch,
+          nodeEnv: process.env.NODE_ENV,
+          modules: {
+            'playwright-core': tryRequire('playwright-core'),
+            '@anthropic-ai/sdk': tryRequire('@anthropic-ai/sdk'),
+            'drizzle-orm': tryRequire('drizzle-orm'),
+            'drizzle-orm/node-postgres': tryRequire('drizzle-orm/node-postgres'),
+            'pg': tryRequire('pg'),
+          },
+        },
+      });
+    } catch (error) {
+      return handleApiError(error);
+    }
+  })();
+  return withAdminCors(res);
+}


### PR DESCRIPTION
## Summary

- `next.config.ts`에 `serverExternalPackages: ['playwright-core']` 추가
- `playwright-core`가 webpack으로 번들링되지 않고 standalone `node_modules`에 복사됨
- `admin/debug` 진단 엔드포인트 추가 (배포 후 모듈 로드 상태 확인용)

## 근본 원인

`browserPool.ts`가 `playwright-core`를 정적 import(`import { chromium } from 'playwright-core'`)로 사용하고, 이 파일이 `generationPipeline.ts` → `@/lib/qc` 체인을 통해 generate/test-generation 라우트에 포함됨.

`playwright-core`가 `serverExternalPackages`에 없으면 Next.js webpack이 번들링을 시도하지만, Alpine Linux standalone 환경에서 모듈 로드에 실패 → 라우트 전체가 500 `text/plain: Internal Server Error`를 반환함.

`qc-stats` 라우트는 `playwright-core` 의존 체인이 없어 정상 동작했음.

## Test Plan

- [ ] CI: 1751개 테스트 통과 확인
- [ ] Railway 배포 후 `GET https://xzawed.xyz/api/v1/admin/debug` 호출 → 모든 모듈 `ok` 확인
- [ ] 부하 테스트 재실행: `ADMIN_API_KEY=... TEST_USER_ID=... pnpm tsx scripts/runGenerationLoadTest.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)