### PR TITLE
chore: 회고 검토 이슈 수정 — 테스트 신뢰도·Dockerfile 검증·문서 갱신

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,7 @@ pnpm test:coverage    # 커버리지 리포트
 - `AiProviderFactory.ts` 모델 ID 수정 시 `.test.ts`도 반드시 동시에 업데이트 (CI 파손 방지)
 - **JSONB 필드명 이중성**: `catalogRepository.parseEndpoints()` 같은 JSONB 매퍼는 snake_case(`example_call`)와 camelCase(`exampleCall`) 둘 다 처리 필요 — DB 직접 삽입 vs 코드 경로 차이
 - **Playwright 병렬 체크 주의**: 단일 `page` 인스턴스에서 `Promise.allSettled` 사용 시 viewport를 변경하는 체크는 반드시 다른 체크 완료 후 순차 실행 (`renderingQc.ts` 참고)
-- **playwright-core executablePath 주의**: `playwright-core`는 `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` 환경변수를 자동으로 읽지 않음. `chromium.launch({ executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH })` 형태로 명시적 전달 필요. `playwright`(풀 패키지)와 달리 `playwright-core`는 브라우저 다운로드·자동 경로 탐색을 수행하지 않음 (`browserPool.ts` 참고)
+- **playwright-core executablePath 주의**: `playwright-core`는 `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` 환경변수를 자동으로 읽지 않음. `const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH; chromium.launch({ ...(executablePath && { executablePath }) })` 형태로 명시적 전달 필요 (미설정 시 executablePath를 전달하지 않아 playwright-core 기본 탐색 로직이 유지됨). `playwright`(풀 패키지)와 달리 `playwright-core`는 브라우저 다운로드·자동 경로 탐색을 수행하지 않음 (`browserPool.ts` 참고)
 - **slug 충돌 처리**: `assignUniqueSlug()` in `projectService.ts` — base → base-2 → … → base-10 → timestamp fallback; 23505 unique 위반 시 1회 재시도
 - **generationTracker 단일 인스턴스**: `src/lib/ai/generationTracker.ts`의 `generationTracker`는 모듈 레벨 싱글톤. TTL 차등: `generating` 30분, `completed`/`failed` 10분. Railway 단일 인스턴스 환경에서만 동작 — 멀티 인스턴스 배포 시 Redis 등 외부 저장소로 교체 필요
 - **모듈 레벨 상태가 있는 파일 테스트**: `let registered = false` 같은 모듈 레벨 플래그가 있는 파일은 테스트 간 상태 누출이 발생한다. `vi.resetModules()` + 매 테스트마다 `await import(...)` 동적 임포트로 격리한다 (`eventPersister.ts` 참고)

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,12 @@ RUN find /app/.next/standalone/node_modules -path "*/playwright-core/lib/coreBun
       dest="$(dirname "$(dirname "$f")")/browsers.json"; \
       [ ! -f "$dest" ] && cp /app/node_modules/playwright-core/browsers.json "$dest" && echo "copied browsers.json → $dest"; \
     done
+# Fail fast if coreBundle.js is present but browsers.json is still missing —
+# guards against silent failure when playwright-core upgrades change lib/ structure.
+RUN if find /app/.next/standalone/node_modules -path "*/playwright-core/lib/coreBundle.js" -print -quit | grep -q .; then \
+      find /app/.next/standalone/node_modules -path "*/playwright-core/browsers.json" -print -quit | grep -q . || \
+      { echo "ERROR: playwright-core/browsers.json missing in standalone after copy — update Dockerfile copy script after playwright-core upgrade"; exit 1; }; \
+    fi
 
 # ── Stage 3: Production runner ──
 FROM node:20-alpine AS runner

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -1,6 +1,6 @@
 # 배포 가이드
 
-> **최종 업데이트:** 2026-04-12  
+> **최종 업데이트:** 2026-05-22  
 > **플랫폼:** Railway (자동 배포, main 브랜치 push 시)
 
 ---
@@ -129,7 +129,40 @@ Railway 대시보드 → Variables 탭에서 설정.
 
 ---
 
-## 4. 도메인 설정
+## 4. Playwright QC 환경 구성 (Dockerfile)
+
+`ENABLE_RENDERING_QC=true` 시 서버에서 Chromium을 실행하여 렌더링 품질을 검사합니다. 이 환경을 구성하는 데 중요한 두 가지 사항이 있습니다.
+
+### Alpine Chromium 패키지
+
+Stage 3 (runner)에서 시스템 Chromium을 직접 설치합니다:
+
+```dockerfile
+RUN apk add --no-cache chromium nss freetype harfbuzz ca-certificates ttf-freefont
+ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
+```
+
+Railway 환경변수 `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium`도 함께 설정해야 합니다.
+
+### playwright-core browsers.json 복사 (nft 동적 require 우회)
+
+Next.js standalone 빌드는 nft(Node File Tracer)로 필요한 파일만 복사합니다. playwright-core의 `coreBundle.js`가 `require(path.join(__dirname, '..', 'browsers.json'))`으로 `browsers.json`을 동적 로드하는데, nft는 동적 require를 추적하지 못해 standalone에서 파일이 누락됩니다.
+
+Dockerfile Stage 2에서 빌드 후 명시적으로 복사합니다:
+
+```dockerfile
+RUN find /app/.next/standalone/node_modules -path "*/playwright-core/lib/coreBundle.js" | \
+    while read f; do \
+      dest="$(dirname "$(dirname "$f")")/browsers.json"; \
+      [ ! -f "$dest" ] && cp /app/node_modules/playwright-core/browsers.json "$dest"; \
+    done
+```
+
+> **playwright-core 버전 업그레이드 시 주의**: `lib/coreBundle.js` 경로가 변경되면 복사가 되지 않아 런타임에만 크래시가 발생합니다(`browsers.json` 파일 부재). Dockerfile에 검증 단계가 포함되어 빌드 시 조기 감지됩니다.
+
+---
+
+## 6. 도메인 설정
 
 ### Cloudflare DNS 설정
 
