### PR TITLE
fix(docs): README·랜딩 정합성 정정 + 무료 API 개수 동적화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ src/
 │   ├── auth/        # 인증 추상화 — getAuthUser, authjs-config (AUTH_PROVIDER 분기)
 │   ├── cache/       # proxyCache.ts — LRU+TTL 인메모리 캐시 (프록시 응답 서버사이드 캐시)
 │   ├── config/      # 환경변수 기반 설정 (features, providers, rateLimit, qc 등)
-│   ├── catalog/     # API 카탈로그 동작 검증 — healthCheck.ts(DB기반 라이브 검증 분류), keyCheck.ts(플랫폼 키 검증)
+│   ├── catalog/     # API 카탈로그 — healthCheck.ts(DB기반 라이브 검증 분류), keyCheck.ts(플랫폼 키 검증), activeApiCount.ts(활성 개수 동적 카운트 — 랜딩/카탈로그 마케팅 카피, 하드코딩 금지)
 │   ├── constants/   # 공용 상수 — cdn.ts (CSP CDN 화이트리스트, buildSiteCsp)
 │   ├── countries/   # 자체 호스팅 국가 데이터 API 로직 — transform(mledoze 변환), query(region/search 필터·코드 조회), types
 │   ├── db/          # Drizzle 연결(connection)·schema·failover (DB_PROVIDER=postgres 경로)

