### PR TITLE
fix: browsers.json nft 트레이스 경로 복사 — generate/regenerate 500 최종 해소

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,18 +21,14 @@ ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
 ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
 
 RUN mkdir -p /app/public && pnpm build
-# playwright-core: pnpm symlinks cause __dirname to resolve to .pnpm path at runtime.
-# Install in an isolated temp dir (npm flat layout, no symlinks), then copy real files
-# into standalone — ensures __dirname resolves correctly inside coreBundle.js.
-# We also rm the existing nft-traced symlink first so cp targets a real directory.
-RUN PW_VER=$(node -p "require('/app/node_modules/playwright-core/package.json').version") && \
-    mkdir -p /tmp/pw-root && \
-    printf '{"name":"pw","private":true}' > /tmp/pw-root/package.json && \
-    npm install --prefix /tmp/pw-root "playwright-core@${PW_VER}" --no-package-lock && \
-    rm -rf /app/.next/standalone/node_modules/playwright-core && \
-    mkdir -p /app/.next/standalone/node_modules && \
-    cp -r /tmp/pw-root/node_modules/playwright-core /app/.next/standalone/node_modules/playwright-core && \
-    rm -rf /tmp/pw-root
+# nft traces coreBundle.js to the .pnpm path but misses browsers.json because it is
+# required dynamically: require(path.join(__dirname, '..', 'browsers.json')).
+# Copy browsers.json to every playwright-core location nft placed in standalone.
+RUN find /app/.next/standalone/node_modules -path "*/playwright-core/lib/coreBundle.js" | \
+    while read f; do \
+      dest="$(dirname "$(dirname "$f")")/browsers.json"; \
+      [ ! -f "$dest" ] && cp /app/node_modules/playwright-core/browsers.json "$dest" && echo "copied browsers.json → $dest"; \
+    done
 
 # ── Stage 3: Production runner ──
 FROM node:20-alpine AS runner


### PR DESCRIPTION
## 근본 원인 (드디어 확인)

PR #119, #121, #122, #123 모두 같은 이유로 효과 없었음:

**nft(Node File Tracer)는 `browsers.json`을 추적하지 못한다.**

playwright-core의 `coreBundle.js`는 다음과 같이 browsers.json을 로드:
```javascript
require(path.join(__dirname, '..', 'browsers.json'))
```

`path.join(__dirname, ...)` 형태의 **동적 require**는 nft가 정적 분석으로 추적 불가.
따라서 standalone의 `.pnpm/playwright-core@1.60.0/.../playwright-core/` 에
`coreBundle.js`는 있지만 `browsers.json`은 없음 → 모듈 초기화 실패.

## 왜 이전 시도들이 실패했나

- `cp -rL` / `npm install` 방식은 `node_modules/playwright-core/` (flat 경로)를 만들었음
- 하지만 런타임에 실제 로드되는 `coreBundle.js`는 **`.pnpm` 경로** 것
- Next.js standalone은 nft가 트레이스한 `.pnpm` 경로로 모듈을 로드함
- flat 경로의 browsers.json은 전혀 참조되지 않음

## 수정 내용

`pnpm build` 후 standalone 내 모든 `playwright-core/lib/coreBundle.js` 위치를 `find`로 탐색,
각 위치의 상위 디렉터리(`playwright-core/`)에 `browsers.json`을 복사.

```dockerfile
RUN find /app/.next/standalone/node_modules -path "*/playwright-core/lib/coreBundle.js" | \
    while read f; do \
      dest="$(dirname "$(dirname "$f")")/browsers.json"; \
      [ ! -f "$dest" ] && cp /app/node_modules/playwright-core/browsers.json "$dest"; \
    done
```

npm install 불필요, symlink 문제 없음, 딱 필요한 파일 하나만 복사.

## 테스트 계획

- [ ] Railway 빌드 성공 (browsers.json copied 로그 확인)
- [ ] `/api/v1/generate` 500 → 정상 응답
- [ ] `/api/v1/generate/regenerate` 500 → 정상 응답

🤖 Generated with [Claude Code](https://claude.com/claude-code)