@@ -168,7 +201,7 @@ Supabase Dashboard → Authentication → URL Configuration:
 
 ---
 
-## 5. 무료 티어 한도
+## 7. 무료 티어 한도
 
 | 서비스 | 무료 한도 | 예상 사용량 | 여유도 |
 |--------|-----------|------------|--------|

--- a/src/__tests__/api/admin-debug.test.ts
+++ b/src/__tests__/api/admin-debug.test.ts
@@ -42,6 +42,7 @@ function makeRequest(method = 'GET') {
 
 describe('GET /api/v1/admin/debug', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     requireMock.mockReturnValue({});
   });

--- a/src/lib/ai/qualityLoop.test.ts
+++ b/src/lib/ai/qualityLoop.test.ts
@@ -932,7 +932,7 @@ describe('resolveIterationTimeoutMs', () => {
 });
 
 describe('runQualityLoop — 파이프라인 예산 가드', () => {
-  beforeEach(() => { vi.useFakeTimers(); });
+  beforeEach(() => { vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] }); });
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllEnvs();

--- a/src/lib/qc/browserPool.test.ts
+++ b/src/lib/qc/browserPool.test.ts
@@ -214,6 +214,51 @@ describe('browserPool', () => {
     });
   });
 
+  describe('browser crash recovery (isConnected=false)', () => {
+    it('disconnected browser is replaced on next getPage() call', async () => {
+      process.env.ENABLE_RENDERING_QC = 'true';
+      const { getPage } = await importBrowserPool();
+
+      await getPage();
+      expect(chromiumLaunchMock).toHaveBeenCalledTimes(1);
+
+      // Simulate crash: next isConnected() check returns false
+      mockBrowser.isConnected.mockReturnValue(false);
+
+      const page2 = await getPage();
+      expect(page2).not.toBeNull();
+      expect(chromiumLaunchMock).toHaveBeenCalledTimes(2); // re-launched
+    });
+
+    it('crash while waiters are queued — all queued callers receive null without deadlock', async () => {
+      process.env.ENABLE_RENDERING_QC = 'true';
+      delete process.env.QC_MAX_CONCURRENT_PAGES; // MAX = 2
+      vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
+
+      try {
+        const { getPage } = await importBrowserPool();
+
+        // Fill semaphore (2 slots)
+        await getPage();
+        await getPage();
+
+        // Third caller queues — will block until semaphore or timeout
+        const p3 = getPage();
+
+        // Simulate browser crash — getBrowser() will drain waitQueue with resolve(false)
+        mockBrowser.isConnected.mockReturnValue(false);
+
+        // Advance past semaphore timeout so queued caller resolves
+        await vi.advanceTimersByTimeAsync(11_000);
+
+        const page3 = await p3;
+        expect(page3).toBeNull(); // resolved (not deadlocked)
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe('semaphore timeout', () => {
     beforeEach(() => {
       vi.useFakeTimers();


### PR DESCRIPTION
## Summary

4개 에이전트 병렬 회고 검토에서 발견된 이슈를 수정합니다.

- **테스트 신뢰도 강화**: `qualityLoop.test.ts` fake timer 옵션 명시화, `browserPool.test.ts` 브라우저 크래시 복구 경로 추가, `admin-debug.test.ts` 모듈 캐시 격리
- **Dockerfile silent failure 방지**: `browsers.json` 복사 후 검증 단계 추가 — playwright-core 버전 업그레이드 시 런타임이 아닌 빌드 시점에 조기 감지
- **문서 정합성 회복**: CLAUDE.md 예시 코드 실제 구현과 일치, deployment.md Playwright QC 절 신설

## 변경 상세

| 파일 | 변경 내용 |
|------|----------|
| `qualityLoop.test.ts` | `vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] })` — Vitest 버전 무관하게 Date mock 보장 |
| `browserPool.test.ts` | `isConnected=false` 시나리오 2개 추가: 재시작 확인, 대기 caller null 해소 확인 |
| `admin-debug.test.ts` | `beforeEach`에 `vi.resetModules()` — 동적 import 테스트 간 모듈 캐시 누출 차단 |
| `Dockerfile` | `browsers.json` 복사 후 존재 여부 검증 RUN 추가 — `exit 1`로 빌드 실패 |
| `CLAUDE.md` | playwright-core executablePath 예시: 직접 전달 → 조건부 spread 패턴으로 수정 |
| `docs/guides/deployment.md` | Playwright QC 환경 구성 절 신설, 날짜 갱신 |

## Test Plan

- [x] `pnpm test` — 1759 passed, 0 failures
- [ ] PR CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)