### PR TITLE
fix: playwright-core standalone — 격리 npm 설치로 isDescendantOf 오류 해소

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,18 @@ ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
 ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
 
 RUN mkdir -p /app/public && pnpm build
-# playwright-core: pnpm symlinks cause __dirname to resolve to .pnpm path at runtime,
-# but browsers.json is not traced there by nft. npm install creates a flat node_modules
-# entry so __dirname === /app/.next/standalone/node_modules/playwright-core/lib at runtime.
+# playwright-core: pnpm symlinks cause __dirname to resolve to .pnpm path at runtime.
+# Install in an isolated temp dir (npm flat layout, no symlinks), then copy real files
+# into standalone — ensures __dirname resolves correctly inside coreBundle.js.
+# We also rm the existing nft-traced symlink first so cp targets a real directory.
 RUN PW_VER=$(node -p "require('/app/node_modules/playwright-core/package.json').version") && \
-    cd /app/.next/standalone && \
-    npm install "playwright-core@${PW_VER}" --no-save --no-package-lock --legacy-peer-deps
+    mkdir -p /tmp/pw-root && \
+    printf '{"name":"pw","private":true}' > /tmp/pw-root/package.json && \
+    npm install --prefix /tmp/pw-root "playwright-core@${PW_VER}" --no-package-lock && \
+    rm -rf /app/.next/standalone/node_modules/playwright-core && \
+    mkdir -p /app/.next/standalone/node_modules && \
+    cp -r /tmp/pw-root/node_modules/playwright-core /app/.next/standalone/node_modules/playwright-core && \
+    rm -rf /tmp/pw-root
 
 # ── Stage 3: Production runner ──
 FROM node:20-alpine AS runner


### PR DESCRIPTION
## 문제

PR #122의 `npm install playwright-core` 접근이 Railway 빌드에서 실패:
```
npm error Cannot read properties of null (reading 'isDescendantOf')
```

`.next/standalone` 디렉터리에 `package.json`이 없어 npm 10이 상위 `/app/package.json`(pnpm workspace 구조)을 탐색하다 arborist 내부 오류 발생.

## 수정

격리된 `/tmp/pw-root`에 최소 `package.json`을 생성 후 `npm install --prefix`로 설치, 설치된 실제 파일을 standalone으로 `cp -r` 복사.

**왜 cp -r이 이번엔 안전한가:**
- npm은 pnpm과 달리 flat layout으로 심링크 없이 실제 파일을 설치
- 따라서 `cp -r` 복사본도 심링크 없는 실제 파일
- 런타임에서 `__dirname` = `/app/node_modules/playwright-core/lib/` (정확)
- `browsers.json`도 올바른 경로에 존재 → 로드 성공

**기존 nft 심링크 제거:** `rm -rf .../playwright-core` 로 nft가 생성한 pnpm 심링크를 먼저 제거하여 `cp -r` 대상이 확실히 새 실제 디렉터리가 되도록 처리.

## 변경 파일

- `Dockerfile`: Stage 2 playwright-core 처리 방식 변경

## 테스트 계획

- [ ] Railway Docker 빌드 성공 (npm install 오류 없음)
- [ ] 배포 후 `/api/v1/generate` 500 → 정상 응답
- [ ] 7일 이상 지속된 generate route 500 오류 최종 해소

🤖 Generated with [Claude Code](https://claude.com/claude-code)