### PR TITLE
docs: 감사 문서-코드 불일치 일괄 정정 (구조트리·테스트수·env·끊긴링크)

### DIFF
--- a/.claude/commands/deploy-check.md
+++ b/.claude/commands/deploy-check.md
@@ -7,7 +7,6 @@
 ```bash
 pnpm lint
 pnpm type-check
-pnpm format:check
 ```
 
 ### 2단계: 테스트

--- a/.env.example
+++ b/.env.example
@@ -6,11 +6,33 @@ SUPABASE_SERVICE_ROLE_KEY=
 # === AI ===
 ANTHROPIC_API_KEY=
 
+# AI Provider 선택 (미설정 시 claude). 현재 허용값은 claude 하나뿐 — 그 외 값은 런타임 에러
+# AI_PROVIDER=claude
+
 # Claude 모델 오버라이드 (미설정 시 아래 기본값 사용)
 # 허용 모델: claude-haiku-4-5 | claude-sonnet-4-6 | claude-opus-4-6 | claude-opus-4-7
 # 주의: 날짜 suffix 포함 ID(예: claude-haiku-4-5-20251001)는 Anthropic 404 반환
 # AI_MODEL_SUGGESTION=claude-haiku-4-5    # 컨텍스트 추천용 (기본: haiku — 빠름·저렴)
 # AI_MODEL_GENERATION=claude-opus-4-7     # 코드 생성용   (기본: opus-4-7 — 최고 품질)
+
+# === Provider 전환 (DB / Auth) — 선택, 미설정 시 supabase 기본 ===
+# 자세한 내용: docs/reference/env-vars.md, docs/decisions/provider-migration.md
+# DB_PROVIDER=supabase                     # supabase(기본) | postgres
+# AUTH_PROVIDER=supabase                   # supabase(기본) | authjs
+# NEXT_PUBLIC_AUTH_PROVIDER=supabase       # 클라이언트용 빌드 타임 상수
+#
+# --- DB_PROVIDER=postgres 선택 시 ---
+# DATABASE_URL=                            # PostgreSQL 연결 문자열 (필수)
+# DB_POOL_MAX=10                           # pg.Pool 최대 연결 수 (기본: 10)
+# DB_IDLE_TIMEOUT_MS=30000                 # idle 연결 타임아웃 ms (기본: 30000)
+# DB_CONNECTION_TIMEOUT_MS=5000            # 연결 획득 타임아웃 ms (기본: 5000)
+#
+# --- AUTH_PROVIDER=authjs 선택 시 (Auth.js v5 전용 변수) ---
+# AUTH_SECRET=                             # NextAuth 세션 서명 키 (필수)
+# AUTH_GOOGLE_ID=
+# AUTH_GOOGLE_SECRET=
+# AUTH_GITHUB_ID=
+# AUTH_GITHUB_SECRET=
 
 # === 암호화 키 (사용자 API 키 암호화용) ===
 # 생성 방법: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
@@ -46,6 +68,16 @@ RAILWAY_TOKEN=
 # SENTRY_AUTH_TOKEN=
 # SENTRY_ORG=your-org-slug
 # SENTRY_PROJECT=your-project-slug
+
+# === 알림 / 모니터링 (선택) ===
+# Slack Webhook URL — 미설정 시 알림 스킵
+# SLACK_WEBHOOK_URL=
+# 5분 윈도우 내 코드 생성 실패 N회 이상 시 Slack 알림 (기본: 5)
+# ERROR_RATE_ALERT_THRESHOLD=5
+
+# === 프록시 응답 캐시 (인메모리, per-instance) ===
+# 프록시 응답 LRU 캐시 최대 항목 수 (기본: 500)
+# PROXY_CACHE_MAX_ENTRIES=500
 
 # === Admin ===
 ADMIN_API_KEY=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ src/
 │   ├── (auth)/      # 인증 관련 페이지
 │   ├── (main)/      # 메인 페이지 그룹
 │   └── site/        # 서브도메인 서빙 ([slug])
