### PR TITLE
fix(test): full-suite 플래키 타임아웃 해소 — config/providers mock + testTimeout 상향

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ pnpm test:coverage    # 커버리지 리포트
 | Unsplash Attribution 자동 삽입 ADR (PR #102, 2026-05-04) | [docs/decisions/2026-05-04-unsplash-attribution-auto-injection.md](docs/decisions/2026-05-04-unsplash-attribution-auto-injection.md) |
 | playwright-core browsers.json nft 추적 실패 수정 ADR (PR #125, 2026-05-22) | [docs/decisions/2026-05-22-playwright-core-nft-browsers-json-fix.md](docs/decisions/2026-05-22-playwright-core-nft-browsers-json-fix.md) |
 | 보안 감사 발견 항목 수정 ADR (C-1·H-2~H-11, PR #129·#131, 2026-05-23) | [docs/decisions/2026-05-23-security-audit-findings.md](docs/decisions/2026-05-23-security-audit-findings.md) |
+| Vitest full-suite 플래키 타임아웃 해소 ADR (config/providers mock + testTimeout, 2026-06-09) | [docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md](docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md) |
 
 - [README.md](README.md) — 프로젝트 전체 개요
 - [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) — PR 템플릿
@@ -216,6 +217,7 @@ pnpm test:coverage    # 커버리지 리포트
 - **slug 충돌 처리**: `assignUniqueSlug()` in `projectService.ts` — base → base-2 → … → base-10 → timestamp fallback; 23505 unique 위반 시 1회 재시도
 - **generationTracker 단일 인스턴스**: `src/lib/ai/generationTracker.ts`의 `generationTracker`는 모듈 레벨 싱글톤. TTL 차등: `generating` 30분, `completed`/`failed` 10분. Railway 단일 인스턴스 환경에서만 동작 — 멀티 인스턴스 배포 시 Redis 등 외부 저장소로 교체 필요
 - **모듈 레벨 상태가 있는 파일 테스트**: `let registered = false` 같은 모듈 레벨 플래그가 있는 파일은 테스트 간 상태 누출이 발생한다. `vi.resetModules()` + 매 테스트마다 `await import(...)` 동적 임포트로 격리한다 (`eventPersister.ts` 참고)
+- **api 라우트 테스트는 `@/lib/config/providers`를 반드시 모킹**: 라우트는 line-1에서 `getDbProvider`를 import하는데, 이 체인이 `@/lib/db/failover`(→ `pg`)·`@/lib/db/connection`(→ drizzle-orm/node-postgres)의 네이티브+CJS cold 초기화를 끌어온다. `vi.resetModules()` + 인-테스트 `await import('@/app/.../route')` 패턴에서 첫 테스트가 이 비용을 지불하며, 병렬 full-suite 경합 시 기본 5000ms를 넘겨 간헐 타임아웃을 유발한다. `vi.mock('@/lib/config/providers', () => ({ getDbProvider: vi.fn().mockReturnValue('supabase') }))`로 차단한다 (형제 api 테스트 11개 패턴). `vitest.config.ts`의 `testTimeout`/`hookTimeout`는 경합 마진을 위해 15000ms로 상향됨 — 상세: [docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md](docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md)
 - **SonarCloud vs Codecov 지표 불일치**: Codecov/Vitest는 `vitest.config.ts`의 `coverage.include` 범위(`src/lib/**`, `src/services/**`, `src/providers/**`, `src/repositories/**`, `src/components/**`)를 측정. SonarCloud는 전체 TypeScript를 더 넓게 측정할 수 있어 두 숫자는 구조적으로 차이가 날 수 있으며, 단순 설정 오류로 단정하지 않는다.
 - **temperature deprecated (Claude 4.x)**: Claude 4.x 모델(`claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-opus-4-7`)은 `temperature` 파라미터를 지원하지 않음. ClaudeProvider에서 완전히 제거됨 (Extended Thinking 포함). `IAiPrompt.temperature` 필드는 legacy 호환용으로 유지하나 실제 API 호출에 사용하지 않음
 - **인메모리 rate limit 한계**: proxy의 Map 기반 리밋은 서버 재시작 시 초기화됨 (분당 카운터라 보안 영향 낮음). Railway 단일 인스턴스 전제 — 멀티 인스턴스 전환 시 Redis 등 외부 저장소 필요 (generationTracker와 동일 제약)

--- a/docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md
+++ b/docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md
@@ -1,0 +1,101 @@
+# ADR: Vitest full-suite 플래키 타임아웃 — 경합 기인 cold-import 지연 해소
+
+- 날짜: 2026-06-09
+- 상태: 채택
+- 관련 PR: fix/test-flaky-timeout-config-providers-mock
+- 관련 변경: vitest 2→4 업그레이드 직후(`pnpm install`로 lockfile 동기화) 발생
+
+## 배경
+
+GitHub `main` 최신화(24커밋, vitest 2.1.9 → 4.1.8, typescript 5.9 → 6.0 등) 후 `pnpm test`
+전체 스위트(138 파일 / 1776 테스트)에서 **간헐적으로 2건이 `Test timed out in 5000ms`로 실패**했다.
+동일 파일을 격리 실행하면 즉시 통과(3.9s)했고, 전체 실행에서만 재현되었다. 처음 실패한 두 건은
+`generate.test.ts > 비로그인 401`, `projects.test.ts > 비로그인 401`이었다.
+
+## 조사
+
+웹 리서치(deep-research, 검증된 9개 findings)와 코드베이스 분석 워크플로우(5 probe + 적대적 비평)를
+거쳐 다음을 확인했다.
+
+1. **`vi.resetModules()` + 인-테스트 `await import('@/app/.../route')` 패턴**: 각 실패 테스트는
+   `beforeEach`의 `resetModules()` 직후 **첫 `it()`**이며, 본문에서 라우트 모듈을 동적 import한다.
+   resetModules는 Vitest 프로젝트-소스 레지스트리를 비우므로 첫 테스트가 라우트 그래프의
+   cold transform+evaluation 비용 전부를 5000ms 예산 안에서 지불한다.
+2. **pg/drizzle cold 초기화 유입 경로**: `generate/route.ts:1`·`projects/route.ts:1`이 모두
+   `import { getDbProvider } from '@/lib/config/providers'`. `providers.ts` → `@/lib/db/failover`
+   (`import { Client } from 'pg'`) → `@/lib/db/connection`(drizzle-orm/node-postgres). 이 체인이
+   두 실패 파일에서 **미목(unmocked)**이었다. 반면 형제 api 테스트 **11개**는 `@/lib/config/providers`를
+   모킹하고 있었고 — 플래키한 2개는 정확히 그 mock을 빠뜨린 파일이었다.
+3. **경합 증폭 요인(실측으로 확정)**: R0(아래) 적용 후에도 머신 부하가 오르자 타임아웃이 재발했는데,
+   **희생자가 옮겨다녔다**(`projects`는 통과, `generate` 잔존, `health.test.ts`가 새 희생자). 즉 특정
+   무거운 import 하나가 아니라, 32코어 호스트에서 ~31 워커가 CPU를 오버구독하고 단일 메인스레드
+   Vite 서버가 모듈 변환을 직렬화하면서 cold-import를 내는 **임의의 첫 테스트**가 5000ms를 넘겼다.
+   **판별 진단**: `pnpm test -- --maxWorkers=4` 2회 연속 0건 → 경합이 메커니즘임을 입증.
+   관찰된 스파이크는 6296ms·6464ms로 5000ms를 약간 넘는 수준이며, 격리·저워커 실행은 모두 깨끗 →
+   실제 hang이 아니라 **경합 하의 cold-import 지연**.
+
+### 기각된 가설 (오조준 방지)
+
+- ❌ MSW `onUnhandledRequest:'warn'` 네트워크 누수가 원인 — 현재 어떤 테스트도 MSW에 도달하는
+  미처리 요청을 내지 않음(모두 stub/직접 호출). 로그의 `NetworkError` flood는 happy-dom이
+  `PreviewFrame` iframe `src`(localhost preview URL)를 로드 시도하는 노이즈로, 타임아웃 원인 아님.
+- ❌ `PreviewFrame` 폴링 루프 — `useState`만 있고 `?t`는 새로고침 버튼 클릭 시에만 증가. 타이머/fetch 없음.
+- 이상 두 가설은 코드 검증으로 기각. 잠재 위험으로만 남김(아래 후속 과제).
+
+## 결정
+
+두 가지를 함께 적용한다.
+
+### R0 — `@/lib/config/providers` 모킹 (두 실패 파일)
+
+`generate.test.ts`·`projects.test.ts` 상단에 형제 11개 파일과 동일한 mock 추가:
+
+```ts
+vi.mock('@/lib/config/providers', () => ({
+  getDbProvider: vi.fn().mockReturnValue('supabase'),
+}));
+```
+
+라우트의 line-1 import가 끌어오던 pg/drizzle 네이티브+CJS 초기화 체인을 **근원에서 절단**한다.
+적용 후 `projects.test.ts`의 첫-테스트 스파이크가 사라졌고(import 330ms → 115ms), 두 파일이
+형제 파일과 일관된다.
+
+### R1 — `testTimeout`/`hookTimeout` 15000ms (`vitest.config.ts`)
+
+기본 5000ms는 병렬 full-suite에서 cold-import 라우트 그래프에 너무 빠듯하다. 경합 하의 ~6.5s 스파이크에
+**머신 독립적 마진**을 부여한다.
+
+```ts
+testTimeout: 15_000,
+hookTimeout: 15_000,
+```
+
+## 기각된 대안
+
+- **`maxWorkers` percentage 캡 (예: `'50%'`)**: 32코어 로컬은 완화하지만 저코어 CI(2–4 vCPU)에서는
+  1워커로 직렬화되어 CI를 크게 느리게 한다. 채택 안 함.
+- **`generationPipeline` 통째 mock(R5)**: `generate.test.ts`의 성공 경로 테스트가 `setupHappyPath`로
+  **실제 파이프라인(mocked 내부 의존성)**을 구동하므로 통째 모킹 시 깨진다. 적용 안 함. 잔여
+  `@anthropic-ai/sdk` cold 비용은 R1 마진으로 흡수됨(스파이크 6.5s ≪ 15s).
+- **`pool:'threads'`**: pg-native 미설치라 네이티브 충돌 위험은 낮으나, 오버구독을 못 고치고 forks가
+  격리해주는 모듈 레벨 상태 누수(`generationTracker`, `eventPersister` `registered` 플래그, `browserPool`)에
+  노출. 채택 안 함.
+
+## 검증
+
+- R0 적용 후 두 파일 격리 17/17 통과, import 330ms → 115ms.
+- **R0 단독은 불충분**: 머신 부하 상승 시 4/4 재발(희생자 이동) → 경합이 지배적임을 실측.
+- `--maxWorkers=4` 2/2 통과 → 경합 판별 확정.
+- **R0+R1 적용 후 기본 워커 전체 스위트 5/5 통과, 타임아웃 0건** (적용 전 동일 조건 4/7 실패와 대비).
+- `pnpm type-check`·`pnpm lint` 통과.
+
+## 후속 과제 (이번 범위 밖, 예방)
+
+- CI(2–4 vCPU + v8 coverage)에서 실제 타임아웃이 발생하는지 모니터링. 발생 위치(로컬 vs CI)에 따라
+  워커 전략 재검토.
+- vitest 4.1.8이 fork-pool 타임아웃 회귀 수정(PR #8705/#9027)을 포함하는지 미확정 — 추후 패치 시 확인.
+- 예방적 하드닝(별도 PR): MSW `onUnhandledRequest:'error'` + `/api/v1/preview` 핸들러,
+  `PreviewFrame` iframe `src` happy-dom 로드 노이즈 차단, `builder/page.tsx` `pollForCompletion`에
+  테스트가 생길 경우 fake timers + afterEach 언마운트.
+- `@/lib/config/providers`를 import하는 라우트를 테스트하면서 mock을 빠뜨린 다른 api 파일이 없는지
+  주기적 감사(현재는 이 2개만 누락이었음).

--- a/src/__tests__/api/generate.test.ts
+++ b/src/__tests__/api/generate.test.ts
@@ -10,6 +10,14 @@ vi.mock('@/lib/auth/index', () => ({
   getAuthUser: vi.fn(),
 }));
 
+// config/providers를 모킹하여 라우트의 line-1 import가 pg/drizzle(@/lib/db/failover → pg,
+// @/lib/db/connection → drizzle-orm/node-postgres) cold 초기화를 끌어오는 체인을 차단한다.
+// resetModules + in-test import 패턴에서 첫 테스트가 이 네이티브 로드 비용을 5000ms 예산 안에
+// 지불하면서 발생하던 full-suite 플래키 타임아웃을 제거한다 (형제 api 테스트 11개와 동일 패턴).
+vi.mock('@/lib/config/providers', () => ({
+  getDbProvider: vi.fn().mockReturnValue('supabase'),
+}));
+
 vi.mock('@/services/factory', () => ({
   createProjectService: vi.fn(),
   createCatalogService: vi.fn(),

--- a/src/__tests__/api/projects.test.ts
+++ b/src/__tests__/api/projects.test.ts
@@ -11,6 +11,14 @@ vi.mock('@/lib/auth/index', () => ({
   getAuthUser: vi.fn(),
 }));
 
+// config/providers를 모킹하여 라우트의 line-1 import가 pg/drizzle(@/lib/db/failover → pg,
+// @/lib/db/connection → drizzle-orm/node-postgres) cold 초기화를 끌어오는 체인을 차단한다.
+// resetModules + in-test import 패턴에서 첫 테스트가 이 네이티브 로드 비용을 5000ms 예산 안에
+// 지불하면서 발생하던 full-suite 플래키 타임아웃을 제거한다 (형제 api 테스트 11개와 동일 패턴).
+vi.mock('@/lib/config/providers', () => ({
+  getDbProvider: vi.fn().mockReturnValue('supabase'),
+}));
+
 // Service factory mock — routes now use createProjectService() from @/services/factory
 vi.mock('@/services/factory', () => ({
   createProjectService: vi.fn(),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,13 @@ export default defineConfig({
     setupFiles: ['./src/test/setup.ts'],
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     exclude: ['node_modules/**', 'e2e/**'],
+    // 기본 5000ms는 full-suite 병렬 실행 시 너무 빠듯하다. 고코어 머신/CI에서
+    // 워커가 CPU를 오버구독하면 단일 메인스레드 Vite 서버가 모듈 변환을 직렬화하여,
+    // 라우트 그래프를 cold-import하는 첫 테스트가 간헐적으로 ~6.5s까지 치솟아 타임아웃났다.
+    // (maxWorkers=4 진단 시 0건 — 경합 기인 cold-import 지연이지 실제 hang은 아님.)
+    // 워커 percentage 캡은 저코어 CI를 직렬화시키므로, 머신 독립적인 타임아웃 마진으로 해소한다.
+    testTimeout: 15_000,
+    hookTimeout: 15_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
## 배경

GitHub `main` 최신화(vitest 2.1.9 → 4.1.8 포함) 후 `pnpm test` 전체 스위트(138 파일 / 1776 테스트)에서 **간헐적으로 2건이 `Test timed out in 5000ms`로 실패**(격리 실행 시 통과). deep-research(검증된 9개 findings) + 코드베이스 분석 워크플로우(5 probe + 적대적 비평)로 근본 원인을 규명했습니다.

## 근본 원인 (실측 확정)

1. **`vi.resetModules()` + 인-테스트 `await import(route)` 패턴** — 실패 테스트는 각 파일의 첫 `it()`이며, 라우트 `line-1`의 `getDbProvider` import가 `@/lib/db/failover`(→ `pg`)·`@/lib/db/connection`(→ drizzle-orm/node-postgres)의 네이티브+CJS **cold 초기화**를 끌어와 첫 테스트가 그 비용을 5000ms 예산 안에 지불.
2. **경합 증폭(지배적 드라이버)** — 32코어 호스트에서 ~31 워커가 CPU를 오버구독하고 단일 메인스레드 Vite 서버가 모듈 변환을 직렬화 → cold-import 테스트가 간헐적으로 **~6.5s**까지 스파이크. R0 적용 후에도 부하 상승 시 **희생자가 이동**(`projects`→통과, `generate` 잔존, `health` 신규)하며 재발 → 특정 import가 아닌 경합이 원인임을 실측. **`--maxWorkers=4` 진단 0건**으로 확정.

기각된 가설(오조준 방지): MSW `'warn'` 네트워크 누수 / `PreviewFrame` 폴링 루프 — 코드 검증으로 둘 다 현재 원인 아님(로그의 `NetworkError`는 happy-dom iframe `src` 로드 노이즈). 잠재 위험으로만 남김.

## 변경

| | 조치 | 파일 |
|---|------|------|
| **R0** | `@/lib/config/providers` 모킹 추가 (형제 api 테스트 11개와 동일 패턴, pg/drizzle 체인 근원 차단) | `generate.test.ts`, `projects.test.ts` |
| **R1** | `testTimeout`/`hookTimeout` **15000ms** (머신 독립적 경합 마진) | `vitest.config.ts` |

**기각된 대안**: `maxWorkers` percentage 캡(저코어 CI 직렬화) / `generationPipeline` 통째 mock(성공 경로 테스트 파손) / `pool:'threads'`(오버구독 미해결 + 모듈 레벨 상태 누수 노출).

## 검증

- R0 후 두 파일 격리 17/17 통과, import 330ms → 115ms.
- R0 단독은 부하 상승 시 4/4 재발(희생자 이동) → 경합 실측.
- `--maxWorkers=4` 2/2 통과 → 경합 판별 확정.
- **R0+R1 후 기본 워커 full-suite 5/5 통과, 타임아웃 0건** (적용 전 동일 조건 4/7 실패).
- `pnpm type-check`·`pnpm lint` 통과.

## 후속 과제 (별도 PR)

CI(저코어 + coverage) 타임아웃 모니터링, vitest 4.1.8의 fork-pool 회귀 수정 포함 여부 확인, 예방적 하드닝(MSW `'error'` + preview 핸들러, iframe 로드 노이즈 차단).

상세: [ADR](docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
