### PR TITLE
fix(config): 하드코딩 도메인·DB 타임아웃 env화, qc-stats DB에러 surface, 죽은 설정 제거

### DIFF
--- a/src/__tests__/api/deploy.test.ts
+++ b/src/__tests__/api/deploy.test.ts
@@ -40,7 +40,6 @@ vi.mock('@/lib/config/features', () => ({
     maxRegenerations: 5,
     contextMinLength: 50,
     contextMaxLength: 2000,
-    generationTimeoutMs: 120000,
   }),
 }));
 

--- a/src/app/api/v1/admin/qc-stats/qc-stats.test.ts
+++ b/src/app/api/v1/admin/qc-stats/qc-stats.test.ts
@@ -63,4 +63,21 @@ describe('GET /api/v1/admin/qc-stats', () => {
     const json = await response.json();
     expect(json.data.period.days).toBe(14);
   });
+
+  it('Supabase 쿼리 에러 시 0 메트릭으로 은폐하지 않고 500을 반환한다', async () => {
+    const { createServiceClient } = await import('@/lib/supabase/server');
+    vi.mocked(createServiceClient).mockResolvedValueOnce({
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            gte: () =>
+              Promise.resolve({ count: null, data: null, error: { code: 'XX000', message: 'db down' } }),
+          }),
+        }),
+      }),
+    } as never);
+
+    const response = await GET(makeRequest());
+    expect(response.status).toBe(500);
+  });
 });

--- a/src/app/api/v1/admin/qc-stats/route.ts
+++ b/src/app/api/v1/admin/qc-stats/route.ts
@@ -44,6 +44,15 @@ export async function GET(request: Request): Promise<Response> {
           .gte('created_at', from.toISOString()),
       ]);
 
+      // Supabase 쿼리 에러를 검사한다. 무시하면 count/data가 0·빈배열로 폴백되어 DB 장애 시에도
+      // 정상(0 메트릭)으로 보고되는 은폐가 발생한다 → 에러를 surface하여 500으로 응답.
+      const queryError =
+        failureCountResult.error ??
+        stage3FallbackResult.error ??
+        stageSkippedResult.error ??
+        qualityLoopResult.error;
+      if (queryError) throw queryError;
+
       const failureCount = failureCountResult.count ?? 0;
       const stage3FallbackCount = stage3FallbackResult.count ?? 0;
       const stageSkippedRows = (stageSkippedResult.data ?? []) as Array<{ payload: { stage?: string } | null }>;

--- a/src/lib/apiKeyGuides.ts
+++ b/src/lib/apiKeyGuides.ts
@@ -13,6 +13,10 @@ export interface ApiKeyGuide {
   tips?: string[];
 }
 