-├── components/      # UI 컴포넌트 (builder/, catalog/, dashboard/, gallery/, layout/, settings/, ui/)
+├── components/      # UI 컴포넌트 (builder/, catalog/, dashboard/, layout/, settings/, ui/)
 ├── hooks/           # 커스텀 React hooks
 ├── lib/             # 유틸리티
 │   ├── ai/          # AI 파이프라인 — generationPipeline(오케스트레이터), stageRunner, generationSaver, qualityLoop, generationTracker
@@ -64,8 +64,6 @@ pnpm build            # 프로덕션 빌드
 pnpm lint             # ESLint 검사
 pnpm lint:fix         # ESLint 자동 수정
 pnpm type-check       # TypeScript 타입 검사
-pnpm format           # Prettier 포맷팅
-pnpm format:check     # 포맷 검사
 pnpm test             # 전체 테스트
 pnpm test:unit        # 단위 테스트 (lib, providers)
 pnpm test:integration # 통합 테스트 (API routes)
@@ -146,7 +144,6 @@ pnpm test:coverage    # 커버리지 리포트
 | API 카탈로그 전수 검증 ADR (62개, 2026-05-01) | [docs/decisions/2026-05-01-api-catalog-verification.md](docs/decisions/2026-05-01-api-catalog-verification.md) |
 | API 카탈로그 즉시 사용 가능 기준 정리 ADR (23개 활성, 2026-05-01) | [docs/decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md](docs/decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md) |
 | 프로덕션 인시던트 회고 ADR — ET API 마이그레이션 및 연쇄 장애 (2026-05-03) | [docs/decisions/2026-05-03-production-incident-et-api-migration.md](docs/decisions/2026-05-03-production-incident-et-api-migration.md) |
