### PR TITLE
fix(ci): Node 22 전면 상향 — supabase-js 2.108 eager WebSocket 가드 대응 (#154 오탐 근본 원인)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies
@@ -120,7 +120,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies
@@ -146,7 +146,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/claude-automation.yml
+++ b/.github/workflows/claude-automation.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies
@@ -54,16 +54,18 @@ jobs:
             verification-report.json
           retention-days: 14
 
-      # 실패(BROKEN 1개 이상 → exit 1) 시: 중복 방지하며 GitHub Issue 생성/갱신
-      - name: Open or update issue on broken APIs
+      # 헬스체크 실패 시: "실제 API BROKEN" vs "헬스체크 도구 실패"를 구분해 GitHub Issue 생성/갱신.
+      # verification-report.json 부재 = 스크립트가 API 검증 전 크래시 → 도구 오류이지 API 장애가 아니다.
+      - name: Open or update issue on broken APIs or tool failure
         if: failure() && steps.healthcheck.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          if [ -f verification-report.json ] && jq -e '.broken > 0' verification-report.json >/dev/null 2>&1; then
+          # 실제 BROKEN API 감지 (리포트 생성 + broken > 0)
           TITLE="🚨 카탈로그 API 헬스체크 실패 (BROKEN 감지)"
-          # broken 목록 추출 (verification-report.json은 스크립트가 생성)
-          BROKEN=$(jq -r '.apis[] | select(.overallStatus=="broken") | "- **\(.name)** (\(.category)) — \(.endpoints[] | select(.status=="broken") | .reason) [\(.baseUrl)]"' verification-report.json 2>/dev/null | sort -u || echo "(상세 파싱 실패 — 아티팩트 확인)")
+          BROKEN=$(jq -r '.apis[] | select(.overallStatus=="broken") | "- **\(.name)** (\(.category)) — \(.endpoints[] | select(.status=="broken") | .reason) [\(.baseUrl)]"' verification-report.json | sort -u)
           BODY=$(cat <<EOF
           일일 카탈로그 헬스체크에서 **BROKEN** API가 감지되었습니다. (run: ${{ github.run_id }})
 
@@ -74,6 +76,19 @@ jobs:
           - 자세한 절차: docs/decisions/2026-06-21-api-catalog-health-monitoring.md
           EOF
           )
+          else
+          # verification-report.json 부재/파싱 불가 = 헬스체크 도구·환경 실패 (개별 API의 BROKEN 신호 아님)
+          TITLE="⚠️ 카탈로그 헬스체크 실행 실패 (도구 오류)"
+          BODY=$(cat <<EOF
+          카탈로그 헬스체크 스크립트가 **API 검증을 완료하지 못하고 실패**했습니다. (run: ${{ github.run_id }})
+          \`verification-report.json\`이 생성되지 않았으므로 **개별 API의 BROKEN 신호가 아니라 헬스체크 도구·환경 문제**입니다.
+
+          - 로그: 이 워크플로 실행의 "Run catalog health check" 스텝 출력 확인
+          - 흔한 원인: 런타임/의존성 비호환(예: realtime-js가 Node 22+ 네이티브 WebSocket 요구), Supabase 연결 실패, 네트워크 오류
+          - 대응: 위 로그로 원인 진단 후 도구/워크플로 수정. 카탈로그 데이터(is_active/deprecated_at)는 임의 변경 금지.
+          EOF
+          )
+          fi
           EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty' || echo "")
           if [ -n "$EXISTING" ]; then
             gh issue comment "$EXISTING" --body "$BODY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ pnpm keys:verify               # 플랫폼 키 설정 검증 (scripts/verifyPlat
 | 테스트 플래키 타임아웃 잔여·후속 작업 핸드오프 (항목 1·2·3·4·6 완료, 5는 상시 모니터링, 2026-06-09) | [docs/superpowers/plans/2026-06-09-test-flakiness-followups.md](docs/superpowers/plans/2026-06-09-test-flakiness-followups.md) |
 | 서비스 종합 건강 감사 및 발견 16건 수정 ADR (2026-06-09) | [docs/decisions/2026-06-09-service-health-audit-fixes.md](docs/decisions/2026-06-09-service-health-audit-fixes.md) |
 | API 카탈로그 동작 검증 & 헬스 모니터링 자동화 ADR (REST Countries 폐기·DB 기반 헬스체크, 2026-06-21) | [docs/decisions/2026-06-21-api-catalog-health-monitoring.md](docs/decisions/2026-06-21-api-catalog-health-monitoring.md) |
+| Node 22 전면 상향 ADR (supabase-js 2.108 eager WebSocket 가드 대응·#154 오탐 근본 원인, 2026-06-22) | [docs/decisions/2026-06-22-node22-supabase-websocket-fix.md](docs/decisions/2026-06-22-node22-supabase-websocket-fix.md) |
 
 - [README.md](README.md) — 프로젝트 전체 개요
 - [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) — PR 템플릿
@@ -250,6 +251,7 @@ pnpm keys:verify               # 플랫폼 키 설정 검증 (scripts/verifyPlat
 - **REST Countries 폐기(2026-06-21)**: v3.1 전 엔드포인트가 deprecated(HTTP 200 + deprecation 본문, legacy.json 301). `is_active=false`로 비활성. 무료 키리스 대체 없음(v5 유료) — 필요 시 `mledoze/countries` 데이터셋 번들 권장
 - **플랫폼 키 검증 = 배포 런타임 전용**: 키 의존 API의 env 키(`API_KEY_*`) 유효성은 배포 컨텍스트에서만 검증 가능 — 관리자 진단 엔드포인트 **`GET /api/v1/admin/keys-verify`**(ADMIN_API_KEY 보호, 로직 `src/lib/catalog/keyCheck.ts`)를 배포 환경에서 호출한다. 로컬 `railway run`은 sealed/빈 변수를 구분 못 함. **2026-06-21 확정 사실**: 키 의존 API의 env 변수들은 **이름만 있고 값이 빈 상태**였음(sealed 아님). 배포 진단에서 7개 전부 MISSING → 키 의존 API 7개를 **`is_active=false` 비활성화**(활성 30→**23**, 전부 키 불필요·즉시 사용 가능). 재활성화하려면 Railway env에 **실제 키 값**을 입력 후 `is_active=true` 복원 + `keys-verify` 재검증. 또한 카탈로그 `auth_config.env_var` 이름이 실제 Railway 변수명과 일치해야 함(불일치 시 401): **카카오 검색이 존재하지 않는 `API_KEY_KAKAO`를 참조**했던 버그 → `API_KEY_F1EC6F97`로 정정
 - **프록시 키 prefix 미적용(잠재 버그)**: `auth_config`의 `prefix`/`header_prefix`(카카오 `KakaoAK `, Unsplash `Client-ID `)를 프록시 `resolveApiKey`가 적용하지 않고 raw 값을 주입한다. env 값에 prefix가 포함돼 있어야 동작 — `keys-verify`의 `needsPrefixFix`로 확인 후 프록시 수정 여부 결정(env 값에 이미 prefix가 있으면 이중 적용 주의)
+- **Node 22+ 필수 (supabase-js 2.108+ eager WebSocket 가드)**: `@supabase/supabase-js` 2.108부터 `realtime-js`가 **생성자(eager)에서** 네이티브 WebSocket 부재 시 throw한다. Node < 22에서는 `createClient()`/`createServerClient()` **생성 호출 자체가 크래시**(`Error: Node.js N detected without native WebSocket support.`) — realtime 미사용이어도 발생. 그래서 Dockerfile·전 워크플로·`package.json engines`를 **Node 22**로 고정했다(`node:22-alpine`, `node-version: 22`, `engines.node: ">=22"`). **Node 버전을 20으로 내리지 말 것**(프로덕션 전 페이지 + 헬스체크가 클라이언트 생성 시점에 다운). supabase-js bump 시 런타임 요구사항 변동 확인. 상세: [docs/decisions/2026-06-22-node22-supabase-websocket-fix.md](docs/decisions/2026-06-22-node22-supabase-websocket-fix.md)
 
 ## 세션 시작 체크리스트 (필수)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # ── Stage 1: Install dependencies ──
-FROM node:20-alpine AS deps
+FROM node:22-alpine AS deps
 RUN corepack enable && corepack prepare pnpm@9 --activate
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --prod=false
 
 # ── Stage 2: Build ──
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 RUN corepack enable && corepack prepare pnpm@9 --activate
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
@@ -37,7 +37,7 @@ RUN if find /app/.next/standalone/node_modules -path "*/playwright-core/lib/core
     fi
 
 # ── Stage 3: Production runner ──
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/docs/decisions/2026-06-22-node22-supabase-websocket-fix.md
+++ b/docs/decisions/2026-06-22-node22-supabase-websocket-fix.md
@@ -1,0 +1,108 @@
+# Node 22 전면 상향 — supabase-js 2.108 eager WebSocket 가드 대응 (#154 근본 원인)
+
+- 날짜: 2026-06-22
+- 상태: 적용 (PR `fix/node22-supabase-websocket`)
+- 관련 이슈: #154 (카탈로그 헬스체크 "BROKEN 감지" — **오탐**)
+- 선행 PR: #151 (`chore(deps)` — `@supabase/supabase-js` `2.107.x → 2.108.2` 포함)
+
+## 배경 / 증상
+
+2026-06-21 일일 카탈로그 헬스체크(`scheduled.yml`)가 처음으로 실패하며 GitHub 이슈 #154
+("🚨 카탈로그 API 헬스체크 실패 (BROKEN 감지)")를 자동 생성했다. 그러나 **실제로 BROKEN인
+API는 없었다** — 헬스체크 스크립트가 **API를 한 건도 호출하기 전에 크래시**했다.
+
+스케줄 런 히스토리: 6/14~6/20 전부 success → **6/21 첫 실패**. 그 사이 머지된 것은
+#150·**#151(deps bump)**·#152이며, #151이 `@supabase/supabase-js`를 **2.108.2**로 올렸다.
+
+## 근본 원인 (CI 스택트레이스로 확증)
+
+`gh run view 27917956818 --log-failed`:
+
+```
+Error: Node.js 20 detected without native WebSocket support.
+  at getWebSocketConstructor (@supabase/realtime-js/.../websocket-factory.ts:178)
+  at RealtimeClient._initializeOptions (RealtimeClient.ts:805)
+  at new RealtimeClient (RealtimeClient.ts:284)            ← 생성자(eager)
+  at SupabaseClient._initRealtimeClient (SupabaseClient.ts:629)
+  at new SupabaseClient (SupabaseClient.ts:366)
+  at createClient (@supabase/supabase-js/.../index.ts:65)
+  at scripts/verifyCatalog.ts:63                            ← 모듈 최상위 createClient()
+```
+
+`@supabase/realtime-js`는 **2.108.x에서 WebSocket 가용성 검사를 생성자(eager)로 이동**했다
+(2.107.x에서는 `connect()` 시점의 lazy 검사였다 — 로컬 소스 대조 확인). 가드 로직
+(`websocket-factory.ts`):
+
+- Node **< 22**: 네이티브 `WebSocket` 부재 → `throw "Node.js N detected without native WebSocket support."`
+- Node **22+**: `typeof globalThis.WebSocket !== 'undefined'` → 네이티브 생성자 반환 (throw 없음)
+
+즉 **2.108.2 + Node 20 조합에서는 `createClient(url, key)` 호출 자체가 throw**한다. realtime을
+실제로 쓰지 않아도(헬스체크는 PostgREST `select`만 사용) 생성자에서 즉시 실패한다.
+
+## 이것은 #154보다 큰 잠재 P0였다
+
+`createClient`/`SupabaseClient` 생성자가 throw하므로, **앱의 모든 Supabase 클라이언트 생성 경로가
+Node 20에서 위험**했다:
+
+- `src/lib/supabase/server.ts` `createServiceClient()` → `@supabase/supabase-js` `createClient` 직접 호출
+- 동 파일 `createClient()` → `@supabase/ssr` `createServerClient` → 내부에서 동일 `createClient` 호출
+  (realtime 비활성화 옵션 없음 — `createServerClient.js` 대조 확인). **미들웨어 인증 경로 포함.**
+
+프로덕션 `Dockerfile`은 3개 스테이지 전부 `node:20-alpine`였다. 따라서 **`main`을 Railway에
+배포하는 순간 전 페이지가 클라이언트 생성 시점에 500**이 될 수 있었다.
+
+조사 시점 프로덕션은 정상(200)이었다 — 마지막 배포 태그가 `deploy/2026-05-23-0000`(#151 이전)으로,
+**프로덕션이 아직 2.108.2 빌드를 받지 않은 상태**였기 때문이다. 즉 활성 장애가 아니라 **다음 배포가
+트리거하는 잠재 landmine**이었다.
+
+## 결정
+
+`@supabase/realtime-js`가 공식 권장하는 경로("Option 1: Use Node.js 22+")대로 **프로젝트 전반을
+Node 22로 상향**한다. (대안인 `ws` 폴리필 + 호출부 transport 주입은 의존성 추가 + 호출부 분산으로
+누락 위험이 커 기각.) Node 22는 현 Active LTS이며 Next.js 16·Playwright와 호환된다.
+
+## 변경 사항
+
+| 파일 | 변경 |
+|------|------|
+| `Dockerfile` | `node:20-alpine` → `node:22-alpine` (deps·builder·runner 3개 스테이지) |
+| `.github/workflows/ci.yml` | `node-version: 20 → 22` (lint/test/build/e2e 4곳) |
+| `.github/workflows/scheduled.yml` | `node-version: 20 → 22` |
+| `.github/workflows/claude-automation.yml` | `node-version: 20 → 22` |
+| `package.json` | `engines.node: ">=22"` 추가 (요구사항 명시 → 회귀 방지) |
+| `.github/workflows/scheduled.yml` | 이슈 생성 가드 재작성 (아래) |
+
+`qc-monitor.yml`은 curl/jq만 사용(Node 미설정)이라 변경 없음.
+
+### 헬스체크 이슈 가드 재작성 (오탐 증폭기 제거)
+
+기존 워크플로는 헬스체크 스텝이 **어떤 이유로든** 실패하면(크래시 포함) 항상
+"🚨 BROKEN 감지" 이슈를 생성했다. `verification-report.json`이 없으면 `jq`가 폴백 텍스트
+"(상세 파싱 실패)"를 내고도 BROKEN 이슈를 만들었다 — #154가 정확히 이 경로다.
+
+가드를 **실제 BROKEN vs 도구 실패**로 분기하도록 변경:
+
+- `verification-report.json` 존재 **AND** `.broken > 0` → "🚨 ... (BROKEN 감지)" (기존 동작)
+- 리포트 부재/파싱 불가 → "⚠️ 카탈로그 헬스체크 실행 실패 (도구 오류)" — **개별 API의 BROKEN
+  신호가 아니라 도구·환경 문제**임을 명시하고 런 로그 진단을 안내. 카탈로그 데이터 임의 변경 금지.
+
+`verifyCatalog.ts`는 리포트를 broken 판정(exit 1)보다 **먼저** 기록하므로, "리포트 존재 + broken>0"은
+곧 실제 BROKEN을 의미한다(스크립트 크래시는 리포트 부재로 나타난다).
+
+## 검증
+
+- **node 22 네이티브 WebSocket**: `node -e "typeof WebSocket"` → `function` (factory의 native 경로 충족).
+- **실제 재현 (결정적)**: 로컬 Node v22.18.0 + 락파일 동기화(supabase-js 2.108.2 / realtime-js 2.108.2)에서
+  CI를 크래시시킨 `createClient(url, key)`와 앱의 `createServerClient(...)`를 그대로 생성 →
+  **둘 다 throw 없이 성공**(`realtime present: true`). Node 20 크래시 ↔ Node 22 정상 대조 확정.
+- **이슈 가드 로직**: report+broken>0 / report+broken=0 / 리포트 부재 / 깨진 JSON 4개 시나리오를
+  stub `gh`로 시뮬레이션 → 부재·broken0·malformed는 "도구 오류", broken>0만 "BROKEN 감지"로 라우팅.
+- **YAML 유효성**: `scheduled.yml` `yaml.safe_load` 통과. node 20 잔존 핀 0건 확인.
+
+## 후속
+
+- **#154**: 머지 + Railway 재배포로 다음 스케줄 런이 정상 산출(broken 0)됨을 확인한 뒤 닫는다.
+  카탈로그 데이터(`is_active`/`deprecated_at`)는 손대지 않는다(실제 장애 아님).
+- 배포 성공 후 `deploy/YYYY-MM-DD-HHmm` 태그(배포 태그 규칙). 프로덕션 헬스 200 확인.
+- 향후 supabase-js/realtime-js 메이저·마이너 bump 시 Node 런타임 요구사항 변동 여부 확인
+  (dependabot deps PR 리뷰 체크포인트).

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "license": "UNLICENSED",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",


### PR DESCRIPTION
## 배경

2026-06-21 일일 카탈로그 헬스체크(`scheduled.yml`)가 처음 실패하며 이슈 **#154**("🚨 BROKEN 감지")를 자동 생성. **그러나 실제 BROKEN API는 없음** — 헬스체크가 API를 호출하기 전 크래시했다.

CI 스택트레이스(`gh run view 27917956818 --log-failed`)로 근본 원인 확증:

```
Error: Node.js 20 detected without native WebSocket support.
  at getWebSocketConstructor (@supabase/realtime-js/.../websocket-factory.ts:178)
  at new RealtimeClient (RealtimeClient.ts:284)          ← 생성자(eager)
  at new SupabaseClient (SupabaseClient.ts:366)
  at createClient (@supabase/supabase-js/.../index.ts:65)
  at scripts/verifyCatalog.ts:63                          ← 모듈 최상위 createClient()
```

PR #151의 deps bump가 `@supabase/supabase-js`를 **2.108.2**로 올렸고, 이 버전 `realtime-js`는 **생성자에서(eager)** 네이티브 WebSocket 부재 시 throw한다(2.107.x는 `connect()` 시점 lazy). 따라서 **Node 20에서는 `createClient()` 호출 자체가 크래시**한다(realtime 미사용이어도).

### 이것은 #154보다 큰 잠재 P0였다

`createClient`/`createServerClient`(미들웨어 인증 포함) 둘 다 동일 생성자를 거치고, 프로덕션 `Dockerfile`은 전 스테이지 `node:20-alpine`였다 → **`main`을 배포하는 순간 전 페이지가 클라이언트 생성 시점에 500**. 조사 시점 프로덕션이 정상(200)인 이유는 마지막 배포 태그가 `deploy/2026-05-23-0000`(#151 이전)으로 **아직 2.108.2 빌드를 받지 않았기** 때문 — 활성 장애가 아닌 **다음 배포가 트리거하는 landmine**이었다.

## 변경

| 파일 | 변경 |
|------|------|
| `Dockerfile` | `node:20-alpine` → `node:22-alpine` (deps·builder·runner) |
| `ci.yml` | `node-version: 20 → 22` (×4) |
| `scheduled.yml` | `node-version: 20 → 22` + **이슈 가드 재작성** |
| `claude-automation.yml` | `node-version: 20 → 22` |
| `package.json` | `engines.node: ">=22"` (요구사항 명시·회귀 방지) |
| ADR + CLAUDE.md | [2026-06-22-node22-supabase-websocket-fix.md](docs/decisions/2026-06-22-node22-supabase-websocket-fix.md) 추가, gotcha·문서 테이블 갱신 |

`realtime-js` 공식 권장("Use Node.js 22+")을 따름. Node 22는 현 Active LTS·Next.js 16/Playwright 호환. `qc-monitor.yml`은 Node 미설정(curl/jq)이라 변경 없음.

### 헬스체크 이슈 가드 재작성 (오탐 증폭기 제거)

기존엔 헬스체크 스텝이 **어떤 이유로든** 실패하면 항상 "BROKEN 감지" 이슈를 만들었다(리포트 부재 시 jq 폴백으로도). 이제:
- `verification-report.json` 존재 **AND** `.broken > 0` → "🚨 BROKEN 감지" (기존 동작)
- 리포트 부재/파싱 불가 → "⚠️ 카탈로그 헬스체크 실행 실패 (도구 오류)" — 개별 API 장애가 아닌 도구·환경 문제임을 명시. 카탈로그 데이터 임의 변경 금지 안내.

## 검증

- **실제 재현(결정적)**: 로컬 Node v22.18.0 + 락파일 동기화(supabase-js/realtime-js **2.108.2**)에서 CI를 크래시시킨 `createClient(url,key)`와 앱의 `createServerClient(...)`를 그대로 생성 → **둘 다 throw 없이 성공**(`realtime present: true`).
- node 22 글로벌 `WebSocket = function` 확인(factory native 경로 충족).
- 이슈 가드: report+broken>0 / broken=0 / 리포트 부재 / 깨진 JSON 4개 시나리오 stub `gh` 시뮬레이션 → broken>0만 "BROKEN 감지", 나머지는 "도구 오류"로 라우팅.
- `scheduled.yml` YAML 유효성·heredoc `EOF` 컬럼0 확인. node 20 잔존 핀 0건.
- pnpm-lock.yaml 변경 없음.

## 머지 후 후속

- [ ] Railway 재배포 → 다음 스케줄 런이 정상 산출(broken 0)됨 확인 → **#154 닫기**. 카탈로그 데이터(`is_active`/`deprecated_at`)는 손대지 않음(실제 장애 아님).
- [ ] 배포 성공 후 `deploy/YYYY-MM-DD-HHmm` 태그 + 프로덕션 헬스 200 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)