+// 가이드에 노출되는 게시 도메인은 배포 환경에 따라 다르므로 NEXT_PUBLIC_APP_URL을 사용한다
+// (sitemap.ts·adminAuth.ts와 동일한 env+폴백 패턴). 하드코딩 시 self-host/테스트 도메인에서 오안내됨.
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://xzawed.xyz';
+
 /**
  * API 이름 → 발급 가이드 매핑
  * 비개발자(노인 포함)도 이해할 수 있도록 최대한 쉬운 표현 사용
@@ -264,8 +268,7 @@ const GUIDES: Record<string, ApiKeyGuide> = {
       },
       {
         title: '2단계: 애플리케이션 등록',
-        description:
-          '로그인 후 [Application 등록] 화면에서 애플리케이션 이름을 입력하고, "사용 API" 목록에서 [Maps]를 선택하세요. 그 아래 서비스 URL에 https://xzawed.xyz 를 입력하고 [등록하기]를 클릭하세요.',
+        description: `로그인 후 [Application 등록] 화면에서 애플리케이션 이름을 입력하고, "사용 API" 목록에서 [Maps]를 선택하세요. 그 아래 서비스 URL에 ${APP_URL} 를 입력하고 [등록하기]를 클릭하세요.`,
       },
       {
         title: '3단계: Client ID 복사',

--- a/src/lib/config/features.test.ts
+++ b/src/lib/config/features.test.ts
@@ -23,11 +23,11 @@ describe('features config — env() isNaN fallback', () => {
     expect(limits.maxDailyGenerations).toBe(10);
   });
 
-  it('GENERATION_TIMEOUT_MS가 비숫자 문자열이면 기본값(120000)을 사용한다', async () => {
-    vi.stubEnv('GENERATION_TIMEOUT_MS', 'abc');
+  it('비숫자 문자열 env면 기본값을 사용한다 (env() NaN 폴백)', async () => {
+    vi.stubEnv('MAX_APIS_PER_PROJECT', 'abc');
     const { getLimits } = await import('./features');
     const limits = getLimits('free');
-    expect(limits.generationTimeoutMs).toBe(120000);
+    expect(limits.maxApisPerProject).toBe(5);
   });
 
   it('숫자 문자열이면 파싱된 값을 사용한다', async () => {

--- a/src/lib/config/features.ts
+++ b/src/lib/config/features.ts
@@ -7,7 +7,6 @@ export interface FeatureLimits {
   maxDeployPerDay: number;
   contextMinLength: number;
   contextMaxLength: number;
-  generationTimeoutMs: number;
 }
 
 function env(key: string, defaultValue: number): number {
@@ -26,7 +25,6 @@ const DEFAULT_LIMITS: FeatureLimits = {
   maxDeployPerDay: env('MAX_DEPLOY_PER_DAY', 5),
   contextMinLength: env('CONTEXT_MIN_LENGTH', 50),
   contextMaxLength: env('CONTEXT_MAX_LENGTH', 2000),
-  generationTimeoutMs: env('GENERATION_TIMEOUT_MS', 120000),
 };
 
 const PLAN_OVERRIDES: Record<string, Partial<FeatureLimits>> = {

--- a/src/lib/db/connection.test.ts
+++ b/src/lib/db/connection.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// pg.Pool / drizzle을 mock하여 실제 DB 연결 없이 getDb()의 풀 설정 분기를 검증한다.
+vi.mock('pg', () => ({ Pool: vi.fn() }));
+vi.mock('drizzle-orm/node-postgres', () => ({ drizzle: vi.fn(() => ({ __mockDb: true })) }));
+vi.mock('@/lib/utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+describe('getDb()', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('DB_PROVIDER가 postgres가 아니면 throw한다', async () => {
+    vi.stubEnv('DB_PROVIDER', 'supabase');
+    const { getDb } = await import('./connection');
+    expect(() => getDb()).toThrow();
+  });
+
+  it('DATABASE_URL 미설정 시 throw한다', async () => {
+    vi.stubEnv('DB_PROVIDER', 'postgres');
+    vi.stubEnv('DATABASE_URL', '');
+    const { getDb } = await import('./connection');
+    expect(() => getDb()).toThrow();
+  });
+
+  it('기본 풀 설정으로 Pool을 생성한다', async () => {
+    vi.stubEnv('DB_PROVIDER', 'postgres');
+    vi.stubEnv('DATABASE_URL', 'postgres://u:p@h:5432/db');
+    const { getDb } = await import('./connection');
+    getDb();
+
+    const { Pool } = await import('pg');
+    expect(vi.mocked(Pool)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionString: 'postgres://u:p@h:5432/db',
+        max: 10,
+        idleTimeoutMillis: 30000,
+        connectionTimeoutMillis: 5000,
+      }),
+    );
+  });
+
+  it('env로 풀 설정(max·idle·connection 타임아웃)을 오버라이드한다', async () => {
+    vi.stubEnv('DB_PROVIDER', 'postgres');
+    vi.stubEnv('DATABASE_URL', 'postgres://u:p@h:5432/db');
+    vi.stubEnv('DB_POOL_MAX', '20');
+    vi.stubEnv('DB_IDLE_TIMEOUT_MS', '60000');
+    vi.stubEnv('DB_CONNECTION_TIMEOUT_MS', '8000');
+    const { getDb } = await import('./connection');
+    getDb();
+
+    const { Pool } = await import('pg');
+    expect(vi.mocked(Pool)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        max: 20,
+        idleTimeoutMillis: 60000,
+        connectionTimeoutMillis: 8000,
+      }),
+    );
+  });
+
+  it('두 번째 호출은 캐시된 인스턴스를 반환한다 (Pool 1회만 생성)', async () => {
+    vi.stubEnv('DB_PROVIDER', 'postgres');
+    vi.stubEnv('DATABASE_URL', 'postgres://u:p@h:5432/db');
+    const { getDb } = await import('./connection');
+    const a = getDb();
+    const b = getDb();
+
+    expect(a).toBe(b);
+    const { Pool } = await import('pg');
+    expect(vi.mocked(Pool)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/db/connection.ts
+++ b/src/lib/db/connection.ts
@@ -19,11 +19,12 @@ export function getDb(): DrizzleDb {
     throw new Error('DATABASE_URL 환경변수가 설정되지 않았습니다.');
   }
 
+  // 풀 설정은 배포 환경(DB 성능·네트워크)에 따라 튜닝할 수 있도록 환경변수로 노출(기본값 폴백).
   _pool = new Pool({
     connectionString,
-    max: 10,
-    idleTimeoutMillis: 30000,
-    connectionTimeoutMillis: 5000,
+    max: Number.parseInt(process.env.DB_POOL_MAX ?? '', 10) || 10,
+    idleTimeoutMillis: Number.parseInt(process.env.DB_IDLE_TIMEOUT_MS ?? '', 10) || 30000,
+    connectionTimeoutMillis: Number.parseInt(process.env.DB_CONNECTION_TIMEOUT_MS ?? '', 10) || 5000,
   });
 
   _db = drizzle(_pool, { schema });


### PR DESCRIPTION
## 개요

교차 검증 발견 중 **하드코딩/설정/품질** 항목을 수정합니다 (권장안 PR B).

## 수정
| 항목 | 위치 | 출처 |
|------|------|------|
| 네이버맵 가이드 하드코딩 도메인 → `NEXT_PUBLIC_APP_URL` | apiKeyGuides.ts | Claude HIGH |
| qc-stats Supabase `.error` 검사 — DB 장애를 0 메트릭으로 은폐하던 문제 surface(→500) | qc-stats/route.ts | Codex C-L9 |
| DB 풀 타임아웃 env화(`DB_POOL_MAX`·`DB_IDLE_TIMEOUT_MS`·`DB_CONNECTION_TIMEOUT_MS`) | db/connection.ts | Claude MED |
| 죽은 설정 `generationTimeoutMs`/`GENERATION_TIMEOUT_MS` 제거(프로덕션 소비자 없음) | features.ts | Codex C-Q3 |

## 테스트
- 신규: qc-stats 쿼리 에러→500 (은폐 방지 검증)
- 보존: features.test의 `env()` NaN 폴백 커버리지(다른 env var로 재배치), deploy.test mock 정리

## 검증
- ✅ 전체 **141 파일 / 1832 테스트** 통과, `type-check`·`lint` 통과

## 비고
- qc-stats 레이어 전면 분리(C-Q1)·settings 직접접근(C-Q2)는 아키텍처 리팩터라 별도 follow-up
- 새 env 변수(`DB_*`)는 PR C(문서 일괄)에서 env-vars.md/.env.example에 문서화 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)