### PR TITLE
fix: playwright-core standalone npm install — __dirname .pnpm 경로 500 오류 해소

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,13 @@ ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
 ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
 ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
 
-RUN mkdir -p /app/public && pnpm build && \
-    # playwright-core is excluded from webpack bundling (serverExternalPackages) but pnpm symlinks
-    # can cause nft to miss it during standalone trace. Copy it explicitly.
-    mkdir -p /app/.next/standalone/node_modules && \
-    cp -rL /app/node_modules/playwright-core /app/.next/standalone/node_modules/playwright-core
+RUN mkdir -p /app/public && pnpm build
+# playwright-core: pnpm symlinks cause __dirname to resolve to .pnpm path at runtime,
+# but browsers.json is not traced there by nft. npm install creates a flat node_modules
+# entry so __dirname === /app/.next/standalone/node_modules/playwright-core/lib at runtime.
+RUN PW_VER=$(node -p "require('/app/node_modules/playwright-core/package.json').version") && \
+    cd /app/.next/standalone && \
+    npm install "playwright-core@${PW_VER}" --no-save --no-package-lock --legacy-peer-deps
 
 # ── Stage 3: Production runner ──
 FROM node:20-alpine AS runner


### PR DESCRIPTION
## 원인

Railway 배포 로그에서 확인된 실제 오류:
```
Cannot find module '/app/node_modules/.pnpm/playwright-core@1.60.0/node_modules/playwright-core/browsers.json'
Require stack:
- /app/node_modules/.pnpm/playwright-core@1.60.0/node_modules/playwright-core/lib/coreBundle.js
```

`cp -rL`로 `/app/.next/standalone/node_modules/playwright-core`에 파일을 복사해도, Node.js는 원본 모듈을 로드할 때 심링크를 따라가 `__dirname`을 `.pnpm` 실제 경로로 resolve한다. 따라서 `coreBundle.js`가 `browsers.json`을 `.pnpm` 경로에서 찾지만 그 파일은 standalone에 없어 500 오류가 발생한다.

## 수정

`cp -rL` → `npm install "playwright-core@<exact_version>"` 으로 교체.

`npm install`은 심링크 없이 flat 구조로 파일을 설치하므로 `__dirname`이 `/app/.next/standalone/node_modules/playwright-core/lib`을 정확히 가리키고, `browsers.json`도 같은 경로에 존재한다.

## 변경 파일

- `Dockerfile`: Stage 2 playwright-core 처리 방식 변경

## 테스트 계획

- [ ] Railway CI 통과 확인
- [ ] 배포 후 `/api/v1/generate` 500 → 정상 응답 확인
- [ ] `/api/v1/admin/debug` 엔드포인트에서 `playwright-core: ok` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)