-| Quality Loop 재활성화 및 ET 타임아웃 분리 구현 계획 | [docs/superpowers/plans/2026-05-03-quality-loop-restoration.md](docs/superpowers/plans/2026-05-03-quality-loop-restoration.md) |
 | Quality Loop 재활성화 및 ET 타임아웃 분리 ADR (PR #99, 2026-05-03) | [docs/decisions/2026-05-03-quality-loop-restoration-et-timeout.md](docs/decisions/2026-05-03-quality-loop-restoration-et-timeout.md) |
 | 프록시 응답 캐시 구현 ADR (PR #101, 2026-05-04) | [docs/decisions/2026-05-04-proxy-response-cache.md](docs/decisions/2026-05-04-proxy-response-cache.md) |
 | Unsplash Attribution 자동 삽입 ADR (PR #102, 2026-05-04) | [docs/decisions/2026-05-04-unsplash-attribution-auto-injection.md](docs/decisions/2026-05-04-unsplash-attribution-auto-injection.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,19 +32,24 @@ src/
 │   ├── (auth)/      # 인증 관련 페이지
 │   ├── (main)/      # 메인 페이지 그룹
 │   └── site/        # 서브도메인 서빙 ([slug])
-├── components/      # UI 컴포넌트 (builder/, catalog/, dashboard/, gallery/, layout/, settings/, ui/)
+├── components/      # UI 컴포넌트 (builder/, catalog/, dashboard/, layout/, settings/, ui/)
 ├── hooks/           # 커스텀 React hooks
 ├── lib/             # 유틸리티
 │   ├── ai/          # AI 파이프라인 — generationPipeline(오케스트레이터), stageRunner, generationSaver, qualityLoop, generationTracker
+│   ├── auth/        # 인증 추상화 — getAuthUser, authjs-config (AUTH_PROVIDER 분기)
 │   ├── cache/       # proxyCache.ts — LRU+TTL 인메모리 캐시 (프록시 응답 서버사이드 캐시)
-│   ├── config/      # 환경변수 기반 설정
+│   ├── config/      # 환경변수 기반 설정 (features, providers, rateLimit, qc 등)
+│   ├── constants/   # 공용 상수 — cdn.ts (CSP CDN 화이트리스트, buildSiteCsp)
+│   ├── db/          # Drizzle 연결(connection)·schema·failover (DB_PROVIDER=postgres 경로)
 │   ├── deploy/      # 배포 관련
 │   ├── events/      # EventBus (pub/sub) + eventPersister (전체 이벤트 자동 DB 기록)
 │   ├── generation/  # pollGenerationStatus — 생성 상태 폴링 (builder/page.tsx에서 추출, 주입형·단위 테스트 대상)
 │   ├── monitoring/  # slackAlert (Webhook 알림), errorRateMonitor (생성 실패율 임계값 감지)
 │   ├── i18n/        # 다국어 — t() 함수, ko.ts (한국어 메시지), types.ts (MessageKey)
 │   ├── qc/          # QC 로직 — browserPool, deepQcRunner, featureSmokeTest, qcChecks, renderingQc
+│   ├── services/    # lib 레벨 유틸리티 서비스
 │   ├── supabase/    # Supabase 클라이언트
+│   ├── templates/   # 코드 생성 템플릿 (lib 레벨)
 │   └── utils/       # 공통 유틸리티, 에러 클래스
 ├── middleware.ts     # 서브도메인 라우팅, 보안 헤더 (CSP, HSTS)
 ├── providers/       # AI Provider (IAiProvider → ClaudeProvider)
@@ -167,7 +172,7 @@ pnpm test:e2e         # E2E (Playwright — 실 백엔드 env 필요, CI에서 �
 이 서비스는 다수 사용자가 이용 중입니다. 배포 품질 = 서비스 신뢰도.
 
 ### CSP / 보안 헤더 변경 시
-- `middleware.ts`, `site/[slug]/route.ts`, `preview/[projectId]/route.ts` 3개 파일을 반드시 동시에 확인
+- `src/middleware.ts`, `src/app/site/[slug]/route.ts`, `src/app/api/v1/preview/[projectId]/route.ts` 3개 파일을 반드시 동시에 확인 (전체 경로 기준 — 이름만으로는 못 찾음)
 - CSP 헤더가 2중 적용되는 경로가 없는지 검증 (HTTP 표준: CSP 2개면 둘 다 적용)
 - 프롬프트가 사용하는 CDN이 CSP에서 허용되는지 확인
 
@@ -221,7 +226,7 @@ pnpm test:e2e         # E2E (Playwright — 실 백엔드 env 필요, CI에서 �
 - **playwright-core executablePath 주의**: `playwright-core`는 `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` 환경변수를 자동으로 읽지 않음. `const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH; chromium.launch({ ...(executablePath && { executablePath }) })` 형태로 명시적 전달 필요 (미설정 시 executablePath를 전달하지 않아 playwright-core 기본 탐색 로직이 유지됨). `playwright`(풀 패키지)와 달리 `playwright-core`는 브라우저 다운로드·자동 경로 탐색을 수행하지 않음 (`browserPool.ts` 참고)
 - **slug 충돌 처리**: `assignUniqueSlug()` in `projectService.ts` — base → base-2 → … → base-10 → timestamp fallback; 23505 unique 위반 시 1회 재시도
 - **generationTracker 단일 인스턴스**: `src/lib/ai/generationTracker.ts`의 `generationTracker`는 모듈 레벨 싱글톤. TTL 차등: `generating` 30분, `completed`/`failed` 10분. Railway 단일 인스턴스 환경에서만 동작 — 멀티 인스턴스 배포 시 Redis 등 외부 저장소로 교체 필요
-- **생성 상태 폴링 추출**: `builder/page.tsx`의 SSE 폴백 폴링은 `src/lib/generation/pollGenerationStatus.ts`로 추출됨(주입형 `fetchFn`·`delay`·콜백, 단위 테스트 대상). `page.tsx`는 thin 래퍼. **보존된 quirk**: `status:'failed'`는 즉시 실패시키지 않고 `throw` → catch에서 마지막 시도일 때만 `failGeneration` → 'failed'가 지속되면 `maxAttempts`(120)까지 재시도 후 실패. 추출 시 동작 변경 없이 보존했으며 개선은 별도 사안. 테스트는 DI-delay(즉시 resolve)로 결정적 검증, 기본 `setTimeout` 경로만 `vi.useFakeTimers()`+`runAllTimersAsync()`로 커버
+- **생성 상태 폴링 추출**: `builder/page.tsx`의 SSE 폴백 폴링은 `src/lib/generation/pollGenerationStatus.ts`로 추출됨(주입형 `fetchFn`·`delay`·콜백, 단위 테스트 대상). `page.tsx`는 thin 래퍼. 상태 처리: `generating`→진행률 갱신, `completed`+result→완료, **`failed`→즉시 terminal 실패**(이전엔 maxAttempts까지 재시도하던 quirk를 교차검증 후 개선), `not_found`→프로젝트 미존재 메시지, 그 외(`unknown`)→연결 복구 실패 메시지. 테스트는 DI-delay(즉시 resolve)로 결정적 검증, 기본 `setTimeout` 경로만 `vi.useFakeTimers()`+`runAllTimersAsync()`로 커버
 - **모듈 레벨 상태가 있는 파일 테스트**: `let registered = false` 같은 모듈 레벨 플래그가 있는 파일은 테스트 간 상태 누출이 발생한다. `vi.resetModules()` + 매 테스트마다 `await import(...)` 동적 임포트로 격리한다 (`eventPersister.ts` 참고)
 - **api 라우트 테스트는 `@/lib/config/providers`를 반드시 모킹**: 라우트는 line-1에서 `getDbProvider`를 import하는데, 이 체인이 `@/lib/db/failover`(→ `pg`)·`@/lib/db/connection`(→ drizzle-orm/node-postgres)의 네이티브+CJS cold 초기화를 끌어온다. `vi.resetModules()` + 인-테스트 `await import('@/app/.../route')` 패턴에서 첫 테스트가 이 비용을 지불하며, 병렬 full-suite 경합 시 기본 5000ms를 넘겨 간헐 타임아웃을 유발한다. `vi.mock('@/lib/config/providers', () => ({ getDbProvider: vi.fn().mockReturnValue('supabase') }))`로 차단한다 (현재 api 라우트 테스트 16/16 모두 이 패턴 적용 — `health.test.ts`는 `@/lib/db/failover`·`@/repositories/factory`까지 함께 모킹해야 native 그래프가 완전 차단된다). `vitest.config.ts`의 `testTimeout`/`hookTimeout`는 경합 마진을 위해 15000ms로 상향됨 — 상세: [docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md](docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md)
 - **happy-dom iframe 로드 노이즈 차단**: `vitest.config.ts`의 `environmentOptions.happyDOM.settings.navigation.disableChildFrameNavigation = true`로 iframe `src` 실제 로드를 막아 `DOMException NetworkError` 로그 flood를 차단함. v20에서 `disableIframePageLoading`은 deprecated이므로 사용 금지. `disableFallbackToSetURL`(기본 false) 보존으로 `iframe.src` 속성은 그대로 반영되어 단언에는 무영향

--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 [![status](https://img.shields.io/badge/status-v1.0.0%20Live-brightgreen?style=flat-square)](https://xzawed.xyz)
 [![Next.js](https://img.shields.io/badge/Next.js-16+-black?style=flat-square&logo=next.js)](https://nextjs.org)
 [![AI](https://img.shields.io/badge/AI-Claude%20Opus%204.7-blueviolet?style=flat-square)](https://anthropic.com)
-[![Tests](https://img.shields.io/badge/Vitest-1725%20listed-success?style=flat-square)](./docs/guides/testing.md)
+[![Tests](https://img.shields.io/badge/Vitest-1837%20listed-success?style=flat-square)](./docs/guides/testing.md)
 [![Coverage](https://img.shields.io/badge/Coverage-85%25%2B-yellow?style=flat-square)](./docs/guides/testing.md)
 [![Deploy](https://img.shields.io/badge/Deploy-Railway-8A2BE2?style=flat-square&logo=railway)](https://railway.app)
 
@@ -138,7 +138,7 @@ src/
 
 | Item | Details |
 |------|---------|
-| ✅ Test inventory | **1,725 Vitest tests + 33 Playwright tests** (`vitest list`, `playwright test --list`) |
+| ✅ Test inventory | **1,837 Vitest tests + 33 Playwright tests** (`vitest list`, `playwright test --list`) |
 | 🔬 Unit tests | Vitest + happy-dom — AI pipeline, security validation, rate limiting, Circuit Breaker |
 | 🔗 Integration tests | Vitest + MSW — API route auth, input validation, permissions, business logic |
 | 🌐 E2E tests | Playwright — 3 device types (mobile · tablet · desktop) |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![status](https://img.shields.io/badge/status-v1.0.0%20Live-brightgreen?style=flat-square)](https://xzawed.xyz)
 [![Next.js](https://img.shields.io/badge/Next.js-16+-black?style=flat-square&logo=next.js)](https://nextjs.org)
 [![AI](https://img.shields.io/badge/AI-Claude%20Opus%204.7-blueviolet?style=flat-square)](https://anthropic.com)
-[![Tests](https://img.shields.io/badge/Vitest-1725%20listed-success?style=flat-square)](./docs/guides/testing.md)
+[![Tests](https://img.shields.io/badge/Vitest-1837%20listed-success?style=flat-square)](./docs/guides/testing.md)
 [![Coverage](https://img.shields.io/badge/Coverage-85%25%2B-yellow?style=flat-square)](./docs/guides/testing.md)
 [![Deploy](https://img.shields.io/badge/Deploy-Railway-8A2BE2?style=flat-square&logo=railway)](https://railway.app)
 
@@ -138,7 +138,7 @@ src/
 
 | 항목 | 내용 |
 |------|------|
-| ✅ 테스트 목록 | **Vitest 1,725개 + Playwright 33개** (`vitest list`, `playwright test --list` 기준) |
+| ✅ 테스트 목록 | **Vitest 1,837개 + Playwright 33개** (`vitest list`, `playwright test --list` 기준) |
 | 🔬 단위 테스트 | Vitest + happy-dom — AI 파이프라인, 보안 검증, 레이트리밋, Circuit Breaker, 배포 서비스 등 |
 | 🔗 통합 테스트 | Vitest + MSW — API 라우트 인증·입력·권한·비즈니스 로직 전 경로 |
 | 🌐 E2E 테스트 | Playwright — 3종 디바이스 (모바일 · 태블릿 · 데스크톱) |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,7 +1,7 @@
 # 시스템 아키텍처
 
 > **최종 업데이트:** 2026-05-05  
-> **구현 상태:** 운영 중 (2026-05-08 기준 Vitest 목록 1,725개, Playwright 목록 33개)
+> **구현 상태:** 운영 중 (2026-06-09 기준 Vitest 목록 1,837개, Playwright 목록 33개)
 
 ---
 
@@ -501,7 +501,6 @@ export interface FeatureLimits {
   maxDeployPerDay: number;
   contextMinLength: number;
   contextMaxLength: number;
-  generationTimeoutMs: number;
 }
 
 function env(key: string, defaultValue: number): number {
@@ -520,7 +519,6 @@ const DEFAULT_LIMITS: FeatureLimits = {
   maxDeployPerDay: env('MAX_DEPLOY_PER_DAY', 5),
   contextMinLength: env('CONTEXT_MIN_LENGTH', 50),
   contextMaxLength: env('CONTEXT_MAX_LENGTH', 2000),
-  generationTimeoutMs: env('GENERATION_TIMEOUT_MS', 120000),
 };
 
 const PLAN_OVERRIDES: Record<string, Partial<FeatureLimits>> = {

--- a/docs/decisions/2026-05-03-quality-loop-restoration-et-timeout.md
+++ b/docs/decisions/2026-05-03-quality-loop-restoration-et-timeout.md
@@ -117,4 +117,4 @@ const adopted = strictAdoption
 - `docs/reference/env-vars.md` — 신규 환경변수 `QUALITY_LOOP_ET_ITERATION_TIMEOUT_MS`, `QUALITY_LOOP_STRICT_ADOPTION` 문서화
 - [ADR 2026-04-29](2026-04-29-generation-success-rate-improvement.md) — Quality Loop 기능 최초 도입 배경
 - [ADR 2026-05-03 프로덕션 인시던트](2026-05-03-production-incident-et-api-migration.md) — Quality Loop 비활성화 원인 설명
-- [구현 계획](../superpowers/plans/2026-05-03-quality-loop-restoration.md) — PR #99 작업 계획 문서
+- PR #99 작업 계획 문서 (구현 계획 — 별도 보관)

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -141,6 +141,4 @@ pnpm test:coverage    # 커버리지 리포트
 pnpm type-check       # TypeScript 검사
 pnpm lint             # ESLint
 pnpm lint:fix         # ESLint 자동 수정
-pnpm format           # Prettier 포맷팅
-pnpm format:check     # 포맷 검사
 ```

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -20,7 +20,7 @@
        ──────────────────
 ```
 
-**현재 테스트 목록:** 132개 Vitest 파일, 1,725개 Vitest 테스트 + 3개 Playwright E2E 파일, 33개 Playwright 프로젝트별 테스트
+**현재 테스트 목록:** 142개 Vitest 파일, 1,837개 Vitest 테스트 + 3개 Playwright E2E 파일, 33개 Playwright 프로젝트별 테스트
 
 > 확인 명령: `pnpm exec vitest list`, `pnpm exec playwright test --list` (2026-05-08 기준). 실제 통과 여부는 `pnpm test`와 `pnpm test:e2e` 실행 결과를 기준으로 판단합니다.
 
@@ -373,7 +373,7 @@ lint (ESLint)
   ↓
 type-check (tsc --noEmit)
   ↓
-test (pnpm test:coverage — Vitest 목록 1,725개 기준)
+test (pnpm test:coverage — Vitest 목록 1,837개 기준)
   ↓
 커버리지 업로드 (Codecov + SonarCloud)
   ↓

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -21,12 +21,15 @@
 | 변수 | 값 | 필수 조건 | Railway | 설명 |
 |------|----|----------|---------|------|
 | `DB_PROVIDER` | `supabase` (기본) \| `postgres` | 항상 | ➖ | 미설정 시 `supabase` 기본값 |
-| `AUTH_PROVIDER` | `supabase` (기본) \| `authjs` | 항상 | ➖ | 미설정 시 `supabase` 기본값 |
+| `AUTH_PROVIDER` | `supabase` (기본) \| `authjs` | 항상 | ➖ | 미설정 시 `supabase` 기본값. `authjs` 선택 시 아래 `AUTH_*` 전용 변수 필요. 코드 위치: `src/lib/config/providers.ts` `getAuthProvider()` |
 | `NEXT_PUBLIC_AUTH_PROVIDER` | `supabase` (기본) \| `authjs` | 항상 | ➖ | 클라이언트 컴포넌트용 빌드 타임 상수 |
 | `DATABASE_URL` | PostgreSQL 연결 문자열 | `DB_PROVIDER=postgres` 시 필수 | ❌ | 온프레미스 DB URL |
-| `AUTH_SECRET` | 임의 시크릿 | `AUTH_PROVIDER=authjs` 시 필수 | ❌ | NextAuth 세션 서명 키 |
-| `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` | Google OAuth 자격증명 | `AUTH_PROVIDER=authjs` 시 필수 | ❌ | |
-| `AUTH_GITHUB_ID` / `AUTH_GITHUB_SECRET` | GitHub OAuth 자격증명 | `AUTH_PROVIDER=authjs` 시 필수 | ❌ | |
+| `DB_POOL_MAX` | 양의 정수 (기본 `10`) | `DB_PROVIDER=postgres` 시 선택 | ➖ | pg.Pool 최대 연결 수. 숫자 아님·0 설정 시 `10`으로 폴백. 코드 위치: `src/lib/db/connection.ts` |
+| `DB_IDLE_TIMEOUT_MS` | ms (기본 `30000`) | `DB_PROVIDER=postgres` 시 선택 | ➖ | pg.Pool idle 연결 타임아웃 (ms). 미설정·0 시 `30000`으로 폴백 |
+| `DB_CONNECTION_TIMEOUT_MS` | ms (기본 `5000`) | `DB_PROVIDER=postgres` 시 선택 | ➖ | pg.Pool 신규 연결 획득 타임아웃 (ms). 미설정·0 시 `5000`으로 폴백 |
+| `AUTH_SECRET` | 임의 시크릿 | `AUTH_PROVIDER=authjs` 시 필수 | ❌ | NextAuth(Auth.js) 세션 서명 키. authjs 전용 변수 |
+| `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` | Google OAuth 자격증명 | `AUTH_PROVIDER=authjs` 시 필수 | ❌ | authjs 전용. `src/lib/auth/authjs-config.ts`에서 사용 |
+| `AUTH_GITHUB_ID` / `AUTH_GITHUB_SECRET` | GitHub OAuth 자격증명 | `AUTH_PROVIDER=authjs` 시 필수 | ❌ | authjs 전용. `src/lib/auth/authjs-config.ts`에서 사용 |
 
 ---
 
@@ -35,6 +38,7 @@
 | 변수 | 필수 | Railway | 설명 |
 |------|------|---------|------|
 | `ANTHROPIC_API_KEY` | ✅ | ✅ | Claude API 키 |
+| `AI_PROVIDER` | 선택 | ➖ | AI Provider 선택. 현재 허용값은 `claude` 하나뿐 (기본). 그 외 값 설정 시 `AiProviderFactory.create()`가 `Unknown AI provider` 에러를 던짐. 코드 위치: `src/providers/ai/AiProviderFactory.ts` |
 | `AI_MODEL_SUGGESTION` | 선택 | ➖ | 컨텍스트 추천용 모델 (기본: `claude-haiku-4-5`). 허용값: `claude-haiku-4-5` · `claude-sonnet-4-6` · `claude-opus-4-6` · `claude-opus-4-7` |
 | `AI_MODEL_GENERATION` | 선택 | ➖ | 코드 생성용 모델 (기본: `claude-opus-4-7`). 허용값 동일. **주의**: 날짜 suffix 포함 ID(예: `claude-haiku-4-5-20251001`)는 Anthropic 404 반환 |
 | `ET_COMPLEXITY_THRESHOLD` | 선택 | ➖ | Extended Thinking 활성화 복잡도 임계값 (기본: `35`). 0-100 점수 중 이 값 이상이면 ET 활성화. **빈 문자열 또는 0 이하 값 설정 시 기본값 35로 폴백** |
@@ -83,6 +87,7 @@
 | `SENTRY_PROJECT` | 선택 | ❌ | Sentry 프로젝트 슬러그 |
 | `SENTRY_AUTH_TOKEN` | 선택 | ❌ | Sentry 소스맵 업로드 토큰 |
 | `SLACK_WEBHOOK_URL` | 선택 | ❌ | Slack 알림 Webhook URL. 미설정 시 알림 스킵. `slackAlert()` + `errorRateMonitor`에서 사용 |
+| `ERROR_RATE_ALERT_THRESHOLD` | 선택 | ➖ | 코드 생성 실패율 알림 임계값 (기본: `5`). 5분 윈도우 내 `CODE_GENERATION_FAILED` 횟수가 이 값 이상이면 Slack 알림 1회 발송 (윈도우 내 중복 알림 방지). 인메모리·단일 인스턴스 전제. 코드 위치: `src/lib/monitoring/errorRateMonitor.ts` |
 
 ---
 
@@ -98,7 +103,6 @@
 | `MAX_CODE_VERSIONS` | `10` | ➖ | 프로젝트당 최대 코드 버전 수. 초과 시 오래된 버전 삭제 |
 | `CONTEXT_MIN_LENGTH` | `50` | ➖ | 컨텍스트 최소 길이 (자) |
 | `CONTEXT_MAX_LENGTH` | `2000` | ➖ | 컨텍스트 최대 길이 (자) |
-| `GENERATION_TIMEOUT_MS` | `120000` | ➖ | 생성 타임아웃 (ms) |
 | `ANTHROPIC_TIMEOUT_MS` | `270000` | ➖ | Anthropic SDK 호출 타임아웃 (ms). Railway 300초 HTTP 컷 전 안전 종료를 위해 270초로 설정. 운영 환경에서 더 긴 응답을 허용하려면 조정 |
 
 ---
@@ -110,6 +114,7 @@
 | `RATE_LIMIT_PER_MIN` | `60` | ➖ | proxy + admin 라우트 분당 요청 한도 (사용자/IP 단위) |
 | `MAX_CONCURRENT_RATE_LIMIT_USERS` | `1000` | ➖ | rate limit Map의 LRU evict 임계값 (활성 사용자/IP 한도). 초과 시 가장 오래된 항목 자동 evict — Railway 단일 인스턴스 메모리 누적 차단 |
 | `RATE_LIMIT_BYPASS_USER_IDS` | `` (빈 문자열) | ➖ | 쉼표 구분 userId 목록. 포함된 계정은 일일 생성 한도(`MAX_DAILY_GENERATIONS`) 검사 스킵. 관리자·개발자 계정 우회용. 코드 위치: `src/services/rateLimitService.ts` `checkAndIncrementDailyLimit()` |
+| `PROXY_CACHE_MAX_ENTRIES` | `500` | ➖ | 프록시 응답 캐시(`proxyCache`)의 LRU 최대 항목 수. 빈 문자열·숫자 아님·0 이하 값 설정 시 기본값 500으로 폴백. 인메모리·per-instance — 서버 재시작 시 초기화. 코드 위치: `src/lib/cache/proxyCache.ts` |
 
 ---
 


### PR DESCRIPTION
## 개요

Codex + Claude 교차 검증의 **문서-코드 불일치(doc-drift)** 발견을 일괄 정정합니다 (권장안 PR C, 문서 전용).

## 변경
- **CLAUDE.md 구조 트리**: 미존재 `components/gallery/` 제거, `lib/`에 auth·constants·db·services·templates 추가, CSP gotcha 경로 전체경로화, 'failed' polling gotcha를 PR A의 즉시-terminal로 갱신
- **테스트 수**: 132파일/1,725 → **142파일/1,837** (testing.md·README·README.en·overview)
- **죽은 format 스크립트 제거**: AGENTS.md·development.md·deploy-check.md (prettier 미설치)
- **미존재 참조 제거**: AGENTS.md gallery/, 끊긴 `quality-loop-restoration.md` 계획 링크(AGENTS.md + ADR)
- **env 문서 보강**: PROXY_CACHE_MAX_ENTRIES(500)·ERROR_RATE_ALERT_THRESHOLD(5)·AI_PROVIDER·DB_POOL_MAX/DB_IDLE_TIMEOUT_MS/DB_CONNECTION_TIMEOUT_MS·authjs OAuth 추가, 삭제된 GENERATION_TIMEOUT_MS 제거

## 검증
- 문서 전용 변경 (소스 `.ts` 미변경)
- env 기본값은 소스 코드 대조로 검증 (ERROR_RATE=5·AI_PROVIDER=claude 등)
- 잔존 드리프트 grep 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)