### PR TITLE
fix(reliability): 감사 신뢰성 발견 수정 (이벤트퍼시스터·브라우저경쟁·고아정리·타이머누수·폴링)

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -39,13 +39,16 @@ function useSupabaseAuth() {
   useEffect(() => {
     if (!supabase) return; // not in supabase mode
 
-    // Get initial session
+    // Get initial session. rejection 핸들러가 없으면 스토리지/클라이언트 실패 시 unhandled
+    // rejection이 발생하고 인증 상태가 미결로 남는다 → catch로 null 처리하여 항상 최종화.
     supabase.auth.getSession().then(({ data: { session } }) => {
       if (session?.user) {
         setUser(mapSupabaseUser(session.user));
       } else {
         setUser(null);
       }
+    }).catch(() => {
+      setUser(null);
     });
 
     // Listen for auth changes

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,6 +1,11 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     await import('../sentry.server.config');
+    // 이벤트 퍼시스터를 앱 시작 시 한 번 전역 등록한다(idempotent). 이전엔 generate·regenerate·
+    // callback 라우트 모듈에서만 등록되어, 그 라우트들이 로드되기 전 projectService·deployService가
+    // 발행한 이벤트(PROJECT_CREATED, DEPLOYMENT_* 등)가 영속화되지 않을 수 있었다.
+    const { registerEventPersister } = await import('./lib/events/eventPersister');
+    registerEventPersister();
   }
 
   if (process.env.NEXT_RUNTIME === 'edge') {

--- a/src/lib/ai/qualityLoop.ts
+++ b/src/lib/ai/qualityLoop.ts
@@ -278,16 +278,18 @@ async function runLlmRetryIteration(
   const { systemPrompt, userFeedback, aiProvider, iterationTimeoutMs, useET, projectId, attempt } = options;
   try {
     const improvementPrompt = buildQualityImprovementPrompt(state.parsed, state.quality, state.qcReport, userFeedback);
-    const timeoutPromise = new Promise<never>((_, reject) =>
-      setTimeout(
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
         () => reject(new Error(`Quality loop iteration timed out after ${iterationTimeoutMs}ms`)),
         iterationTimeoutMs,
-      )
-    );
+      );
+    });
+    // race 종료 후 타이머를 정리한다. 성공 시에도 타이머가 만료(최대 200초)까지 살아남던 누수 차단.
     const retryResponse = await Promise.race([
       aiProvider.generateCode({ system: systemPrompt, user: improvementPrompt, extendedThinking: useET }),
       timeoutPromise,
-    ]);
+    ]).finally(() => clearTimeout(timeoutId));
     const retryParsed = parseGeneratedCode(retryResponse.content);
 
     if (!retryParsed.html) {

--- a/src/lib/generation/pollGenerationStatus.test.ts
+++ b/src/lib/generation/pollGenerationStatus.test.ts
@@ -149,7 +149,7 @@ describe('pollGenerationStatus', () => {
     expect(deps.delay).not.toHaveBeenCalled();
   });
 
-  it("status: 'failed'는 즉시 실패하지 않고 maxAttempts까지 재시도 후 실패 (기존 quirk 보존)", async () => {
+  it("status: 'failed'는 터미널 상태로 즉시 실패한다 (재시도하지 않음)", async () => {
     const fetchFn = vi
       .fn()
       .mockResolvedValue(makeRes({ data: { status: 'failed', error: '생성 실패함' } }));
@@ -157,8 +157,9 @@ describe('pollGenerationStatus', () => {
 
     await pollGenerationStatus('p', deps);
 
-    expect(fetchFn).toHaveBeenCalledTimes(3);
-    expect(deps.delay).toHaveBeenCalledTimes(2); // 마지막 시도 전까지만 대기
+    // 서버가 보고한 failed는 즉시 종료 — 무의미한 재시도(최대 2분) 없음
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(deps.delay).not.toHaveBeenCalled();
     expect(deps.failGeneration).toHaveBeenCalledTimes(1);
     expect(deps.failGeneration).toHaveBeenCalledWith('생성 실패함');
   });

--- a/src/lib/generation/pollGenerationStatus.ts
+++ b/src/lib/generation/pollGenerationStatus.ts
@@ -57,8 +57,10 @@ function handleStatusData(
     return 'stop';
   }
   if (data.status === 'failed') {
-    // 동작 보존: throw → 호출부 catch에서 마지막 시도일 때만 failGeneration
-    throw new Error(data.error ?? '코드 생성에 실패했습니다.');
+    // 서버가 'failed'를 보고하면 터미널 상태다. 즉시 실패 처리한다.
+    // (이전엔 throw하여 마지막 시도까지 재시도 → 최대 2분간 무의미하게 폴링하던 동작을 개선)
+    deps.failGeneration(data.error ?? '코드 생성에 실패했습니다.');
+    return 'stop';
   }
   if (data.status === 'not_found') {
     deps.failGeneration('프로젝트를 찾을 수 없습니다. 대시보드에서 확인해주세요.');

--- a/src/lib/qc/browserPool.test.ts
+++ b/src/lib/qc/browserPool.test.ts
@@ -130,6 +130,18 @@ describe('browserPool', () => {
       expect(chromiumLaunchMock).toHaveBeenCalledTimes(1);
       expect(mockBrowser.newContext).toHaveBeenCalledTimes(2);
     });
+
+    it('동시 첫 호출 시 브라우저를 한 번만 실행한다 (launch 경쟁 제거)', async () => {
+      process.env.ENABLE_RENDERING_QC = 'true';
+      const { getPage } = await importBrowserPool();
+
+      // 두 호출을 동시에 시작 — 공유 launch promise가 없으면 각자 chromium.launch()를 실행해 두 번 호출됨
+      const [page1, page2] = await Promise.all([getPage(), getPage()]);
+
+      expect(page1).toBe(mockPage);
+      expect(page2).toBe(mockPage);
+      expect(chromiumLaunchMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('releasePage()', () => {

--- a/src/lib/qc/browserPool.ts
+++ b/src/lib/qc/browserPool.ts
@@ -45,6 +45,19 @@ function releaseSemaphore(): void {
 // --- Browser singleton ---
 
 let browserInstance: Browser | null = null;
+// 동시 첫 호출이 각자 chromium.launch()를 실행해 여러 브라우저를 띄우고 싱글톤 참조를 덮어쓰며
+// 하나를 누수시키는 경쟁을 막기 위해, 진행 중인 launch promise를 공유한다.
+let browserLaunchPromise: Promise<Browser> | null = null;
+
+async function launchChromium(): Promise<Browser> {
+  logger.info('[QC] Launching Chromium browser');
+  const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+  return chromium.launch({
+    headless: true,
+    ...(executablePath && { executablePath }),
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu', '--disable-dev-shm-usage'],
+  });
+}
 
 async function getBrowser(): Promise<Browser | null> {
   if (!isQcEnabled()) return null;
@@ -69,13 +82,11 @@ async function getBrowser(): Promise<Browser | null> {
       browserInstance = null;
     }
 
-    logger.info('[QC] Launching Chromium browser');
-    const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
-    browserInstance = await chromium.launch({
-      headless: true,
-      ...(executablePath && { executablePath }),
-      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu', '--disable-dev-shm-usage'],
+    // 진행 중인 launch가 있으면 그 promise를 공유(중복 실행 방지). 실패 시 promise를 비워 재시도 허용.
+    browserLaunchPromise ??= launchChromium().finally(() => {
+      browserLaunchPromise = null;
     });
+    browserInstance = await browserLaunchPromise;
     return browserInstance;
   } catch (err) {
     logger.error('[QC] Failed to launch browser', {

--- a/src/lib/qc/renderingQc.ts
+++ b/src/lib/qc/renderingQc.ts
@@ -74,21 +74,20 @@ function settledResults(
 }
 
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error(`QC timeout after ${ms}ms`)), ms)
-    ),
-  ]);
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(`QC timeout after ${ms}ms`)), ms);
+  });
+  // race가 끝나면 타이머를 정리해 누수를 막는다(성공 시 타이머가 만료까지 살아있던 문제).
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timeoutId));
 }
 
 async function withCheckTimeout<T>(fn: () => Promise<T>, name: string, timeoutMs = QC_TIMEOUTS.CHECK_MS): Promise<T> {
-  return Promise.race([
-    fn(),
-    new Promise<T>((_, reject) =>
-      setTimeout(() => reject(new Error(`Check timeout: ${name}`)), timeoutMs)
-    ),
-  ]);
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<T>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(`Check timeout: ${name}`)), timeoutMs);
+  });
+  return Promise.race([fn(), timeout]).finally(() => clearTimeout(timeoutId));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/projectService.test.ts
+++ b/src/services/projectService.test.ts
@@ -114,6 +114,18 @@ describe('ProjectService.create()', () => {
     ).rejects.toThrow(ValidationError);
   });
 
+  it('insertProjectApis 실패 시 생성된 project를 삭제하고 에러를 전파한다 (고아 방지)', async () => {
+    (projectRepo.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    (projectRepo.insertProjectApis as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('API 연결 실패')
+    );
+
+    await expect(service.create('user-1', validInput)).rejects.toThrow('API 연결 실패');
+
+    // Supabase 비트랜잭션 → 부분 실패 시 best-effort로 고아 project 삭제
+    expect(projectRepo.delete).toHaveBeenCalledWith('proj-1');
+  });
+
   it('프로젝트가 20개 이상이면 ValidationError를 던진다', async () => {
     (projectRepo.findByUserId as ReturnType<typeof vi.fn>).mockResolvedValue(Array(20).fill({ id: 'p' }));
     await expect(service.create('user-1', validInput)).rejects.toThrow(ValidationError);

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -62,8 +62,14 @@ export class ProjectService {
     };
     const project = await this.projectRepo.create(createData);
 
-    // Use repository method instead of direct Supabase access
-    await this.projectRepo.insertProjectApis(project.id, input.apiIds);
+    // Supabase JS 클라이언트는 다중 문 트랜잭션을 지원하지 않으므로, project 연결(API) 삽입이
+    // 실패하면 best-effort로 방금 만든 project를 삭제해 고아 레코드를 방지한다.
+    try {
+      await this.projectRepo.insertProjectApis(project.id, input.apiIds);
+    } catch (err) {
+      await this.projectRepo.delete(project.id).catch(() => {});
+      throw err;
+    }
 
     eventBus.emit({
       type: 'PROJECT_CREATED',


### PR DESCRIPTION
## 개요

Codex + Claude 이중 교차 검증에서 **합의된 신뢰성 발견**을 수정합니다 (권장안 PR A). 동작 보존 원칙으로 진행했습니다.

## 수정 (출처: 두 검증 합의 / 단독)

| 항목 | 위치 | 출처 |
|------|------|------|
| eventPersister 전역 등록(instrumentation, nodejs) — generate 라우트 로드 전 이벤트 미영속 갭 | instrumentation.ts | Codex |
| browserPool 공유 launch promise — 동시 첫 호출 브라우저 중복실행·누수 경쟁 제거 | browserPool.ts | Codex |
| projectService.create 고아 정리 — insertProjectApis 실패 시 project best-effort 삭제 | projectService.ts | Codex |
| QC 타임아웃 clearTimeout — race 성공 시 타이머 만료까지 누수 차단 | renderingQc.ts, qualityLoop.ts | **둘 다** |
| useAuth getSession rejection 핸들러 | useAuth.ts | Codex |
| 'failed' 즉시 terminal — 최대 2분 무의미 재시도 quirk 개선 | pollGenerationStatus.ts | Codex+기존 |

## 테스트
- 신규: browserPool 동시-launch(launch 1회), projectService 고아정리(insertProjectApis 실패→delete)
- 갱신: pollGenerationStatus 'failed' 즉시 실패(재시도 0)

## 검증
- ✅ 전체 **141 파일 / 1831 테스트** 통과
- ✅ `type-check` · `lint` 통과

## 비고
- qc-stats 레이어 전면 리팩터·settings 직접접근·deployService 외부 리소스 롤백은 아키텍처 대공사라 별도 follow-up (이번 범위 제외)
- 'failed' 즉시 처리는 #142/#143에서 의도적으로 보존했던 quirk였으나, 두 검증이 독립 합의하여 개선으로 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)