--- a/README.en.md
+++ b/README.en.md
@@ -6,7 +6,7 @@
 [![status](https://img.shields.io/badge/status-v1.0.0%20Live-brightgreen?style=flat-square)](https://xzawed.xyz)
 [![Next.js](https://img.shields.io/badge/Next.js-16+-black?style=flat-square&logo=next.js)](https://nextjs.org)
 [![AI](https://img.shields.io/badge/AI-Claude%20Opus%204.7-blueviolet?style=flat-square)](https://anthropic.com)
-[![Tests](https://img.shields.io/badge/Vitest-1886%20listed-success?style=flat-square)](./docs/guides/testing.md)
+[![Tests](https://img.shields.io/badge/Vitest-1917%20listed-success?style=flat-square)](./docs/guides/testing.md)
 [![Coverage](https://img.shields.io/badge/Coverage-85%25%2B-yellow?style=flat-square)](./docs/guides/testing.md)
 [![Deploy](https://img.shields.io/badge/Deploy-Railway-8A2BE2?style=flat-square&logo=railway)](https://railway.app)
 
@@ -48,16 +48,16 @@ CustomWebService lets anyone — without coding knowledge — build and publish 
 🔍 Stage 0 (Feature Extraction)  — Haiku + tool_use extracts feature spec → injected into Stage 1 prompt
          ↓
 🏗️ Stage 1 (Structure & Logic)   — Generates real API fetch calls, mobile-first, security rules applied  (0→30%)
-         ↓  conditional: missing fetch calls or placeholder detected
+         ↓  conditional: missing fetch / placeholder / hardcoded array / no-proxy, or Fast QC fail
 ✅ Stage 2 (Validation)           — AI self-reviews and fixes Stage 1 output                            (30→65%)
-         ↓  conditional: quality score < 80
-🎨 Stage 3 (Design)               — Category-based theme injection (finance→modern-dark, weather→ocean-blue) (65→90%)
+         ↓  conditional: structural score < 80 or mobile score < 70
+🎨 Stage 3 (Design)               — Category-based theme injection (finance→modern-dark, weather→ocean-blue) (65→85%)
          ↓
 🔁 Quality Loop                   — Default 2 retries (up to 3), best-of-n selection
          ↓
-⚡ Fast QC                        — Playwright rendering check (console errors, horizontal scroll, touch targets)
+⚡ Fast QC                        — Playwright rendering check (console errors, horizontal scroll, footer visibility, layout overlap, runtime placeholder)
          ↓
-🔬 Deep QC                        — Interaction, network, accessibility, responsive validation (async, optional)
+🔬 Deep QC                        — Interaction, network, accessibility, responsive, touch-target validation (async, optional)
 ```
 
 ### ⚙️ Key Design Patterns
@@ -79,7 +79,7 @@ CustomWebService lets anyone — without coding knowledge — build and publish 
 > AI-generated code is untrusted by default. All output is validated server-side.
 
 **🛡️ Static Analysis of AI Output**
-- Blocks `eval()`, `document.write()`, direct `innerHTML` assignment
+- Blocks `eval()` (rejects generation); flags `document.write()` and direct `innerHTML` assignment as warnings
 - Detects hardcoded API key patterns (OpenAI, Stripe, Google, GitHub, Slack, AWS)
 - Blocks CSS XSS vectors: `expression()`, `url(javascript:)`, `-moz-binding:`
 
@@ -114,7 +114,7 @@ CustomWebService lets anyone — without coding knowledge — build and publish 
 ```
 src/
 ├── app/
-│   ├── api/v1/          # 🔌 REST API route.ts files (26)
+│   ├── api/v1/          # 🔌 REST API route.ts files (28)
 │   ├── (auth)/          # 🔐 Auth pages
 │   ├── (main)/          # 🏠 Main pages (builder, catalog, dashboard)
 │   └── site/[slug]/     # 🌐 Subdomain serving
@@ -139,7 +139,7 @@ src/
 
 | Item | Details |
 |------|---------|
-| ✅ Test inventory | **1,886 Vitest tests (145 files) + 33 Playwright tests** (`vitest list`, `playwright test --list`) |
+| ✅ Test inventory | **1,917 Vitest tests (148 files) + 33 Playwright tests** (`vitest list`, `playwright test --list`) |
 | 🔬 Unit tests | Vitest + happy-dom — AI pipeline, security validation, rate limiting, Circuit Breaker |
 | 🔗 Integration tests | Vitest + MSW — API route auth, input validation, permissions, business logic |
 | 🌐 E2E tests | Playwright — 3 device types (mobile · tablet · desktop) |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![status](https://img.shields.io/badge/status-v1.0.0%20Live-brightgreen?style=flat-square)](https://xzawed.xyz)
 [![Next.js](https://img.shields.io/badge/Next.js-16+-black?style=flat-square&logo=next.js)](https://nextjs.org)
 [![AI](https://img.shields.io/badge/AI-Claude%20Opus%204.7-blueviolet?style=flat-square)](https://anthropic.com)
-[![Tests](https://img.shields.io/badge/Vitest-1886%20listed-success?style=flat-square)](./docs/guides/testing.md)
+[![Tests](https://img.shields.io/badge/Vitest-1917%20listed-success?style=flat-square)](./docs/guides/testing.md)
 [![Coverage](https://img.shields.io/badge/Coverage-85%25%2B-yellow?style=flat-square)](./docs/guides/testing.md)
 [![Deploy](https://img.shields.io/badge/Deploy-Railway-8A2BE2?style=flat-square&logo=railway)](https://railway.app)
 
@@ -48,16 +48,16 @@ CustomWebService는 비개발자도 몇 분 안에 자신만의 웹서비스를 
 🔍 Stage 0 (기능 추출)  — Claude Haiku, tool use로 기능 사양 자동 추출 → Stage 1 프롬프트 주입
          ↓
 🏗️ Stage 1 (구조·기능)  — 실제 API fetch 호출 코드 생성, 모바일 퍼스트, 보안 규칙 적용  (0→30%)
-         ↓  조건부: fetch 미호출 또는 placeholder 존재 시
+         ↓  조건부: fetch 미호출·placeholder·하드코딩 배열·프록시 미경유 또는 Fast QC 실패 시
 ✅ Stage 2 (기능 검증)  — Stage 1 결과를 AI가 자체 검증·수정                           (30→65%)
-         ↓  조건부: 품질 점수 80 미만 시
-🎨 Stage 3 (디자인)     — 카테고리별 테마 적용 (금융→modern-dark, 날씨→ocean-blue 등)  (65→90%)
+         ↓  조건부: 구조 점수 < 80 또는 모바일 점수 < 70 등 품질 미달 시
+🎨 Stage 3 (디자인)     — 카테고리별 테마 적용 (금융→modern-dark, 날씨→ocean-blue 등)  (65→85%)
          ↓
 🔁 Quality Loop         — 기본 2회 재시도(최대 3회), best-of-n 품질 비교 선택
          ↓
-⚡ Fast QC              — Playwright 브라우저 렌더링 검증 (콘솔 에러·가로 스크롤·터치 타겟)
+⚡ Fast QC              — Playwright 렌더링 검증 (콘솔 에러·가로 스크롤·푸터 가시성·레이아웃 겹침·런타임 placeholder)
          ↓
-🔬 Deep QC              — 상호작용·네트워크·접근성·반응형 심층 검증 (비동기, 선택적)
+🔬 Deep QC              — 상호작용·네트워크·접근성·반응형·터치 타겟 심층 검증 (비동기, 선택적)
 ```
 
 ### ⚙️ 주요 설계 패턴
@@ -79,12 +79,12 @@ CustomWebService는 비개발자도 몇 분 안에 자신만의 웹서비스를 
 > AI가 생성한 코드는 신뢰할 수 없습니다. 모든 출력물을 의심하고 서버에서 검증합니다.
 
 **🛡️ AI 생성 코드 정적 검증**
-- `eval()`, `document.write()`, `innerHTML` 직접 할당 차단
+- `eval()` 차단(생성 거부) · `document.write()`·`innerHTML` 직접 할당 경고(warning) 감지
 - OpenAI · Stripe · Google · GitHub · Slack · AWS API 키 하드코딩 패턴 감지
 - CSS `expression()`, `url(javascript:)`, `url(data:)`, `-moz-binding:`, `-webkit-binding:`, `@import` 등 XSS 벡터 차단
 
 **🏰 인프라 보안**
-- Proxy SSRF 방지: loopback(127.0.0.1/::1), RFC1918 사설 IP(10.x/172.16-31.x/192.168.x), AWS 메타데이터 서버(169.254.169.254) 6종 패턴 차단
+- Proxy SSRF 방지: 차단 호스트 7종(loopback `127.0.0.1`/`::1`, `0.0.0.0`/`::`, AWS·클라우드 메타데이터 `169.254.169.254`, Alibaba `100.100.100.200`) + 사설·링크로컬 IP 정규식 8종(RFC1918 10.x/172.16-31.x/192.168.x, 127.x, 169.254.x, 0.x, IPv6 ULA·link-local) 차단 + DNS rebinding 방어
 - `middleware.ts`에서 CSP, HSTS, X-Frame-Options 일괄 적용
 - 사용자 API 키 AES-256-GCM 암호화 저장
 - OAuth PKCE 플로우 (Google, GitHub)
@@ -114,7 +114,7 @@ CustomWebService는 비개발자도 몇 분 안에 자신만의 웹서비스를 
 ```
 src/
 ├── app/
-│   ├── api/v1/          # 🔌 REST API route.ts 파일 (26개)
+│   ├── api/v1/          # 🔌 REST API route.ts 파일 (28개)
 │   ├── (auth)/          # 🔐 인증 페이지
 │   ├── (main)/          # 🏠 메인 페이지 (빌더, 카탈로그, 대시보드)
 │   └── site/[slug]/     # 🌐 서브도메인 서빙
@@ -139,11 +139,11 @@ src/
 
 | 항목 | 내용 |
 |------|------|
-| ✅ 테스트 목록 | **Vitest 1,886개 (145파일) + Playwright 33개** (`vitest list`, `playwright test --list` 기준) |
+| ✅ 테스트 목록 | **Vitest 1,917개 (148파일) + Playwright 33개** (`vitest list`, `playwright test --list` 기준) |
 | 🔬 단위 테스트 | Vitest + happy-dom — AI 파이프라인, 보안 검증, 레이트리밋, Circuit Breaker, 배포 서비스 등 |
 | 🔗 통합 테스트 | Vitest + MSW — API 라우트 인증·입력·권한·비즈니스 로직 전 경로 |
 | 🌐 E2E 테스트 | Playwright — 3종 디바이스 (모바일 · 태블릿 · 데스크톱) |
-| 📊 커버리지 | **85%+ lines** (lib/services/providers/repositories/components 대상) · Codecov + SonarCloud 연동 |
+| 📊 커버리지 | **85%+ lines** (Codecov main 측정, lib/services/providers/repositories/components 대상) · Codecov + SonarCloud 연동 |
 
 ```bash
 pnpm test              # 전체 테스트

--- a/src/app/(main)/catalog/page.tsx
+++ b/src/app/(main)/catalog/page.tsx
@@ -24,7 +24,7 @@ export default async function CatalogPage() {
     <div className="mx-auto max-w-7xl px-4 py-8">
       <div className="mb-8">
         <h1 className="text-3xl font-bold" style={{ color: 'var(--text-primary)' }}>API 카탈로그</h1>
-        <p className="mt-2" style={{ color: 'var(--text-secondary)' }}>30+ 무료 API를 탐색하세요</p>
+        <p className="mt-2" style={{ color: 'var(--text-secondary)' }}>{apisResult.total}개 무료 API를 탐색하세요</p>
       </div>
 
       <CatalogView initialApis={apisResult.items} categories={categoriesResult} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,13 @@
 import Link from 'next/link';
 import { ArrowRight, Sparkles, MousePointerClick, Wand2, Globe, Zap, Shield, RefreshCw, BarChart2, Cloud, Newspaper, Building2 } from 'lucide-react';
 import { Footer } from '@/components/layout/Footer';
+import { getActiveApiCount } from '@/lib/catalog/activeApiCount';
 
-export default function LandingPage() {
+// 활성 API 개수를 DB에서 읽어 카피에 주입한다(하드코딩 드리프트 방지). ISR 1시간 캐시로 홈 DB 부하 최소화.
+export const revalidate = 3600;
+
+export default async function LandingPage() {
+  const apiCount = (await getActiveApiCount()) || 23;
   return (
     <div className="min-h-screen noise">
       {/* ── Header ──────────────────────────────────────── */}
@@ -43,7 +48,7 @@ export default function LandingPage() {
           <div className="animate-fade-in mb-8">
             <span className="badge inline-flex items-center gap-2 border border-cyan-500/20 bg-cyan-500/8 text-cyan-400">
               <Sparkles className="h-3.5 w-3.5" />
-              31개 무료 API · AI 코드 자동 생성 · 즉시 게시
+              {apiCount}개 무료 API · AI 코드 자동 생성 · 즉시 게시
             </span>
           </div>
 
@@ -135,7 +140,7 @@ export default function LandingPage() {
         <div className="mx-auto max-w-4xl px-6">
           <div className="grid grid-cols-3 gap-8 text-center">
             {[
-              { value: '31+', label: '무료 API' },
+              { value: `${apiCount}`, label: '무료 API' },
               { value: '3단계', label: '간단한 생성 과정' },
               { value: '100%', label: '무료 서비스' },
             ].map((stat, i) => (
@@ -174,7 +179,7 @@ export default function LandingPage() {
                 color: 'from-cyan-500/20 to-cyan-500/5',
                 iconColor: 'text-cyan-400',
                 title: 'API 선택',
-                description: '날씨, 환율, 뉴스, 부동산, 교통 등 31개 무료 API 중에서 원하는 것을 골라 담으세요. 카테고리별로 정리되어 있어 찾기 쉽습니다.',
+                description: `날씨, 환율, 뉴스, 부동산, 교통 등 ${apiCount}개 무료 API 중에서 원하는 것을 골라 담으세요. 카테고리별로 정리되어 있어 찾기 쉽습니다.`,
               },
               {
                 step: 2,
@@ -235,7 +240,7 @@ export default function LandingPage() {
               { icon: <Shield className="h-5 w-5" />, color: 'text-emerald-400 bg-emerald-400/10', title: '완전 무료', desc: '가입, 생성, 게시 모든 과정이 무료입니다. 신용카드가 필요 없습니다.' },
               { icon: <RefreshCw className="h-5 w-5" />, color: 'text-cyan-400 bg-cyan-400/10', title: '재생성 지원', desc: '마음에 들지 않으면 피드백을 입력해 다시 생성할 수 있습니다.' },
               { icon: <Globe className="h-5 w-5" />, color: 'text-violet-400 bg-violet-400/10', title: '즉시 공유', desc: '생성된 서비스는 고유 주소로 누구나 접근할 수 있습니다.' },
-              { icon: <BarChart2 className="h-5 w-5" />, color: 'text-rose-400 bg-rose-400/10', title: '실제 데이터', desc: '31개 무료 API와 연동하여 실제 날씨, 뉴스, 환율 등을 표시합니다.' },
+              { icon: <BarChart2 className="h-5 w-5" />, color: 'text-rose-400 bg-rose-400/10', title: '실제 데이터', desc: `${apiCount}개 무료 API와 연동하여 실제 날씨, 뉴스, 환율 등을 표시합니다.` },
               { icon: <MousePointerClick className="h-5 w-5" />, color: 'text-blue-400 bg-blue-400/10', title: '코딩 불필요', desc: '코드를 전혀 몰라도 됩니다. 말로 설명하면 AI가 다 해결합니다.' },
             ].map((f, i) => (
               <div key={i} className="card p-6">

--- a/src/lib/catalog/activeApiCount.test.ts
+++ b/src/lib/catalog/activeApiCount.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getActiveApiCount } from './activeApiCount';
+
+const { mockCountActive, mockGetDbProvider, mockCreateClient } = vi.hoisted(() => ({
+  mockCountActive: vi.fn(),
+  mockGetDbProvider: vi.fn(),
+  mockCreateClient: vi.fn(() => ({})),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: mockCreateClient }));
+vi.mock('@/lib/config/providers', () => ({ getDbProvider: mockGetDbProvider }));
+vi.mock('@/services/factory', () => ({
+  createCatalogService: vi.fn(() => ({ countActive: mockCountActive })),
+}));
+
+describe('getActiveApiCount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDbProvider.mockReturnValue('supabase');
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost:54321';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+  });
+
+  it('활성 API 개수를 반환한다', async () => {
+    mockCountActive.mockResolvedValue(23);
+
+    expect(await getActiveApiCount()).toBe(23);
+    expect(mockCreateClient).toHaveBeenCalledWith('http://localhost:54321', 'anon-key');
+  });
+
+  it('supabase env가 없으면 0을 반환한다', async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+    expect(await getActiveApiCount()).toBe(0);
+    expect(mockCountActive).not.toHaveBeenCalled();
+  });
+
+  it('조회가 실패해도 0을 반환한다 (홈 렌더 보호)', async () => {
+    mockCountActive.mockRejectedValue(new Error('db down'));
+
+    expect(await getActiveApiCount()).toBe(0);
+  });
+
+  it('postgres 프로바이더면 클라이언트 없이 조회한다', async () => {
+    mockGetDbProvider.mockReturnValue('postgres');
+    mockCountActive.mockResolvedValue(23);
+
+    expect(await getActiveApiCount()).toBe(23);
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/catalog/activeApiCount.ts
+++ b/src/lib/catalog/activeApiCount.ts
@@ -1,0 +1,27 @@
+import { createClient } from '@supabase/supabase-js';
+import { getDbProvider } from '@/lib/config/providers';
+import { createCatalogService } from '@/services/factory';
+
+/**
+ * 공개 카탈로그의 활성 API 개수 — 랜딩/마케팅 카피의 **단일 진실원천**(DB api_catalog is_active=true·미폐기).
+ *
+ * - 하드코딩 드리프트 방지: 숫자를 코드에 박지 않고 DB에서 읽는다.
+ * - 쿠키 미사용(anon 공개 읽기)이라 호출 페이지를 정적/ISR로 유지할 수 있다.
+ *   (캐시는 호출 측 페이지의 `revalidate`(ISR)로 처리 — 홈 DB 부하를 막는다.)
+ * - 조회 실패 시 0을 반환한다(호출 측에서 폴백 처리해 홈 렌더가 깨지지 않게 한다).
+ */
+export async function getActiveApiCount(): Promise<number> {
+  try {
+    const provider = getDbProvider();
+    let supabase;
+    if (provider === 'supabase') {
+      const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+      const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+      if (!url || !anonKey) return 0;
+      supabase = createClient(url, anonKey);
+    }
+    return await createCatalogService(supabase).countActive();
+  } catch {
+    return 0;
+  }
+}

--- a/src/services/catalogService.test.ts
+++ b/src/services/catalogService.test.ts
@@ -84,6 +84,35 @@ describe('CatalogService.search()', () => {
   });
 });
 
+describe('CatalogService.countActive()', () => {
+  let service: CatalogService;
+  let repo: ICatalogRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repo = makeCatalogRepo();
+    service = new CatalogService(repo);
+  });
+
+  it('활성 API 개수(total)를 반환한다', async () => {
+    (repo.search as ReturnType<typeof vi.fn>).mockResolvedValue({ items: [makeItem()], total: 23 });
+
+    const count = await service.countActive();
+
+    expect(count).toBe(23);
+    // 개수만 필요하므로 최소 limit으로 조회한다 (count는 limit과 무관한 exact 값)
+    expect(repo.search).toHaveBeenCalledWith({ limit: 1 });
+  });
+
+  it('활성 API가 없으면 0을 반환한다', async () => {
+    (repo.search as ReturnType<typeof vi.fn>).mockResolvedValue({ items: [], total: 0 });
+
+    const count = await service.countActive();
+
+    expect(count).toBe(0);
+  });
+});
+
 describe('CatalogService.getById()', () => {
   let service: CatalogService;
   let repo: ICatalogRepository;

--- a/src/services/catalogService.ts
+++ b/src/services/catalogService.ts
@@ -20,6 +20,12 @@ export class CatalogService {
     return this.repo.findById(id);
   }
 
+  /** 활성(is_active=true·미폐기) API 개수만 조회한다 (랜딩/카탈로그 마케팅 카피용 단일 진실원천). */
+  async countActive(): Promise<number> {
+    const { total } = await this.repo.search({ limit: 1 });
+    return total;
+  }
+
   async getCategories(): Promise<Category[]> {
     return this.repo.getCategories();
   }


### PR DESCRIPTION
## 배경
README.md + 랜딩페이지 설명과 전체 코드베이스의 정합성을 감사(47개 주장 검증: **32 일치 / 10 불일치 / 4 부분 / 1 검증불가**, 적대적 재검증 포함)한 결과를 반영.

## 🔴 무료 API 개수 — 동적화 (사용자 노출 마케팅 수치)
랜딩 4곳 + 카탈로그 헤더가 `31/30개`로 하드코딩됐으나 **실제 활성은 23개**.
- `CatalogService.countActive()` + `getActiveApiCount()`(쿠키리스 anon 읽기, 페이지 ISR 1h 캐시) 추가
- 랜딩 `page.tsx`를 `async` + `revalidate=3600`으로 전환, DB에서 활성 개수 동적 주입(실패 시 23 폴백)
- 카탈로그 헤더는 이미 fetch한 `apisResult.total` 사용
- 단일 진실원천(`api_catalog.is_active`)이라 **향후 드리프트 영구 차단**
- 단위 테스트 6개 추가(`countActive` 2 + `getActiveApiCount` 4)

## 🟠 README.md / README.en.md 사실 정정
| 항목 | 기존 → 정정 |
|---|---|
| 테스트 수 | 1,886 → **1,917** (`vitest list` 실측) |
| 테스트 파일 | 145 → **148** |
| route.ts 개수 | 26 → **28** (countries 라우트 반영) |
| SSRF "6종" | → 실제 차단 목록(호스트 7 + 정규식 8 + DNS rebinding) |
| Fast QC 항목 | "터치 타겟" 제거(실제 Deep QC 소속) → 콘솔·가로스크롤·푸터·레이아웃겹침·런타임placeholder |
| eval/innerHTML | "모두 차단" → `eval()`만 차단, `document.write`/`innerHTML`은 **경고** |
| Stage 3 조건 | "품질 점수 80 미만" → 구조<80 또는 모바일<70 |
| Stage 3 진행률 | 65→90% → **65→85%** (실제 코드 마일스톤) |
| Stage 2 트리거 | fetch/placeholder → +하드코딩 배열·프록시 미경유·Fast QC 실패 |
| 커버리지 85% | 출처(Codecov main) 명시 |

## ✅ 정확히 일치 확인 (32개)
모델(Opus 4.7/Haiku 4.5), ET 35pt·5종 신호, Quality Loop 2/3회, 템플릿 11개, 테마 6개, EventBus 17개, Circuit Breaker 3회/60초, AES-256-GCM, PKCE, API키 벤더 6종, 테마 매핑, Relevance Gate, Playwright 3종·33개, 스택 버전(Next 16.2/React 19.2/Tailwind 4.3 등), v1.0.0 — 전부 코드와 일치.

## 검증
- 신규/변경 단위 테스트 통과(16/16), `type-check` clean, 변경 파일 `eslint` clean
- 기존 테스트가 하드코딩 카피("31"/"30+")를 단언하지 않음 확인(grep) → 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)