### PR TITLE
test: 생성 폴링 로직 추출 + 단위테스트 (#4), 후속 #5·#6 정리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ src/
 │   ├── config/      # 환경변수 기반 설정
 │   ├── deploy/      # 배포 관련
 │   ├── events/      # EventBus (pub/sub) + eventPersister (전체 이벤트 자동 DB 기록)
+│   ├── generation/  # pollGenerationStatus — 생성 상태 폴링 (builder/page.tsx에서 추출, 주입형·단위 테스트 대상)
 │   ├── monitoring/  # slackAlert (Webhook 알림), errorRateMonitor (생성 실패율 임계값 감지)
 │   ├── i18n/        # 다국어 — t() 함수, ko.ts (한국어 메시지), types.ts (MessageKey)
 │   ├── qc/          # QC 로직 — browserPool, deepQcRunner, featureSmokeTest, qcChecks, renderingQc
@@ -152,7 +153,7 @@ pnpm test:coverage    # 커버리지 리포트
 | playwright-core browsers.json nft 추적 실패 수정 ADR (PR #125, 2026-05-22) | [docs/decisions/2026-05-22-playwright-core-nft-browsers-json-fix.md](docs/decisions/2026-05-22-playwright-core-nft-browsers-json-fix.md) |
 | 보안 감사 발견 항목 수정 ADR (C-1·H-2~H-11, PR #129·#131, 2026-05-23) | [docs/decisions/2026-05-23-security-audit-findings.md](docs/decisions/2026-05-23-security-audit-findings.md) |
 | Vitest full-suite 플래키 타임아웃 해소 ADR (config/providers mock + testTimeout, 2026-06-09) | [docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md](docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md) |
-| 테스트 플래키 타임아웃 잔여·후속 작업 핸드오프 (예방 1·2·3 완료, 4·5·6 잔존, 2026-06-09) | [docs/superpowers/plans/2026-06-09-test-flakiness-followups.md](docs/superpowers/plans/2026-06-09-test-flakiness-followups.md) |
+| 테스트 플래키 타임아웃 잔여·후속 작업 핸드오프 (항목 1·2·3·4·6 완료, 5는 상시 모니터링, 2026-06-09) | [docs/superpowers/plans/2026-06-09-test-flakiness-followups.md](docs/superpowers/plans/2026-06-09-test-flakiness-followups.md) |
 
 - [README.md](README.md) — 프로젝트 전체 개요
 - [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) — PR 템플릿
@@ -217,6 +218,7 @@ pnpm test:coverage    # 커버리지 리포트
 - **playwright-core executablePath 주의**: `playwright-core`는 `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` 환경변수를 자동으로 읽지 않음. `const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH; chromium.launch({ ...(executablePath && { executablePath }) })` 형태로 명시적 전달 필요 (미설정 시 executablePath를 전달하지 않아 playwright-core 기본 탐색 로직이 유지됨). `playwright`(풀 패키지)와 달리 `playwright-core`는 브라우저 다운로드·자동 경로 탐색을 수행하지 않음 (`browserPool.ts` 참고)
 - **slug 충돌 처리**: `assignUniqueSlug()` in `projectService.ts` — base → base-2 → … → base-10 → timestamp fallback; 23505 unique 위반 시 1회 재시도
 - **generationTracker 단일 인스턴스**: `src/lib/ai/generationTracker.ts`의 `generationTracker`는 모듈 레벨 싱글톤. TTL 차등: `generating` 30분, `completed`/`failed` 10분. Railway 단일 인스턴스 환경에서만 동작 — 멀티 인스턴스 배포 시 Redis 등 외부 저장소로 교체 필요
+- **생성 상태 폴링 추출**: `builder/page.tsx`의 SSE 폴백 폴링은 `src/lib/generation/pollGenerationStatus.ts`로 추출됨(주입형 `fetchFn`·`delay`·콜백, 단위 테스트 대상). `page.tsx`는 thin 래퍼. **보존된 quirk**: `status:'failed'`는 즉시 실패시키지 않고 `throw` → catch에서 마지막 시도일 때만 `failGeneration` → 'failed'가 지속되면 `maxAttempts`(120)까지 재시도 후 실패. 추출 시 동작 변경 없이 보존했으며 개선은 별도 사안. 테스트는 DI-delay(즉시 resolve)로 결정적 검증, 기본 `setTimeout` 경로만 `vi.useFakeTimers()`+`runAllTimersAsync()`로 커버
 - **모듈 레벨 상태가 있는 파일 테스트**: `let registered = false` 같은 모듈 레벨 플래그가 있는 파일은 테스트 간 상태 누출이 발생한다. `vi.resetModules()` + 매 테스트마다 `await import(...)` 동적 임포트로 격리한다 (`eventPersister.ts` 참고)
 - **api 라우트 테스트는 `@/lib/config/providers`를 반드시 모킹**: 라우트는 line-1에서 `getDbProvider`를 import하는데, 이 체인이 `@/lib/db/failover`(→ `pg`)·`@/lib/db/connection`(→ drizzle-orm/node-postgres)의 네이티브+CJS cold 초기화를 끌어온다. `vi.resetModules()` + 인-테스트 `await import('@/app/.../route')` 패턴에서 첫 테스트가 이 비용을 지불하며, 병렬 full-suite 경합 시 기본 5000ms를 넘겨 간헐 타임아웃을 유발한다. `vi.mock('@/lib/config/providers', () => ({ getDbProvider: vi.fn().mockReturnValue('supabase') }))`로 차단한다 (현재 api 라우트 테스트 16/16 모두 이 패턴 적용 — `health.test.ts`는 `@/lib/db/failover`·`@/repositories/factory`까지 함께 모킹해야 native 그래프가 완전 차단된다). `vitest.config.ts`의 `testTimeout`/`hookTimeout`는 경합 마진을 위해 15000ms로 상향됨 — 상세: [docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md](docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md)
 - **happy-dom iframe 로드 노이즈 차단**: `vitest.config.ts`의 `environmentOptions.happyDOM.settings.navigation.disableChildFrameNavigation = true`로 iframe `src` 실제 로드를 막아 `DOMException NetworkError` 로그 flood를 차단함. v20에서 `disableIframePageLoading`은 deprecated이므로 사용 금지. `disableFallbackToSetURL`(기본 false) 보존으로 `iframe.src` 속성은 그대로 반영되어 단언에는 무영향

--- a/docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md
+++ b/docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md
@@ -91,15 +91,19 @@ hookTimeout: 15_000,
 
 ## 후속 과제 (이번 범위 밖, 예방)
 
-- CI(2–4 vCPU + v8 coverage)에서 실제 타임아웃이 발생하는지 모니터링. 발생 위치(로컬 vs CI)에 따라
-  워커 전략 재검토. **(미해결 — 운영 모니터링)**
-- vitest 4.1.8이 fork-pool 타임아웃 회귀 수정(PR #8705/#9027)을 포함하는지 미확정 — 추후 패치 시 확인.
-  **(미해결 — 운영 모니터링)**
+- 🔄 CI(2–4 vCPU + v8 coverage)에서 실제 타임아웃이 발생하는지 모니터링. 발생 위치(로컬 vs CI)에 따라
+  워커 전략 재검토. **(상시 모니터링 — 현재 CI green, 코드 작업 없음)**
+- ✅ **확인 완료**: vitest 4.1.8의 fork-pool 회귀 수정 포함 여부 — 추적 이슈 #8766(2025-10-22)·
+  #8968(2025-11-14 COMPLETED)은 설치본 4.1.8(2026-06-01)보다 앞서 해결 → **4.1.8은 포함**. 다만
+  해당 이슈는 풀 워커 spawn/terminate 타임아웃이고 본 사안은 경합 기인 cold-import 지연이라 **별개** —
+  R1 마진(15s)은 유지한다. (핸드오프의 "PR #8705/#9027" 표기는 부정확, 실제는 위 두 이슈.)
 - ✅ **완료** (브랜치 `test/test-flakiness-followups`): 예방적 하드닝 —
   MSW `onUnhandledRequest:'error'` + `*/api/v1/preview`·`*/api/v1/generate/status` 핸들러 추가,
   `PreviewFrame` iframe `src` happy-dom 로드 노이즈 차단(`navigation.disableChildFrameNavigation`),
-  `health.test.ts` cold-import 하드닝(api 라우트 테스트 16/16 일관). `builder/page.tsx`
-  `pollForCompletion` 가드는 해당 테스트가 생길 때 적용(현재 마운트 테스트 없어 무해). 상세:
+  `health.test.ts` cold-import 하드닝(api 라우트 테스트 16/16 일관). 상세:
   [docs/superpowers/plans/2026-06-09-test-flakiness-followups.md](../superpowers/plans/2026-06-09-test-flakiness-followups.md)
+- ✅ **완료** (브랜치 `test/builder-poll-extraction`): `builder/page.tsx`의 `pollForCompletion`을
+  [src/lib/generation/pollGenerationStatus.ts](../../src/lib/generation/pollGenerationStatus.ts)로
+  동작 보존 추출 + fake-timer 포함 단위 테스트 12건. 레포 유일 fetch-poll 루프에 커버리지 확보.
 - ✅ **확인 완료**: `@/lib/config/providers`를 import하면서 mock을 빠뜨린 api 라우트 테스트 —
   `health.test.ts`가 마지막 누락분이었고 이번에 해소. 현재 16/16 모두 차단 패턴 적용.

--- a/docs/superpowers/plans/2026-06-09-test-flakiness-followups.md
+++ b/docs/superpowers/plans/2026-06-09-test-flakiness-followups.md
@@ -1,7 +1,7 @@
 # 테스트 플래키 타임아웃 — 잔여·후속 작업 핸드오프
 
 - 날짜: 2026-06-09
-- 상태: **예방 항목 1·2·3 완료** (브랜치 `test/test-flakiness-followups`) — 항목 4·5·6만 잔존
+- 상태: **항목 1·2·3·4·6 완료**, 항목 5는 운영 모니터링(코드 작업 없음)으로 상시 유지
 - 선행 ADR: [docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md](../../decisions/2026-06-09-test-flaky-timeout-contention-fix.md)
 
 ## 이 브랜치(`test/test-flakiness-followups`)에서 완료된 것
@@ -111,29 +111,43 @@ mock 반환값을 명시적으로 wiring해야 한다(현재는 `createServiceCl
 개별 요청을 halt하지만 비동기 전파상 테스트를 항상 빨갛게 만들지는 않는다(MSW #946/#943) — 필요 시
 글로벌 fetch 스텁/afterEach 네트워크 스파이로 보강.
 
-### 4. `builder/page.tsx` `pollForCompletion` 테스트 가드 — 우선순위: 낮음 (예방)
+### 4. `builder/page.tsx` `pollForCompletion` 테스트 가드 — ✅ 완료 (추출 + 단위테스트)
 
-**현황**: 레포 내 **유일한 실제 fetch-poll 루프**([builder/page.tsx](../../../src/app/(main)/builder/page.tsx)
-`pollForCompletion`, `setTimeout(1000)` 슬립)이지만 이를 마운트하는 테스트가 **없어서** 현재 무해.
+> **"안전한 마운트 스모크 vs 추출+단위테스트" 선택지에서 사용자가 추출을 승인.** 폴링 로직을
+> `handleGenerate` 클로저에서 [src/lib/generation/pollGenerationStatus.ts](../../../src/lib/generation/pollGenerationStatus.ts)로
+> **동작 보존** 추출하고, `page.tsx`는 thin 래퍼로 교체. 의존성(`fetchFn`·`delay`·콜백)을
+> 주입받아 `pollGenerationStatus.test.ts` **12 케이스**로 전 경로 검증 (generating/completed/
+> unknown/failed-quirk/!res.ok/네트워크 throw/timeout/폴백/순서/interval, fake-timer 기본 delay 1건).
+> DI-delay(즉시 resolve)로 대다수를 결정적으로 검증하고, 기본 `setTimeout` 경로는
+> `vi.useFakeTimers()` + `runAllTimersAsync()`로 1건 커버. 레포 유일 fetch-poll 루프에 실제 커버리지 확보.
 
-**조치**: 향후 builder/page.tsx 테스트 작성 시 **반드시** `vi.useFakeTimers()`로 슬립 제어 +
-언마운트 후 timer advance + `/api/v1/generate/status/:projectId` MSW 핸들러 제공. (유지보수자 가이드:
-async 작업이 테스트보다 오래 살아남으면 RPC 채널 닫힘 → 행 발생.)
+**조치(완료)**: 폴링을 순수·주입형 함수로 추출 → 단위 테스트. **발견한 기존 quirk(미수정, 보존)**:
+`status:'failed'`는 즉시 실패하지 않고 `throw` → catch에서 마지막 시도일 때만 실패시키므로,
+'failed'가 지속되면 `maxAttempts`(120)까지 재시도 후 실패한다. 추출은 동작 변경 없이 보존만 했으며,
+개선은 별도 사안. (향후 `builder/page.tsx`를 **마운트**하는 테스트를 쓸 땐 여전히
+`vi.useFakeTimers()` + 언마운트 후 timer advance + status MSW 핸들러를 지킬 것.)
 
 ## 후속 모니터링 (코드 아님)
 
-### 5. CI 타임아웃 발생 위치 추적
-이번 PR은 CI(Unit&Integration) 통과. 다만 타임아웃이 로컬 32코어(오버구독)에서인지 CI(2–4 vCPU +
-v8 coverage)에서인지 미확정. CI에서 재발하면 워커 전략(저코어에서는 이미 워커 적음) 재검토.
+### 5. CI 타임아웃 발생 위치 추적 — 🔄 상시 모니터링 (코드 작업 없음)
+현재 CI(Unit&Integration·E2E·Build·Lint) 전부 green이라 추적할 타임아웃 이벤트가 없다. **트리거**:
+CI 로그에 `Test timed out` 재발 시. **대응**: 발생 위치(로컬 32코어 오버구독 vs CI 2–4 vCPU +
+v8 coverage)에 따라 워커 전략 재검토(저코어 CI는 이미 워커가 적어 percentage 캡은 역효과).
+지금 시점 코드 변경 없음.
 
-### 6. vitest 4.1.8 fork-pool 회귀 수정 포함 여부
-fork-pool 타임아웃 회귀(이슈 #8766/#8968)는 PR #8705/#9027로 부분 수정됨. 설치 버전 4.1.8이 이를
-포함하는지 changelog로 미확정. 추후 패치 bump 시 확인 — 포함되면 R1 마진을 낮춰도 될 수 있음.
+### 6. vitest 4.1.8 fork-pool 회귀 수정 포함 여부 — ✅ 확인 완료
+**조사 결과(2026-06-09)**: vitest 4.x는 tinypool을 제거하고 풀을 재작성했고, fork-pool 타임아웃
+회귀 추적 이슈는 **#8766**(2025-10-22 closed)·**#8968**(2025-11-14 **COMPLETED**)이다(핸드오프가
+적었던 "PR #8705/#9027"은 부정확). 두 이슈 모두 4.1.0(2026-03-12)·**설치본 4.1.8(2026-06-01)**
+출시보다 4~7개월 앞서 해결됨 → **4.1.8은 이 수정을 포함한다.**
 
-## 권장 실행 순서 (다음 세션)
+**그러나 R1 마진(15s)은 낮추지 않는다.** #8766/#8968은 풀 워커 spawn/terminate 타임아웃
+(`[vitest-pool]: Timeout starting forks runner`)이고, 우리가 겪은 건 **경합 기인 cold-import의
+테스트레벨 `Test timed out in 5000ms`** — 메커니즘이 다르다(ADR에서 fork-pool 가설 기각). 별개
+사안이라 마진 인하 근거가 없다.
 
-- ~~1·2·3번~~ → ✅ 브랜치 `test/test-flakiness-followups`에서 완료 (위 표 참조).
-1. 4번은 builder/page.tsx 테스트를 **실제로 작성할 때** 함께 (현재 마운트 테스트 없어 무해).
-2. 5·6번은 운영 모니터링 — 코드 변경 트리거 시에만.
+## 마무리
 
-남은 항목(4·5·6)도 **활성 버그가 아닌 예방/모니터링** 항목이다. 우선순위 낮음 — 다른 기능 작업과 함께 묶어 처리해도 무방.
+항목 1·2·3·4·6은 완료(브랜치 `test/test-flakiness-followups`, `test/builder-poll-extraction`).
+항목 5만 상시 모니터링으로 남으며 코드 트리거 시에만 대응한다. 전부 **활성 버그가 아닌
+예방/일관성/모니터링** 항목이었다.

--- a/src/app/(main)/builder/page.tsx
+++ b/src/app/(main)/builder/page.tsx
@@ -28,6 +28,7 @@ import { useGenerationStore } from '@/stores/generationStore';
 import { useBuilderModeStore } from '@/stores/builderModeStore';
 import type { BuilderMode } from '@/stores/builderModeStore';
 import { LIMITS } from '@/lib/config/features';
+import { pollGenerationStatus } from '@/lib/generation/pollGenerationStatus';
 import type { ApiCatalogItem, Category } from '@/types/api';
 import type { RelevanceGateResult } from '@/types/project';
 import { ChevronLeft, ChevronRight, Sparkles, Loader2, RefreshCw } from 'lucide-react';
@@ -210,45 +211,18 @@ export default function BuilderPage() {
 
       if (!reader) throw new Error('스트림을 읽을 수 없습니다.');
 
-      const pollForCompletion = async (projectId: string) => {
-        const MAX_ATTEMPTS = 120; // 2 minutes at 1s intervals
-        for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-          try {
-            const res = await fetch(`/api/v1/generate/status/${projectId}`);
-            if (!res.ok) break;
-            const { data } = (await res.json()) as {
-              data: {
-                status: 'generating' | 'completed' | 'failed' | 'unknown';
-                progress?: number;
-                message?: string;
-                result?: { projectId: string; version: number };
-                error?: string;
-              };
-            };
-            if (data.status === 'generating') {
-              updateProgress(data.progress ?? 0, data.message ?? '생성 중...');
-            } else if (data.status === 'completed' && data.result) {
-              completeGeneration(data.result.projectId, data.result.version);
-              resetContext();
-              clearApis();
-              return;
-            } else if (data.status === 'failed') {
-              throw new Error(data.error ?? '코드 생성에 실패했습니다.');
-            } else {
-              // 'unknown' — tracker entry expired or server restarted
-              failGeneration('연결이 복구되지 않았습니다. 대시보드에서 결과를 확인해주세요.');
-              return;
-            }
-          } catch (err) {
-            if (attempt === MAX_ATTEMPTS - 1) {
-              failGeneration(err instanceof Error ? err.message : '폴링 중 오류 발생');
-              return;
-            }
-          }
-          await new Promise<void>((resolve) => setTimeout(resolve, 1000));
-        }
-        failGeneration('생성 시간이 초과되었습니다. 대시보드에서 확인해주세요.');
-      };
+      // 폴링 로직은 @/lib/generation/pollGenerationStatus로 추출 (단위 테스트 대상).
+      // 동작 보존: completed 시 completeGeneration → resetContext → clearApis.
+      const pollForCompletion = (pid: string): Promise<void> =>
+        pollGenerationStatus(pid, {
+          updateProgress,
+          completeGeneration,
+          failGeneration,
+          onCompleted: () => {
+            resetContext();
+            clearApis();
+          },
+        });
 
       let buffer = '';
       let done = false;

--- a/src/lib/generation/pollGenerationStatus.test.ts
+++ b/src/lib/generation/pollGenerationStatus.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi } from 'vitest';
+import { pollGenerationStatus } from './pollGenerationStatus';
+
+/** res.ok / res.json()만 사용하므로 최소 stub. */
+function makeRes(body: unknown, ok = true): Response {
+  return { ok, json: async () => body } as unknown as Response;
+}
+
+/** 공통 deps — delay는 즉시 resolve로 주입하여 실제 대기 없이 결정적으로 검증. */
+function makeDeps(overrides: Partial<Parameters<typeof pollGenerationStatus>[1]> = {}) {
+  return {
+    updateProgress: vi.fn(),
+    completeGeneration: vi.fn(),
+    failGeneration: vi.fn(),
+    onCompleted: vi.fn(),
+    delay: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('pollGenerationStatus', () => {
+  it('completed + result면 completeGeneration·onCompleted 호출 후 즉시 종료', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(
+        makeRes({ data: { status: 'completed', result: { projectId: 'p9', version: 3 } } }),
+      );
+    const deps = makeDeps({ fetchFn });
+
+    await pollGenerationStatus('p9', deps);
+
+    expect(deps.completeGeneration).toHaveBeenCalledTimes(1);
+    expect(deps.completeGeneration).toHaveBeenCalledWith('p9', 3);
+    expect(deps.onCompleted).toHaveBeenCalledTimes(1);
+    expect(deps.failGeneration).not.toHaveBeenCalled();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledWith('/api/v1/generate/status/p9');
+    expect(deps.delay).not.toHaveBeenCalled();
+  });
+
+  it('completeGeneration 직후 onCompleted가 호출된다 (순서 보존)', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(
+        makeRes({ data: { status: 'completed', result: { projectId: 'p', version: 1 } } }),
+      );
+    // .mock 접근을 위해 mock을 직접 보유 (makeDeps spread는 타입을 union으로 넓힘).
+    const completeGeneration = vi.fn();
+    const onCompleted = vi.fn();
+
+    await pollGenerationStatus('p', {
+      updateProgress: vi.fn(),
+      completeGeneration,
+      failGeneration: vi.fn(),
+      onCompleted,
+      delay: vi.fn().mockResolvedValue(undefined),
+      fetchFn,
+    });
+
+    expect(completeGeneration.mock.invocationCallOrder[0]).toBeLessThan(
+      onCompleted.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('generating이면 진행률을 갱신하고 다음 시도에서 completed 처리', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(makeRes({ data: { status: 'generating', progress: 40, message: '중간' } }))
+      .mockResolvedValueOnce(
+        makeRes({ data: { status: 'completed', result: { projectId: 'p', version: 2 } } }),
+      );
+    const deps = makeDeps({ fetchFn });
+
+    await pollGenerationStatus('p', deps);
+
+    expect(deps.updateProgress).toHaveBeenCalledTimes(1);
+    expect(deps.updateProgress).toHaveBeenCalledWith(40, '중간');
+    expect(deps.completeGeneration).toHaveBeenCalledWith('p', 2);
+    expect(deps.delay).toHaveBeenCalledTimes(1);
+    expect(deps.delay).toHaveBeenCalledWith(1000);
+  });
+
+  it('generating의 progress/message 누락 시 0·기본 문구로 폴백', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(makeRes({ data: { status: 'generating' } }))
+      .mockResolvedValueOnce(
+        makeRes({ data: { status: 'completed', result: { projectId: 'p', version: 1 } } }),
+      );
+    const deps = makeDeps({ fetchFn });
+
+    await pollGenerationStatus('p', deps);
+
+    expect(deps.updateProgress).toHaveBeenCalledWith(0, '생성 중...');
+  });
+
+  it("status: 'unknown'이면 즉시 failGeneration('연결이 복구...')", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(makeRes({ data: { status: 'unknown' } }));
+    const deps = makeDeps({ fetchFn });
+
+    await pollGenerationStatus('p', deps);
+
+    expect(deps.failGeneration).toHaveBeenCalledTimes(1);
+    expect(deps.failGeneration).toHaveBeenCalledWith(
+      '연결이 복구되지 않았습니다. 대시보드에서 결과를 확인해주세요.',
+    );
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(deps.completeGeneration).not.toHaveBeenCalled();
+  });
+
+  it("completed인데 result가 없으면 'unknown'과 동일 처리 (동작 보존)", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(makeRes({ data: { status: 'completed' } }));
+    const deps = makeDeps({ fetchFn });
+
+    await pollGenerationStatus('p', deps);
+
+    expect(deps.failGeneration).toHaveBeenCalledTimes(1);
+    expect(deps.failGeneration).toHaveBeenCalledWith(
+      '연결이 복구되지 않았습니다. 대시보드에서 결과를 확인해주세요.',
+    );
+    expect(deps.completeGeneration).not.toHaveBeenCalled();
+  });
+
+  it("응답이 !res.ok면 break하여 '시간 초과' 경로로 떨어진다 (동작 보존)", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(makeRes({}, false));
+    const deps = makeDeps({ fetchFn });
+
+    await pollGenerationStatus('p', deps);
+
+    expect(deps.failGeneration).toHaveBeenCalledTimes(1);
+    expect(deps.failGeneration).toHaveBeenCalledWith(
+      '생성 시간이 초과되었습니다. 대시보드에서 확인해주세요.',
+    );
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(deps.delay).not.toHaveBeenCalled();
+  });
+
+  it("status: 'failed'는 즉시 실패하지 않고 maxAttempts까지 재시도 후 실패 (기존 quirk 보존)", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(makeRes({ data: { status: 'failed', error: '생성 실패함' } }));
+    const deps = makeDeps({ fetchFn, maxAttempts: 3 });
+
+    await pollGenerationStatus('p', deps);
+
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    expect(deps.delay).toHaveBeenCalledTimes(2); // 마지막 시도 전까지만 대기
+    expect(deps.failGeneration).toHaveBeenCalledTimes(1);
+    expect(deps.failGeneration).toHaveBeenCalledWith('생성 실패함');
+  });
+
+  it('fetch가 throw하면 마지막 시도에서 에러 메시지로 실패', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('네트워크 끊김'));
+    const deps = makeDeps({ fetchFn, maxAttempts: 2 });
+
+    await pollGenerationStatus('p', deps);
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(deps.delay).toHaveBeenCalledTimes(1);
+    expect(deps.failGeneration).toHaveBeenCalledTimes(1);
+    expect(deps.failGeneration).toHaveBeenCalledWith('네트워크 끊김');
+  });
+
+  it('계속 generating이면 maxAttempts 소진 후 시간 초과로 실패', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(makeRes({ data: { status: 'generating', progress: 10 } }));
+    const deps = makeDeps({ fetchFn, maxAttempts: 3 });
+
+    await pollGenerationStatus('p', deps);
+
+    expect(deps.updateProgress).toHaveBeenCalledTimes(3);
+    expect(deps.delay).toHaveBeenCalledTimes(3);
+    expect(deps.failGeneration).toHaveBeenCalledTimes(1);
+    expect(deps.failGeneration).toHaveBeenCalledWith(
+      '생성 시간이 초과되었습니다. 대시보드에서 확인해주세요.',
+    );
+  });
+
+  it('intervalMs를 주입하면 그 값으로 대기한다', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(makeRes({ data: { status: 'generating', progress: 1 } }))
+      .mockResolvedValueOnce(
+        makeRes({ data: { status: 'completed', result: { projectId: 'p', version: 1 } } }),
+      );
+    const deps = makeDeps({ fetchFn, intervalMs: 250 });
+
+    await pollGenerationStatus('p', deps);
+
+    expect(deps.delay).toHaveBeenCalledWith(250);
+  });
+
+  it('기본 delay(setTimeout) 경로도 fake timers로 제어된다', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchFn = vi
+        .fn()
+        .mockResolvedValueOnce(makeRes({ data: { status: 'generating', progress: 50, message: '중간' } }))
+        .mockResolvedValueOnce(
+          makeRes({ data: { status: 'completed', result: { projectId: 'p', version: 2 } } }),
+        );
+      const updateProgress = vi.fn();
+      const completeGeneration = vi.fn();
+      const failGeneration = vi.fn();
+
+      // delay 미주입 → 모듈 기본 setTimeout(1000) 사용
+      const promise = pollGenerationStatus('p', {
+        updateProgress,
+        completeGeneration,
+        failGeneration,
+        fetchFn,
+      });
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(updateProgress).toHaveBeenCalledWith(50, '중간');
+      expect(completeGeneration).toHaveBeenCalledWith('p', 2);
+      expect(failGeneration).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/lib/generation/pollGenerationStatus.ts
+++ b/src/lib/generation/pollGenerationStatus.ts
@@ -1,0 +1,86 @@
+/**
+ * 생성 상태 폴링 — SSE 스트림이 'complete' 없이 끊기거나(모바일 백그라운드 전환 등)
+ * visibilitychange로 전환될 때 `/api/v1/generate/status/:projectId`를 주기적으로 조회한다.
+ *
+ * 원래 `builder/page.tsx`의 `handleGenerate` 클로저 내부에 있던 로직을 그대로 추출한 것이다.
+ * 동작을 byte-for-byte 보존했으며(아래 주의 참고), 의존성을 주입받아 단위 테스트가 가능하다.
+ *
+ * **주의(기존 동작 보존)**:
+ * - `status: 'failed'`는 즉시 실패시키지 않고 `throw` → catch에서 마지막 시도일 때만
+ *   `failGeneration`. 즉 'failed'가 계속 반환되면 `maxAttempts`까지 재시도 후 실패한다.
+ *   (개선 여지가 있으나 이번 추출은 동작 변경 없이 보존만 한다.)
+ * - 응답이 `!res.ok`이면 루프를 `break`하여 "생성 시간이 초과되었습니다" 경로로 떨어진다.
+ * - `status: 'completed'`인데 `result`가 없으면 'unknown'과 동일하게 처리된다.
+ */
+
+export interface GenerationStatusData {
+  status: 'generating' | 'completed' | 'failed' | 'unknown';
+  progress?: number;
+  message?: string;
+  result?: { projectId: string; version: number };
+  error?: string;
+}
+
+export interface PollGenerationStatusDeps {
+  updateProgress: (progress: number, message: string) => void;
+  completeGeneration: (projectId: string, version?: number) => void;
+  failGeneration: (message: string) => void;
+  /** completed 처리 직후 호출 (기존 코드의 resetContext + clearApis 정리 단계). */
+  onCompleted?: () => void;
+  /** 폴링 간 대기. 기본은 setTimeout 기반 sleep. 테스트에서 즉시 resolve로 주입 가능. */
+  delay?: (ms: number) => Promise<void>;
+  /** fetch 주입 (테스트용). 기본은 전역 fetch. */
+  fetchFn?: typeof fetch;
+  /** 최대 시도 횟수 (기본 120 = 1초 간격 2분). */
+  maxAttempts?: number;
+  /** 폴링 간격 ms (기본 1000). */
+  intervalMs?: number;
+}
+
+const defaultDelay = (ms: number): Promise<void> =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export async function pollGenerationStatus(
+  projectId: string,
+  deps: PollGenerationStatusDeps,
+): Promise<void> {
+  const {
+    updateProgress,
+    completeGeneration,
+    failGeneration,
+    onCompleted,
+    delay = defaultDelay,
+    // 언바운드 호출 시 일부 런타임에서 "Illegal invocation"이 나므로 래핑하여 전달한다.
+    fetchFn = (input, init) => fetch(input, init),
+    maxAttempts = 120,
+    intervalMs = 1000,
+  } = deps;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      const res = await fetchFn(`/api/v1/generate/status/${projectId}`);
+      if (!res.ok) break;
+      const { data } = (await res.json()) as { data: GenerationStatusData };
+      if (data.status === 'generating') {
+        updateProgress(data.progress ?? 0, data.message ?? '생성 중...');
+      } else if (data.status === 'completed' && data.result) {
+        completeGeneration(data.result.projectId, data.result.version);
+        onCompleted?.();
+        return;
+      } else if (data.status === 'failed') {
+        throw new Error(data.error ?? '코드 생성에 실패했습니다.');
+      } else {
+        // 'unknown' — tracker entry expired or server restarted
+        failGeneration('연결이 복구되지 않았습니다. 대시보드에서 결과를 확인해주세요.');
+        return;
+      }
+    } catch (err) {
+      if (attempt === maxAttempts - 1) {
+        failGeneration(err instanceof Error ? err.message : '폴링 중 오류 발생');
+        return;
+      }
+    }
+    await delay(intervalMs);
+  }
+  failGeneration('생성 시간이 초과되었습니다. 대시보드에서 확인해주세요.');
+}


### PR DESCRIPTION
## 개요

테스트 플래키 핸드오프([plan](docs/superpowers/plans/2026-06-09-test-flakiness-followups.md))의 **잔여 항목 4·5·6**을 처리합니다. 항목 1·2·3은 #141에서 완료됐습니다.

## #4 — `builder/page.tsx` `pollForCompletion` 추출 + 단위테스트 (프로덕션 코드)

레포 내 **유일한 실제 fetch-poll 루프**가 `handleGenerate` 클로저에 묻혀 테스트 불가했습니다. 사용자 승인을 받아 **동작 보존 추출 + 단위테스트**로 진행했습니다.

- 폴링 로직을 [src/lib/generation/pollGenerationStatus.ts](src/lib/generation/pollGenerationStatus.ts)로 추출 — 의존성 주입(`fetchFn`·`delay`·`onCompleted` 콜백).
- `page.tsx`는 thin 래퍼로 교체. **순서 보존**: `completed` 시 `completeGeneration → resetContext → clearApis`.
- [pollGenerationStatus.test.ts](src/lib/generation/pollGenerationStatus.test.ts) **12 케이스**: generating/completed/unknown/failed-quirk/`!res.ok`/네트워크 throw/timeout/폴백/호출 순서/interval + 기본 `setTimeout` 경로 fake-timer 1건.
- DI-delay(즉시 resolve)로 대다수를 결정적 검증, 기본 delay만 `vi.useFakeTimers()` + `runAllTimersAsync()`로 커버.

> **발견한 기존 quirk(미수정·보존)**: `status:'failed'`는 즉시 실패시키지 않고 `throw` → catch에서 마지막 시도일 때만 `failGeneration` → 'failed'가 지속되면 `maxAttempts`(120)까지 재시도 후 실패. 추출은 **동작 변경 없이 보존**만 했으며 개선은 별도 사안입니다.

## #6 — vitest 4.1.8 fork-pool 회귀 수정 포함 여부: ✅ 확인 완료

- 추적 이슈 **#8766**(2025-10-22 closed)·**#8968**(2025-11-14 COMPLETED)은 설치본 **4.1.8(2026-06-01)** 보다 4~7개월 앞서 해결 → **4.1.8은 포함**.
- 다만 풀 워커 spawn/terminate 타임아웃이라 우리의 **경합 기인 cold-import 지연**(`Test timed out in 5000ms`)과 **별개** → **R1 마진(15s) 유지**.
- 핸드오프의 "PR #8705/#9027" 표기는 부정확(실제는 위 두 이슈) — 문서 정정.

## #5 — CI 타임아웃 위치 추적: 🔄 상시 모니터링 (코드 작업 없음)

현재 CI 전부 green이라 추적할 이벤트 없음. 트리거(`Test timed out` 재발) 시에만 워커 전략 재검토.

## 검증

- ✅ 전체 **139 파일 / 1788 테스트 2회 green** (신규 +12), 로그 노이즈 0건
- ✅ 신규 테스트 격리 12/12, `pnpm type-check` · `pnpm lint` 통과
- ✅ `page.tsx` diff는 로직 동일(추출만) — 동작 보존

문서(핸드오프 plan·ADR 후속·CLAUDE.md 구조/gotcha) 동기화 포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)