### PR TITLE
feat: 임베디드 SQLite + 단일 관리자(local) 인증 전환 (Phase 1~7, opt-in)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,17 @@ coverage/
 playwright-report/
 test-results/
 
-# drizzle-kit output (regenerated via drizzle-kit generate)
-/drizzle/
+# drizzle-kit output: pg 경로는 재생성(미커밋); sqlite는 런타임 마이그레이션이라 커밋한다
+/drizzle/*
+!/drizzle/sqlite/
+
+# SQLite DB 파일 (DB_PROVIDER=sqlite) — 스키마/마이그레이션만 커밋, 데이터는 커밋 금지
+/data/
+*.db
+*.db-wal
+*.db-shm
+*.sqlite
+*.sqlite3
 
 # claude — settings.local.json(시크릿)만 제외, settings.json(훅/권한)은 버전 관리
 .claude/settings.local.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # ── Stage 1: Install dependencies ──
 FROM node:22-alpine AS deps
 RUN corepack enable && corepack prepare pnpm@9 --activate
+# better-sqlite3 네이티브 모듈 빌드 도구 (musl alpine에 프리빌트가 없으면 소스 컴파일).
+# DB_PROVIDER=sqlite 경로에서만 런타임 사용되지만, deps는 항상 빌드해 둔다.
+RUN apk add --no-cache g++ make python3
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --prod=false
@@ -15,10 +18,13 @@ COPY . .
 ARG NEXT_PUBLIC_SUPABASE_URL
 ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
 ARG NEXT_PUBLIC_APP_URL
+# 클라이언트 인라인 값 — local 모드 로그인 폼 분기용. 미설정 시 빈 값(=supabase OAuth 기본).
+ARG NEXT_PUBLIC_AUTH_PROVIDER
 
 ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
 ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
 ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
+ENV NEXT_PUBLIC_AUTH_PROVIDER=$NEXT_PUBLIC_AUTH_PROVIDER
 
 RUN mkdir -p /app/public && pnpm build
 # nft traces coreBundle.js to the .pnpm path but misses browsers.json because it is
@@ -42,21 +48,30 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# SQLite 영속 데이터 디렉터리 (DB_PROVIDER=sqlite): Railway Volume을 /data에 마운트한다.
+# nextjs(uid 1001)가 app.db를 쓸 수 있도록 소유권을 부여한다. SQLITE_PATH 기본=/data/app.db.
 RUN apk add --no-cache \
+    ca-certificates \
     chromium \
-    nss \
     freetype \
     harfbuzz \
-    ca-certificates \
+    libstdc++ \
+    nss \
     ttf-freefont && \
     addgroup --system --gid 1001 nodejs && \
-    adduser --system --uid 1001 nextjs
+    adduser --system --uid 1001 nextjs && \
+    mkdir -p /data && chown nextjs:nodejs /data
+VOLUME /data
 
 ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+# SQLite 마이그레이션 폴더(+ meta/_journal.json) — 런타임 bootstrapSqlite가
+# runSqliteMigrations('./drizzle/sqlite')로 읽는다. standalone은 이 비추적 자산을
+# 자동 포함하지 않으므로 명시적으로 복사한다(미포함 시 sqlite 모드 부팅 크래시).
+COPY --from=builder --chown=nextjs:nodejs /app/drizzle/sqlite ./drizzle/sqlite
 
 USER nextjs
 EXPOSE 3000

--- a/docs/guides/sqlite-cutover-runbook.md
+++ b/docs/guides/sqlite-cutover-runbook.md
@@ -1,0 +1,98 @@
+# SQLite 컷오버 런북 (Supabase → 임베디드 SQLite + local 인증)
+
+> 대상: `feat/sqlite-migration` 브랜치. Phase 1~7 완료(프로덕션 무영향, docker 검증 끝).
+> 이 문서는 **실제 컷오버**(비가역) 절차다. Phase 8에 해당한다.
+> 배경·진행현황: [WBS 계획서](../superpowers/plans/2026-06-22-db-removal-sqlite-migration.md).
+
+## 0. 전제 — 무엇이 바뀌나
+
+- **DB**: Supabase(PostgreSQL) → 컨테이너 내 임베디드 SQLite(`/data/app.db`, Railway Volume 영속).
+- **인증**: Supabase OAuth(멀티유저) → Auth.js Credentials **단일 관리자** + JWT 무상태.
+- **모델**: 멀티유저 → **단일 사용자/셀프호스트**. RLS·organizations·gallery 등 소멸(범위 외).
+- ⚠️ **비가역 지점**: 4단계(supabase 코드 제거, P8.2) 이후 Supabase로 롤백 불가. 그 전(1~3단계)은
+  env만 되돌리면 Supabase로 복귀 가능(코드가 아직 양쪽 경로 보유).
+
+## 1. 사용자 선행 작업 (코드 외)
+
+### 1.1 Railway 영속 볼륨 — **절대 선행** (없으면 재배포마다 SQLite 소실)
+- Railway 서비스에 **Volume 생성, 마운트 경로 `/data`**.
+- 주의: 볼륨이 붙은 서비스는 replica 불가(단일 인스턴스) — 본 앱은 이미 단일 인스턴스 전제라 무해.
+
+### 1.2 관리자 비밀번호 해시 생성
+```bash
+pnpm admin:hash '원하는관리자비밀번호'
+# 출력된 ADMIN_PASSWORD_HASH=... 값을 복사
+```
+
+### 1.3 환경변수 (Railway)
+| 변수 | 값 | 비고 |
+|---|---|---|
+| `DB_PROVIDER` | `sqlite` | **컷오버 스위치** |
+| `AUTH_PROVIDER` | `local` | **컷오버 스위치** |
+| `AUTH_SECRET` | `openssl rand -base64 32` 결과 | JWT 서명 |
+| `ADMIN_EMAIL` | 로그인 이메일 | |
+| `ADMIN_PASSWORD_HASH` | 1.2 출력값 | 평문 비번 저장 안 함 |
+| `ENCRYPTION_KEY` | **기존 값 그대로 유지** | user_api_keys 복호화(데이터 이관 시 필수) |
+| (선택) `ADMIN_NAME` | 표시 이름 | 기본 `Admin` |
+| (선택) `SQLITE_PATH` | 기본 `/data/app.db` | 보통 미설정 |
+| (선택) `ADMIN_USER_ID` | 기본 `00000000-0000-0000-0000-000000000001` | 데이터 이관 시 동일 유지 |
+
+### 1.4 빌드 인자 (클라이언트 인라인 — 빌드 타임 필요)
+- `NEXT_PUBLIC_AUTH_PROVIDER=local` — 로그인 페이지가 Credentials 폼을 렌더하도록.
+- Railway는 Dockerfile build args를 서비스 변수로 주입하거나 `--build-arg`로 전달.
+
+## 2. (선택) 기존 데이터 이관 — P8.1
+
+**셀프호스트 신규 시작이면 건너뛴다** (부팅 시 카탈로그 49개 + 관리자가 자동 시드되어 바로 사용 가능).
+
+기존 프로젝트/생성코드/저장된 API 키를 보존하려면:
+```bash
+# Supabase 키가 있는 환경에서(.env.local 또는 railway run)
+pnpm cutover:migrate --out ./app.db [--user <보존할_Supabase_user_id>]
+```
+- 모든 `user_id`는 단일 관리자(`ADMIN_USER_ID`)로 리맵된다. **`--user` 지정 권장**(여러 사용자 병합 시 slug 충돌 가능).
+- 산출된 `app.db`를 **Railway 볼륨 `/data/app.db`로 업로드**(예: 임시 디버그 컨테이너에서 복사, 또는 Railway 볼륨 접근 수단).
+- 카탈로그 `api_id` FK는 번들 카탈로그가 **프로덕션 id를 보존**하므로 해소된다.
+- ⚠️ `user_api_keys.encrypted_key`는 `ENCRYPTION_KEY`로 복호화 — **동일 키를 1.3에 유지**해야 한다.
+- 부팅 시드는 멱등이라 이관 파일과 충돌하지 않는다(빈 테이블일 때만 시드).
+
+## 3. 컷오버 스위치 (배포)
+
+1. 1.1~1.4 완료 확인(특히 **볼륨**).
+2. (이관 시) 2단계로 `/data/app.db` 준비.
+3. Railway 환경변수에 `DB_PROVIDER=sqlite`·`AUTH_PROVIDER=local` 외 1.3 전체 설정.
+4. `NEXT_PUBLIC_AUTH_PROVIDER=local` 빌드 인자로 재배포.
+5. 부팅 시 `instrumentation`의 `bootstrapSqlite`가 자동 수행: 마이그레이션 → 관리자 시드 → 카탈로그(49)·플래그(7) 시드(모두 멱등).
+
+### 3.1 검증 (배포 직후)
+- `GET /api/v1/health` → 200
+- `/login` → 이메일/비밀번호 폼 표시 → 관리자 자격증명으로 로그인 → `/dashboard` 진입
+- `/api/v1/catalog` → 활성 23개 카탈로그
+- 새 서비스 생성 → 게시 → `slug.<도메인>` 서빙
+- (이관 시) 기존 프로젝트/키가 대시보드·설정에 보이는지
+
+### 3.2 롤백 (3단계까지만 가능)
+- env를 `DB_PROVIDER=supabase`·`AUTH_PROVIDER=supabase`로 되돌리고 재배포 → Supabase 경로 복귀
+  (코드가 아직 양쪽 보유). **4단계 이후엔 불가**.
+
+## 4. 컷오버 안정화 후 — supabase 경로 제거 (P8.2, 비가역)
+
+3단계가 수 일간 안정적으로 동작한 뒤 진행한다. **이 시점부터 Supabase 롤백 불가.**
+- `@supabase/*`·`pg`·Drizzle-pg 의존 및 경로 제거: `src/lib/supabase/`, Supabase/Drizzle 레포,
+  `createServiceClient`/`createClient`, `.rpc()`, `/(auth)/callback`, `assertOwner`(단일 소유자라 자명),
+  `DB_PROVIDER`/`AUTH_PROVIDER`의 supabase·postgres·authjs 분기.
+- P7.1/P7.4 테스트 정리 동반(supabase/Drizzle 레포 테스트 제거, factory/connection/failover 단순화).
+- 문서 전면 갱신(P8.3): `CLAUDE.md`(기술스택 표 Supabase→SQLite·아키텍처), `README`, `docs/reference/env-vars.md`.
+- 컷오버 ADR 작성(`docs/decisions/`).
+
+## 5. 운영 — 백업 (P6.3, 권장)
+
+- 자체보관 기본: Railway 볼륨 스냅샷 + 주기 SQLite `.backup` 덤프(컨테이너 내 크론 또는 사이드카).
+- (옵션) Litestream으로 WAL→S3 연속 복제(~1s 손실창, S3 의존).
+- 크리티컬 쓰기 내구성은 이미 `synchronous=NORMAL` + 원자적 카운터(`BEGIN IMMEDIATE` 직렬화)로 확보.
+
+## 6. 알려진 잔여 / 주의
+
+- **P4.3**: 배포 레이트리밋/환불·상태머신은 레포 단위 검증됨. 외부 배포(GitHub/Railway) 통합은 실배포에서 확인.
+- **P5.2**: `verification_status` 갱신 cron은 현재 CI→Supabase. sqlite 셀프호스트는 컨테이너 내부 검증으로 전환 필요(시드된 상태가 baseline).
+- **단일 인스턴스 전제**: `generationTracker`·`proxyCache`·인메모리 레이트리밋·SQLite 단일 writer 모두 단일 인스턴스 가정. 수평 확장 시 외부 저장소 재이관 필요.

--- a/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
+++ b/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
@@ -15,7 +15,8 @@
 | **Phase 2 — 인증** | ✅ 기능 완료 (P2.1~P2.3; P2.4 정리는 Phase 3 동반) | `18e4d64`, `c67ec18` |
 | **Phase 3 — 직접-DB/RPC 정리** | ✅ 완료 (callback·repo `.rpc`는 Phase 8 이연) | `a9688f2`, `4b7b75a`, `768da35`, `7cddeef` |
 | **Phase 4 — 서빙/런타임 검증** | 🔵 P4.1 서빙 검증 완료, P4.3 일부 대기 | (검증, 코드 무변경) |
-| Phase 5~8 | ⬜ 대기 | — |
+| **Phase 5 — 설정·번들 데이터 시드** | 🔵 P5.1·P5.3 완료, P5.2 이연 | (이번 커밋) |
+| Phase 6~8 | ⬜ 대기 | — |
 
 - **완료(Phase 1)**: SQLite 스키마(9테이블)·연결(WAL/FK)·마이그레이션(`drizzle/sqlite/`, 커밋)·`DB_PROVIDER=sqlite` / 7개 SQLite 레포(159테스트)·원자적 레이트리밋(`db.transaction`+`UPDATE…WHERE count<limit RETURNING`)·factory 배선.
 - **완료(Phase 2)**: `AUTH_PROVIDER=local`(Auth.js Credentials 단일 관리자 + JWT 무상태, scrypt 비번, `getAuthUser` 분기) / **P2.2** edge-safe 분할 설정(`local-auth-base`+`local-auth-edge`) + 미들웨어 `local` 세션 게이팅(`enforceAuthGate`) / `/api/auth/[...nextauth]/route.ts` provider 디스패치 핸들러 / **P2.3·P2.4** 로그인 페이지 Credentials 폼 + 관리자 `users` 멱등 시드(`seedAdmin`)·부팅 부트스트랩(`bootstrap`, instrumentation 배선 — P6.1 부팅 마이그레이션 일부 선반영) + `scripts/hashAdminPassword.ts`(`pnpm admin:hash`).
@@ -24,6 +25,11 @@
   - 라우트/페이지 전환: health·user-api-keys·suggest-modification·preview / **eventPersister**(sqlite 버그 수정) / **proxy**(진입 + 개인키 해결: 내부 헬퍼 raw `.from`→`createProjectRepository`/`createUserApiKeyRepository`) / **settings/api-keys**(`findAllByUser`) / **admin 4종**(qc-stats·keys-verify·trigger-qc·test-generation) 모두 레포 경유.
   - 신규 레포 메서드(3 구현체 + 인터페이스): `IEventRepository.countByTypeSince`/`findPayloadsByTypeSince`, `ICodeRepository.findMetadataByDateRange` — qc-stats `platform_events`/`generated_codes` 집계용(집계는 DB 오류 throw로 0-메트릭 은폐 방지).
   - 이연(Phase 8 동반): `callback`(raw `.from('users')`)은 Supabase Auth OAuth 전용 아티팩트(local 모드 미사용). repo 내부 `.rpc()` 6은 Supabase 레포 전용(sqlite 레포는 트랜잭션 대체 완료) → supabase 제거 시 동반 소멸.
+- **완료(Phase 5 — 설정·번들 데이터)**: 카탈로그·플래그를 **번들 JSON + 멱등 시드 함수**로 부팅 시 시드.
+  - `src/data/apiCatalog.json`(프로덕션 49행, 23 활성)·`src/data/featureFlags.json`(7) — 프로덕션 미러 생성 산출물. `scripts/generateSqliteSeed.ts`(`pnpm seed:generate`)로 Supabase에서 재생성(countries.json 패턴).
+  - `src/lib/db/sqlite/seedCatalog.ts`(`seedCatalog`/`seedFeatureFlags`, 빈 테이블일 때만 일괄 삽입·멱등) → `bootstrapSqlite`에 배선(마이그레이션→admin→catalog→flags). id·created_at은 프로덕션 값 보존(project_apis FK 일관성).
+  - **검증**: 실 sqlite 서버 스모크 5/5 — 부팅 후 DB `catalog=49·active=23·flags=7·users=1`, `GET /api/v1/catalog`가 시드 데이터 서빙. seedCatalog 단위 4/4(:memory:).
+  - **P5.2 이연**(verification_status cron SQLite write): 현 cron(`scripts/verifyCatalog.ts`)은 CI에서 Supabase에 쓴다. sqlite 셀프호스트는 검증을 컨테이너 내부에서 돌려야 하므로(볼륨 접근) Phase 6 배포 설계와 함께 다룬다. 시드된 `verification_status`(프로덕션 기준)가 baseline.
 - **검증(Phase 4)**: **P4.1 서빙 E2E 검증 완료** — 실 dev 서버(`DB_PROVIDER=sqlite`+`AUTH_PROVIDER=local`) 스모크 6/6: 부팅 부트스트랩(마이그레이션+admin 시드) → 게시 프로젝트+코드 시드 → `GET /site/demo` 200(`findBySlug`+`findByProject`+`assembleHtml` 모두 sqlite 경로 동작)·`SITE_CSP` 헤더·미존재 slug 404. P4.2(인메모리 상태)는 코드 무변경이라 자명. **P4.3**(배포 상태머신/레이트리밋 환불)은 레포 단위(SqliteRateLimitRepository 원자적 카운터·환불) 검증됨, 외부 배포(GitHub/Railway) 통합은 실배포에서 확인 필요.
 - **컷오버 전 사용자 준비물**: Railway 영속 볼륨(P0.1), env `AUTH_SECRET`·`ADMIN_EMAIL`·`ADMIN_PASSWORD_HASH`(`pnpm admin:hash`로 생성)·(선택)`ADMIN_NAME`·`SQLITE_PATH`·`ADMIN_USER_ID`.
 
@@ -108,7 +114,7 @@
 | P4.2 | 인메모리 상태(generationTracker·proxyCache·errorRateMonitor) 유지 확인(단일 인스턴스라 무변경) | — | S | 회귀 없음 |
 | P4.3 | 배포 상태머신(projects.status 전이) + 배포 레이트리밋/환불 SQLite 검증 | P1.5,P4.1 | S | 배포 흐름·환불 동작 |
 
-### Phase 5 — 설정·번들 데이터 (규모 S)
+### Phase 5 — 설정·번들 데이터 (규모 S) — 🔵 P5.1·P5.3 완료, P5.2 이연(Phase 6 동반)
 | ID | 작업 | 선행 | 규모 | AC |
 |---|---|---|---|---|
 | P5.1 | `api_catalog`(49행) 시드 → SQLite 시드 스크립트(기존 seed.sql 변환) | P1.2 | S | 시드 후 23 활성 동작 |

--- a/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
+++ b/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
@@ -7,21 +7,22 @@
 
 ## 0. 진행 현황 (2026-06-23)
 
-브랜치 `feat/sqlite-migration` (origin 백업됨). 전체 스위트 2119 통과, type-check·lint clean, `pnpm build` 성공(미들웨어 Edge 번들 위반 0). **프로덕션 무영향**(sqlite·local 모두 `DB_PROVIDER`/`AUTH_PROVIDER` opt-in, 기존 Supabase 기본값 유지).
+브랜치 `feat/sqlite-migration` (origin 백업됨). 전체 스위트 2126 통과, type-check·lint clean, `pnpm build` 성공(미들웨어 Edge 번들 위반 0). **프로덕션 무영향**(sqlite·local 모두 `DB_PROVIDER`/`AUTH_PROVIDER` opt-in, 기존 Supabase 기본값 유지).
 
 | Phase | 상태 | 커밋 |
 |---|---|---|
 | **Phase 1 — 데이터 계층** (P1.1~1.6) | ✅ 완료 | `69ac078`, `122819d` |
-| **Phase 2 — 인증** | ✅ 기능 완료 (P2.1~P2.3; P2.4 정리는 Phase 3 동반) | `18e4d64` + (이번 커밋) |
-| Phase 3~8 | ⬜ 대기 | — |
+| **Phase 2 — 인증** | ✅ 기능 완료 (P2.1~P2.3; P2.4 정리는 Phase 3 동반) | `18e4d64`, `c67ec18` |
+| **Phase 3 — 직접-DB/RPC 정리** | ✅ 완료 (callback·repo `.rpc`는 Phase 8 이연) | `a9688f2`, `4b7b75a`, `768da35` + (이번 커밋) |
+| Phase 4~8 | ⬜ 대기 | — |
 
 - **완료(Phase 1)**: SQLite 스키마(9테이블)·연결(WAL/FK)·마이그레이션(`drizzle/sqlite/`, 커밋)·`DB_PROVIDER=sqlite` / 7개 SQLite 레포(159테스트)·원자적 레이트리밋(`db.transaction`+`UPDATE…WHERE count<limit RETURNING`)·factory 배선.
 - **완료(Phase 2)**: `AUTH_PROVIDER=local`(Auth.js Credentials 단일 관리자 + JWT 무상태, scrypt 비번, `getAuthUser` 분기) / **P2.2** edge-safe 분할 설정(`local-auth-base`+`local-auth-edge`) + 미들웨어 `local` 세션 게이팅(`enforceAuthGate`) / `/api/auth/[...nextauth]/route.ts` provider 디스패치 핸들러 / **P2.3·P2.4** 로그인 페이지 Credentials 폼 + 관리자 `users` 멱등 시드(`seedAdmin`)·부팅 부트스트랩(`bootstrap`, instrumentation 배선 — P6.1 부팅 마이그레이션 일부 선반영) + `scripts/hashAdminPassword.ts`(`pnpm admin:hash`).
   - ✅ 미들웨어 `await auth()`의 **실 Edge 런타임 동작 검증 완료**(dev 서버 스모크 7/7: 미인증 /dashboard→307 /login, 로그인→JWT 발급, 인증 /dashboard→게이트 통과). 분할 설정이 end-to-end 동작 확인. (전체 서빙·sqlite 통합은 Phase 4에서 계속.)
-- **진행 중(Phase 3 — 직접-DB/RPC/service-role 정리)**: 패턴 = 인라인 가드 `getDbProvider()==='supabase' ? await createServiceClient() : undefined` 후 `createXRepository(client)`.
-  - ✅ **이미 가드 적용**(감사 과대계산 정정): health·user-api-keys·proxy 진입(L270)·suggest-modification·preview / **eventPersister**(sqlite 버그 수정·패턴 확립) / **proxy 개인키 해결**(내부 헬퍼 raw `.from` → `createProjectRepository`/`createUserApiKeyRepository`, 모든 provider 동작, positive 테스트 추가).
-  - ⬜ **남은 실작업**: **admin 4종**(qc-stats: platform_events 집계×4 — 새 event-repo 집계 메서드 필요·keys-verify: api_catalog·test-generation·trigger-qc — 가드 미적용) / **settings/api-keys 페이지**(user_api_keys 직접 조회 → repo).
-  - 이연: `callback`(raw `.from('users')`)은 Supabase Auth OAuth 전용 아티팩트(local 모드 미사용) → P2.4/Phase 8에서 제거. `.rpc()` 6은 Supabase 레포 내부(sqlite 레포는 트랜잭션으로 대체 완료) → Phase 8 supabase 제거 시 동반 소멸.
+- **완료(Phase 3 — 직접-DB/service-role 정리)**: 패턴 = 인라인 가드 `getDbProvider()==='supabase' ? await createServiceClient() : undefined` 후 `createXRepository(client)`(service factory도 provider-aware).
+  - 라우트/페이지 전환: health·user-api-keys·suggest-modification·preview / **eventPersister**(sqlite 버그 수정) / **proxy**(진입 + 개인키 해결: 내부 헬퍼 raw `.from`→`createProjectRepository`/`createUserApiKeyRepository`) / **settings/api-keys**(`findAllByUser`) / **admin 4종**(qc-stats·keys-verify·trigger-qc·test-generation) 모두 레포 경유.
+  - 신규 레포 메서드(3 구현체 + 인터페이스): `IEventRepository.countByTypeSince`/`findPayloadsByTypeSince`, `ICodeRepository.findMetadataByDateRange` — qc-stats `platform_events`/`generated_codes` 집계용(집계는 DB 오류 throw로 0-메트릭 은폐 방지).
+  - 이연(Phase 8 동반): `callback`(raw `.from('users')`)은 Supabase Auth OAuth 전용 아티팩트(local 모드 미사용). repo 내부 `.rpc()` 6은 Supabase 레포 전용(sqlite 레포는 트랜잭션 대체 완료) → supabase 제거 시 동반 소멸.
 - **컷오버 전 사용자 준비물**: Railway 영속 볼륨(P0.1), env `AUTH_SECRET`·`ADMIN_EMAIL`·`ADMIN_PASSWORD_HASH`(`pnpm admin:hash`로 생성)·(선택)`ADMIN_NAME`·`SQLITE_PATH`·`ADMIN_USER_ID`.
 
 ## 1. 목표 & 확정 제약
@@ -91,7 +92,7 @@
 | P2.3 | ✅ `getAuthUser` local 분기(P2.1에 포함) + 로그인 페이지 Credentials 폼 | P2.1 | S | 인증 소비처 회귀 없음 |
 | P2.4 | ⬜→Phase 3 동반: RLS 의존 제거·`assertOwner` 자명화·OAuth 콜백 부트스트랩 제거(단일 소유자). createServiceClient/`.from()` 재배선과 함께 진행. (관리자 `users` 시드·`hashAdminPassword` CLI는 이번에 완료) | P2.3 | S | 권한 경계 단순화, 노출 회귀 테스트 |
 
-### Phase 3 — 직접-DB/RPC/service-role 정리 (규모 M)
+### Phase 3 — 직접-DB/RPC/service-role 정리 (규모 M) — ✅ 완료 (P3.1 `.rpc`·callback은 Phase 8 이연)
 | ID | 작업 | 선행 | 규모 | AC |
 |---|---|---|---|---|
 | P3.1 | `.rpc()` 6곳 → SQLite 레포 메서드로 재배선 | P1.5 | S | RPC 호출 0건 |

--- a/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
+++ b/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
@@ -7,17 +7,19 @@
 
 ## 0. 진행 현황 (2026-06-23)
 
-브랜치 `feat/sqlite-migration` (origin 백업됨). 누적 테스트 204 통과, type-check·lint clean. **프로덕션 무영향**(sqlite·local 모두 `DB_PROVIDER`/`AUTH_PROVIDER` opt-in, 기존 Supabase 기본값 유지).
+브랜치 `feat/sqlite-migration` (origin 백업됨). 전체 스위트 2119 통과, type-check·lint clean, `pnpm build` 성공(미들웨어 Edge 번들 위반 0). **프로덕션 무영향**(sqlite·local 모두 `DB_PROVIDER`/`AUTH_PROVIDER` opt-in, 기존 Supabase 기본값 유지).
 
 | Phase | 상태 | 커밋 |
 |---|---|---|
 | **Phase 1 — 데이터 계층** (P1.1~1.6) | ✅ 완료 | `69ac078`, `122819d` |
-| **Phase 2 — 인증** | 🔵 코어(P2.1) 완료, 나머지 대기 | `18e4d64` |
+| **Phase 2 — 인증** | ✅ 기능 완료 (P2.1~P2.3; P2.4 정리는 Phase 3 동반) | `18e4d64` + (이번 커밋) |
 | Phase 3~8 | ⬜ 대기 | — |
 
-- **완료**: SQLite 스키마(9테이블)·연결(WAL/FK)·마이그레이션(`drizzle/sqlite/`, 커밋)·`DB_PROVIDER=sqlite` / 7개 SQLite 레포(159테스트)·원자적 레이트리밋(`db.transaction`+`UPDATE…WHERE count<limit RETURNING`)·factory 배선 / `AUTH_PROVIDER=local`(Auth.js Credentials 단일 관리자 + JWT 무상태, scrypt 비번, `getAuthUser` 분기).
-- **다음(Phase 2 나머지)**: ① `/api/auth/[...nextauth]/route.ts` 핸들러 ② 미들웨어 local 세션 검증 전환(Supabase `updateSession` 대체) ③ 로그인 페이지 Credentials 폼 ④ 관리자 `users` 시드 + `scripts/hashAdminPassword.ts`.
-- **컷오버 전 사용자 준비물**: Railway 영속 볼륨(P0.1), env `AUTH_SECRET`·`ADMIN_EMAIL`·`ADMIN_PASSWORD_HASH`·(선택)`SQLITE_PATH`·`ADMIN_USER_ID`.
+- **완료(Phase 1)**: SQLite 스키마(9테이블)·연결(WAL/FK)·마이그레이션(`drizzle/sqlite/`, 커밋)·`DB_PROVIDER=sqlite` / 7개 SQLite 레포(159테스트)·원자적 레이트리밋(`db.transaction`+`UPDATE…WHERE count<limit RETURNING`)·factory 배선.
+- **완료(Phase 2)**: `AUTH_PROVIDER=local`(Auth.js Credentials 단일 관리자 + JWT 무상태, scrypt 비번, `getAuthUser` 분기) / **P2.2** edge-safe 분할 설정(`local-auth-base`+`local-auth-edge`) + 미들웨어 `local` 세션 게이팅(`enforceAuthGate`) / `/api/auth/[...nextauth]/route.ts` provider 디스패치 핸들러 / **P2.3·P2.4** 로그인 페이지 Credentials 폼 + 관리자 `users` 멱등 시드(`seedAdmin`)·부팅 부트스트랩(`bootstrap`, instrumentation 배선 — P6.1 부팅 마이그레이션 일부 선반영) + `scripts/hashAdminPassword.ts`(`pnpm admin:hash`).
+  - ⚠️ 미들웨어 `await auth()` 의 **실 Edge 런타임 동작은 Phase 4(서빙 검증)에서 실서버로 확인** 필요(단위 테스트는 edge 설정 모킹으로 분기 로직만 검증).
+- **다음(Phase 3 — 직접-DB/RPC/service-role 정리)**: `.rpc()` 6 호출(레포 계층) / `createServiceClient` 10파일(12 호출 지점) / raw `.from()` 5파일(10 호출 지점: qc-stats·keys-verify·proxy·settings·callback)을 SQLite 레포 + 단일 사용자 인가로 재배선.
+- **컷오버 전 사용자 준비물**: Railway 영속 볼륨(P0.1), env `AUTH_SECRET`·`ADMIN_EMAIL`·`ADMIN_PASSWORD_HASH`(`pnpm admin:hash`로 생성)·(선택)`ADMIN_NAME`·`SQLITE_PATH`·`ADMIN_USER_ID`.
 
 ## 1. 목표 & 확정 제약
 
@@ -81,17 +83,17 @@
 ### Phase 2 — 인증 교체 (규모 M, 셀프호스트로 축소) 
 | ID | 작업 | 선행 | 규모 | AC |
 |---|---|---|---|---|
-| P2.1 | Auth.js v5 JWT 세션 구성(어댑터 없음), 단일 관리자 Credentials provider | P0.3 | M | 로그인→JWT 쿠키 발급·검증 |
-| P2.2 | 미들웨어 세션 검증을 Auth.js(Node 런타임)로 전환, Supabase `updateSession` 제거 | P2.1 | M | 보호 경로 게이팅 동작, Edge 임포트 위반 0 |
-| P2.3 | `getAuthUser` 추상화를 Auth.js로 연결(33개 소비처는 추상화 뒤라 무변경) | P2.1 | S | 인증 소비처 회귀 없음 |
-| P2.4 | RLS 의존 제거 — 단일 소유자라 `assertOwner` 자명화/소거, OAuth 콜백 부트스트랩 제거 | P2.3 | S | 권한 경계 단순화, 노출 회귀 테스트 |
+| P2.1 | ✅ Auth.js v5 JWT 세션 구성(어댑터 없음), 단일 관리자 Credentials provider | P0.3 | M | 로그인→JWT 쿠키 발급·검증 |
+| P2.2 | ✅ 미들웨어 `local` 세션 게이팅 추가. **Node 런타임 전환 대신 Edge 유지 + edge-safe 분할 설정**(`local-auth-base`/`local-auth-edge`)으로 구현 — 프로덕션 Supabase(Edge) 경로 무영향. + `/api/auth/[...nextauth]` 핸들러 | P2.1 | M | 보호 경로 게이팅 동작(단위), Edge 임포트 위반 0(빌드 확인). ⚠️ 실 Edge `auth()` 동작은 Phase 4 |
+| P2.3 | ✅ `getAuthUser` local 분기(P2.1에 포함) + 로그인 페이지 Credentials 폼 | P2.1 | S | 인증 소비처 회귀 없음 |
+| P2.4 | ⬜→Phase 3 동반: RLS 의존 제거·`assertOwner` 자명화·OAuth 콜백 부트스트랩 제거(단일 소유자). createServiceClient/`.from()` 재배선과 함께 진행. (관리자 `users` 시드·`hashAdminPassword` CLI는 이번에 완료) | P2.3 | S | 권한 경계 단순화, 노출 회귀 테스트 |
 
 ### Phase 3 — 직접-DB/RPC/service-role 정리 (규모 M)
 | ID | 작업 | 선행 | 규모 | AC |
 |---|---|---|---|---|
 | P3.1 | `.rpc()` 6곳 → SQLite 레포 메서드로 재배선 | P1.5 | S | RPC 호출 0건 |
-| P3.2 | `createServiceClient` 10개 파일 → SQLite 레포 + 단일 사용자 인가로 재작성(proxy 키 resolve·user-api-keys·suggest-modification·admin·callback 등) | P1.4,P2.3 | M | service-role 개념 소거, 키 resolve 동작 |
-| P3.3 | raw `.from()` 5파일(qc-stats·keys-verify·proxy·settings·callback) 재배선 | P3.2 | S | raw supabase 접근 0건 |
+| P3.2 | `createServiceClient` 10파일(12 호출 지점) → SQLite 레포 + 단일 사용자 인가로 재작성(proxy 키 resolve·user-api-keys·suggest-modification·health·eventPersister·admin 4종·preview) | P1.4,P2.3 | M | service-role 개념 소거, 키 resolve 동작 |
+| P3.3 | raw `.from()` 5파일·10 호출 지점(qc-stats×4·keys-verify·proxy×2·settings/api-keys·callback×2) 재배선 | P3.2 | S | raw supabase 접근 0건 |
 
 ### Phase 4 — 서빙/런타임 검증 (규모 M)
 | ID | 작업 | 선행 | 규모 | AC |

--- a/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
+++ b/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
@@ -41,6 +41,7 @@
   - **P6.2 잔여**: `@supabase/*` 의존 제거는 Phase 8(supabase 경로 제거와 함께). **P6.3 이연**(옵션 백업 크론) + P5.2 verification cron 컨테이너 내부화.
 - **완료(Phase 7 — 테스트 정리, 컷오버 전 가능 범위)**: P7.2(인증·미들웨어 테스트)는 Phase 2에서 완료. P7.3 라우트 테스트 모킹 일관화 — Phase 3에서 getDbProvider를 추가한 라우트(test-generation·qc-stats·trigger-qc) 테스트(`admin-test-generation`·`admin`)에 `@/lib/config/providers` 모킹 추가(native pg cold-init 차단). **P7.1**(supabase/Drizzle 레포 테스트 → `:memory:` 단순화)·**P7.4**(factory/connection/failover 테스트 정리)는 **Phase 8에서 supabase/postgres 레포를 제거할 때 동반**(현재 supabase 레포는 프로덕션 경로라 테스트를 선제거하면 안 됨).
 - **🚦 현재 위치 = 컷오버 게이트**: Phase 1~6 + 검증(P4.1)·테스트 정리(P7.2/P7.3)까지 **프로덕션 무영향으로 완료**. sqlite/local 스택이 docker로 빌드·실행·검증됨. **Phase 8(컷오버)부터는 프로덕션 supabase 경로를 제거**하므로 "무영향" 불변식을 깨는 비가역 변경 — **사용자 승인 + Railway 볼륨 준비 후** 진행한다.
+- **컷오버 준비물 작성 완료(프로덕션 무변경)**: ① **단계별 런북** [docs/guides/sqlite-cutover-runbook.md](../../guides/sqlite-cutover-runbook.md)(볼륨·env·빌드인자·스위치·검증·롤백·P8.2 제거·백업). ② **데이터 이관 스크립트**(P8.1, 선택) `scripts/migrateSupabaseToSqlite.ts`(`pnpm cutover:migrate --out ./app.db [--user <id>]`) — self-contained(마이그레이션+카탈로그/플래그/관리자 시드+사용자 데이터 복사, user_id→단일 관리자 리맵). 산출 app.db를 볼륨 `/data`로 업로드. 둘 다 작성·type-check 통과, 실행은 사용자 컷오버 시점.
 - **컷오버 전 사용자 준비물**: **Railway 영속 볼륨(P0.1) `/data` 마운트**(없으면 재배포마다 소실), env `AUTH_SECRET`·`ADMIN_EMAIL`·`ADMIN_PASSWORD_HASH`(`pnpm admin:hash`로 생성)·(선택)`ADMIN_NAME`·`SQLITE_PATH`·`ADMIN_USER_ID`, 빌드 `--build-arg NEXT_PUBLIC_AUTH_PROVIDER=local`.
 
 ## 1. 목표 & 확정 제약

--- a/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
+++ b/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
@@ -16,8 +16,9 @@
 | **Phase 3 — 직접-DB/RPC 정리** | ✅ 완료 (callback·repo `.rpc`는 Phase 8 이연) | `a9688f2`, `4b7b75a`, `768da35`, `7cddeef` |
 | **Phase 4 — 서빙/런타임 검증** | 🔵 P4.1 서빙 검증 완료, P4.3 일부 대기 | (검증, 코드 무변경) |
 | **Phase 5 — 설정·번들 데이터 시드** | 🔵 P5.1·P5.3 완료, P5.2 이연 | `1ff1834` |
-| **Phase 6 — 인프라/배포** | 🔵 P6.1·P6.4 완료(docker 검증), P6.2 일부·P6.3 이연 | (이번 커밋) |
-| Phase 7~8 | ⬜ 대기 | — |
+| **Phase 6 — 인프라/배포** | 🔵 P6.1·P6.4 완료(docker 검증), P6.2 일부·P6.3 이연 | `c5adbdf` |
+| **Phase 7 — 테스트 정리** | 🔵 P7.2·P7.3 완료, P7.1·P7.4는 Phase 8 동반 | (이번 커밋) |
+| **Phase 8 — 컷오버** | ⬜ 대기 (사용자 게이트) | — |
 
 - **완료(Phase 1)**: SQLite 스키마(9테이블)·연결(WAL/FK)·마이그레이션(`drizzle/sqlite/`, 커밋)·`DB_PROVIDER=sqlite` / 7개 SQLite 레포(159테스트)·원자적 레이트리밋(`db.transaction`+`UPDATE…WHERE count<limit RETURNING`)·factory 배선.
 - **완료(Phase 2)**: `AUTH_PROVIDER=local`(Auth.js Credentials 단일 관리자 + JWT 무상태, scrypt 비번, `getAuthUser` 분기) / **P2.2** edge-safe 분할 설정(`local-auth-base`+`local-auth-edge`) + 미들웨어 `local` 세션 게이팅(`enforceAuthGate`) / `/api/auth/[...nextauth]/route.ts` provider 디스패치 핸들러 / **P2.3·P2.4** 로그인 페이지 Credentials 폼 + 관리자 `users` 멱등 시드(`seedAdmin`)·부팅 부트스트랩(`bootstrap`, instrumentation 배선 — P6.1 부팅 마이그레이션 일부 선반영) + `scripts/hashAdminPassword.ts`(`pnpm admin:hash`).
@@ -38,6 +39,8 @@
   - ⚠️ **테스트 함정**(코드 무관): Git Bash(MSYS)가 `docker run -e SQLITE_PATH=/data/app.db`의 `/data/...`를 `C:/Program Files/Git/...`로 변환 → "directory does not exist". `MSYS_NO_PATHCONV=1`로 우회(SQLITE_PATH 미지정 시 코드 기본값 `/data/app.db`는 문자열 리터럴이라 무영향).
   - **컷오버 빌드/런타임**: 빌드 `--build-arg NEXT_PUBLIC_AUTH_PROVIDER=local`(+기존 supabase args 불필요 시 빈 값), 런타임 env `DB_PROVIDER=sqlite`·`AUTH_PROVIDER=local`·`AUTH_SECRET`·`ADMIN_EMAIL`·`ADMIN_PASSWORD_HASH`. **Railway Volume을 `/data`에 마운트 필수**.
   - **P6.2 잔여**: `@supabase/*` 의존 제거는 Phase 8(supabase 경로 제거와 함께). **P6.3 이연**(옵션 백업 크론) + P5.2 verification cron 컨테이너 내부화.
+- **완료(Phase 7 — 테스트 정리, 컷오버 전 가능 범위)**: P7.2(인증·미들웨어 테스트)는 Phase 2에서 완료. P7.3 라우트 테스트 모킹 일관화 — Phase 3에서 getDbProvider를 추가한 라우트(test-generation·qc-stats·trigger-qc) 테스트(`admin-test-generation`·`admin`)에 `@/lib/config/providers` 모킹 추가(native pg cold-init 차단). **P7.1**(supabase/Drizzle 레포 테스트 → `:memory:` 단순화)·**P7.4**(factory/connection/failover 테스트 정리)는 **Phase 8에서 supabase/postgres 레포를 제거할 때 동반**(현재 supabase 레포는 프로덕션 경로라 테스트를 선제거하면 안 됨).
+- **🚦 현재 위치 = 컷오버 게이트**: Phase 1~6 + 검증(P4.1)·테스트 정리(P7.2/P7.3)까지 **프로덕션 무영향으로 완료**. sqlite/local 스택이 docker로 빌드·실행·검증됨. **Phase 8(컷오버)부터는 프로덕션 supabase 경로를 제거**하므로 "무영향" 불변식을 깨는 비가역 변경 — **사용자 승인 + Railway 볼륨 준비 후** 진행한다.
 - **컷오버 전 사용자 준비물**: **Railway 영속 볼륨(P0.1) `/data` 마운트**(없으면 재배포마다 소실), env `AUTH_SECRET`·`ADMIN_EMAIL`·`ADMIN_PASSWORD_HASH`(`pnpm admin:hash`로 생성)·(선택)`ADMIN_NAME`·`SQLITE_PATH`·`ADMIN_USER_ID`, 빌드 `--build-arg NEXT_PUBLIC_AUTH_PROVIDER=local`.
 
 ## 1. 목표 & 확정 제약
@@ -136,7 +139,7 @@
 | P6.3 | (옵션) Litestream 사이드카(S3 허용 시) 또는 주기 `.backup` 크론(자체보관) | P0.4 | M | 백업 산출물 생성·복구 리허설 |
 | P6.4 | `pnpm test:prod` standalone 헬스체크 + 배포 검증 | P6.1,P6.2 | S | 헬스 200, 핵심 플로우 동작 |
 
-### Phase 7 — 테스트 재작성 (규모 L)
+### Phase 7 — 테스트 재작성 (규모 L) — 🔵 P7.2·P7.3 완료, P7.1·P7.4는 Phase 8 동반(레포 제거 시)
 | ID | 작업 | 선행 | 규모 | AC |
 |---|---|---|---|---|
 | P7.1 | 레포 구현 테스트 14파일 → SQLite `:memory:` 실DB 테스트로 **단순화**(손모킹 폐기 — 오히려 쉬워짐) | P1.4 | L | 레포 커버리지 회복 |

--- a/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
+++ b/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
@@ -19,8 +19,8 @@
 - **완료(Phase 2)**: `AUTH_PROVIDER=local`(Auth.js Credentials 단일 관리자 + JWT 무상태, scrypt 비번, `getAuthUser` 분기) / **P2.2** edge-safe 분할 설정(`local-auth-base`+`local-auth-edge`) + 미들웨어 `local` 세션 게이팅(`enforceAuthGate`) / `/api/auth/[...nextauth]/route.ts` provider 디스패치 핸들러 / **P2.3·P2.4** 로그인 페이지 Credentials 폼 + 관리자 `users` 멱등 시드(`seedAdmin`)·부팅 부트스트랩(`bootstrap`, instrumentation 배선 — P6.1 부팅 마이그레이션 일부 선반영) + `scripts/hashAdminPassword.ts`(`pnpm admin:hash`).
   - ✅ 미들웨어 `await auth()`의 **실 Edge 런타임 동작 검증 완료**(dev 서버 스모크 7/7: 미인증 /dashboard→307 /login, 로그인→JWT 발급, 인증 /dashboard→게이트 통과). 분할 설정이 end-to-end 동작 확인. (전체 서빙·sqlite 통합은 Phase 4에서 계속.)
 - **진행 중(Phase 3 — 직접-DB/RPC/service-role 정리)**: 패턴 = 인라인 가드 `getDbProvider()==='supabase' ? await createServiceClient() : undefined` 후 `createXRepository(client)`.
-  - ✅ **이미 가드 적용**(감사 과대계산 정정): health·user-api-keys·proxy 진입(L270)·suggest-modification·preview / **eventPersister**(이번에 sqlite 버그 수정·패턴 확립).
-  - ⬜ **남은 실작업**: **proxy 내부 헬퍼**(raw `.from('projects')`·`.from('user_api_keys')` → repo) — hot path / **admin 4종**(qc-stats: platform_events 집계×4·keys-verify: api_catalog·test-generation·trigger-qc — 가드 미적용, 일부 새 repo 메서드 필요) / **settings/api-keys 페이지**(user_api_keys).
+  - ✅ **이미 가드 적용**(감사 과대계산 정정): health·user-api-keys·proxy 진입(L270)·suggest-modification·preview / **eventPersister**(sqlite 버그 수정·패턴 확립) / **proxy 개인키 해결**(내부 헬퍼 raw `.from` → `createProjectRepository`/`createUserApiKeyRepository`, 모든 provider 동작, positive 테스트 추가).
+  - ⬜ **남은 실작업**: **admin 4종**(qc-stats: platform_events 집계×4 — 새 event-repo 집계 메서드 필요·keys-verify: api_catalog·test-generation·trigger-qc — 가드 미적용) / **settings/api-keys 페이지**(user_api_keys 직접 조회 → repo).
   - 이연: `callback`(raw `.from('users')`)은 Supabase Auth OAuth 전용 아티팩트(local 모드 미사용) → P2.4/Phase 8에서 제거. `.rpc()` 6은 Supabase 레포 내부(sqlite 레포는 트랜잭션으로 대체 완료) → Phase 8 supabase 제거 시 동반 소멸.
 - **컷오버 전 사용자 준비물**: Railway 영속 볼륨(P0.1), env `AUTH_SECRET`·`ADMIN_EMAIL`·`ADMIN_PASSWORD_HASH`(`pnpm admin:hash`로 생성)·(선택)`ADMIN_NAME`·`SQLITE_PATH`·`ADMIN_USER_ID`.
 

--- a/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
+++ b/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
@@ -1,0 +1,149 @@
+# DB 제거 → 임베디드 SQLite 전환 (단일 사용자·셀프호스트) — WBS 계획
+
+- 날짜: 2026-06-22
+- 상태: **계획(승인 대기)** — 실행 전 사용자 승인 필요
+- 근거: 정합성 감사(7차원 persistence surface) + 딥리서치(SQLite/Railway/Auth.js, 출처 포함) + 사용자 범위 결정 3건
+- 관련: [Supabase 사용 요소](../../../CLAUDE.md), provider 추상화([src/lib/config/providers.ts](../../../src/lib/config/providers.ts))
+
+## 1. 목표 & 확정 제약
+
+**목표**: 관리형 DB(Supabase) 및 외부 상태 저장소 의존을 제거하고, **단일 컨테이너 안에서 자체 완결되는 임베디드 SQLite** 영속성으로 전환한다.
+
+**사용자 확정 결정**
+| 항목 | 결정 | 영향 |
+|---|---|---|
+| 배포 모델 | **단일 사용자 / 셀프호스트** | RLS·멀티유저 격리·organizations·gallery·복잡 OAuth 제거 → 범위 급감 |
+| "오프라인" 의미 | **관리형 DB 비의존만** (외부 API 호출 허용) | Claude 생성·프록시·OAuth는 유지 가능. 제품 핵심 보존 |
+| 백업 주권 | 추천 채택 | **자체보관 기본**(Railway 볼륨 스냅샷 + 주기 `.backup` 덤프), Litestream→S3는 옵션 |
+
+**비목표(YAGNI)**: 멀티유저 RBAC, organizations/memberships, gallery/project_likes, 수평 확장(replica), HA/자동 페일오버(LiteFS sunset).
+
+## 2. 타깃 아키텍처
+
+```
+단일 Railway 컨테이너
+├── Next.js 16 standalone (단일 인스턴스 — 이미 전제)
+├── 임베디드 SQLite (/data/app.db, WAL 모드)        ← Railway Volume 마운트(영속)
+│     drizzle-orm/better-sqlite3 (first-party) + 마이그레이터
+├── 인증: Auth.js v5, JWT 세션(무상태, 쿠키 JWE) — DB 어댑터 없음
+│     단일 관리자 계정(Credentials) 권장 / OAuth는 옵션
+├── 백업: 볼륨 스냅샷 + 주기 SQLite .backup 덤프(자체보관)  ← Litestream→S3는 옵션
+└── 외부 호출 유지: Claude API(생성), 프록시 대상 API, (옵션)OAuth IdP
+```
+
+**구현 전략(핵심)**: 기존 provider 추상화(`DB_PROVIDER`)에 **`sqlite` 경로를 추가**하고, 이미 존재하는 Drizzle(postgres) 레포 7종을 **SQLite 방언으로 미러링**한다. 추상화 seam(`IRepository`·factory)을 유지해 리프트-앤-시프트가 아닌 **어댑터 교체**로 진행 → 리스크·작업량 최소화. 최종 정리 단계에서 Supabase/postgres 경로를 제거.
+
+## 3. 리서치 검증 사실 (출처 기반 — WBS 전제)
+
+- **단일 인스턴스 천장**: 볼륨 붙은 Railway 서비스는 replica 불가, 동일 볼륨 다중 마운트 금지, 재배포 시 짧은 다운타임. 현 앱이 이미 단일 인스턴스 전제라 **수용**. (railway docs)
+- **볼륨 용량**: Free 0.5GB / Hobby 5GB / Pro 50GB(→1TB). OLTP엔 충분.
+- **데이터 계층**: `drizzle-orm/better-sqlite3` first-party + 마이그레이터. WAL 권장(읽기-쓰기 동시성↑). **SQLite는 단일 writer**(WAL도 동시 쓰기 불가, SQLITE_BUSY) → 원자적 카운터는 `BEGIN IMMEDIATE` 직렬화. `synchronous=NORMAL` 기본(크리티컬 쓰기는 FULL).
+- **인증**: Auth.js v5 **JWT = 어댑터 없으면 기본**(무상태). **Next 16 Node 미들웨어**로 과거 edge 분리 제약 완화. 즉시 무효화 불가 → 짧은 TTL/재로그인으로 완화(단일 사용자라 위험 낮음).
+- **백업**: Litestream = DR(HA 아님), WAL→S3 연속 복제, **~1s 손실창**. S3 의존이 주권과 충돌 → **자체보관 우선** 결정.
+
+## 4. WBS (Work Breakdown Structure)
+
+> 규모: S(≤0.5d) · M(0.5~2d) · L(2~5d). 선행 = 선행 작업 패키지 ID. AC = 수용기준.
+
+### Phase 0 — 선행·결정·안전망 (규모 M)
+| ID | 작업 | 선행 | 규모 | AC |
+|---|---|---|---|---|
+| P0.1 | **Railway Volume 생성 + `/data` 마운트** (없으면 데이터 소실 — 최우선) | — | S | 컨테이너 재배포 후에도 `/data` 파일 잔존 확인 |
+| P0.2 | Supabase 프로덕션 **전체 백업**(현행 데이터 export) — 컷오버 안전망 | — | S | api_catalog·projects·generated_codes 등 덤프 보관 |
+| P0.3 | 인증 방식 확정(권장: Auth.js Credentials 단일 관리자 + JWT) | — | S | ADR 한 줄 결정 기록 |
+| P0.4 | 백업 전략 확정(권장: 볼륨 스냅샷 + 주기 `.backup`; Litestream 옵션) | P0.1 | S | 백업·복구 절차 문서화 |
+| P0.5 | 죽은 테이블/기능 확정 제외 목록(organizations·memberships·project_likes·gallery·event_log) 코드 사용처 재확인 | — | S | 제외 대상 0 사용처 확인 |
+
+### Phase 1 — 데이터 계층: SQLite 어댑터 (규모 L)
+| ID | 작업 | 선행 | 규모 | AC |
+|---|---|---|---|---|
+| P1.1 | `better-sqlite3` + `drizzle-orm/better-sqlite3` 도입, DB 연결(WAL·synchronous·busy_timeout pragma) | P0.1 | M | `:memory:` 및 파일 DB 연결·pragma 적용 테스트 |
+| P1.2 | SQLite 스키마 정의(기존 Drizzle 스키마 → SQLite 방언; 죽은 테이블 제외, 단일 사용자로 단순화) | P1.1,P0.5 | M | drizzle 마이그레이션 생성·적용 |
+| P1.3 | `sqlite` 를 `DB_PROVIDER`에 추가, factory 분기 | P1.1 | S | `getDbProvider()='sqlite'` 경로 동작 |
+| P1.4 | 7개 IRepository의 SQLite 구현(Drizzle postgres 구현 미러) — Project·User·Code·Catalog·Event·RateLimit·UserApiKey | P1.2,P1.3 | L | 각 레포 메서드 단위 테스트(`:memory:` SQLite 실DB) |
+| P1.5 | **원자적 레이트리밋 재현** — `BEGIN IMMEDIATE` 트랜잭션 test-and-set + 환불(GREATEST 0) + 일자 만료 | P1.4 | M | 동시(직렬) 요청 한도 초과 차단·환불 정확성 테스트 |
+| P1.6 | JOIN 집계(`countTodayGenerations`·`getApiUsageFromProjects`)·검색(ilike→LIKE)·페이지네이션·버전 채번 SQLite 재구현 | P1.4 | M | 집계·검색·페이지네이션 결과 동등성 테스트 |
+
+### Phase 2 — 인증 교체 (규모 M, 셀프호스트로 축소) 
+| ID | 작업 | 선행 | 규모 | AC |
+|---|---|---|---|---|
+| P2.1 | Auth.js v5 JWT 세션 구성(어댑터 없음), 단일 관리자 Credentials provider | P0.3 | M | 로그인→JWT 쿠키 발급·검증 |
+| P2.2 | 미들웨어 세션 검증을 Auth.js(Node 런타임)로 전환, Supabase `updateSession` 제거 | P2.1 | M | 보호 경로 게이팅 동작, Edge 임포트 위반 0 |
+| P2.3 | `getAuthUser` 추상화를 Auth.js로 연결(33개 소비처는 추상화 뒤라 무변경) | P2.1 | S | 인증 소비처 회귀 없음 |
+| P2.4 | RLS 의존 제거 — 단일 소유자라 `assertOwner` 자명화/소거, OAuth 콜백 부트스트랩 제거 | P2.3 | S | 권한 경계 단순화, 노출 회귀 테스트 |
+
+### Phase 3 — 직접-DB/RPC/service-role 정리 (규모 M)
+| ID | 작업 | 선행 | 규모 | AC |
+|---|---|---|---|---|
+| P3.1 | `.rpc()` 6곳 → SQLite 레포 메서드로 재배선 | P1.5 | S | RPC 호출 0건 |
+| P3.2 | `createServiceClient` 10개 파일 → SQLite 레포 + 단일 사용자 인가로 재작성(proxy 키 resolve·user-api-keys·suggest-modification·admin·callback 등) | P1.4,P2.3 | M | service-role 개념 소거, 키 resolve 동작 |
+| P3.3 | raw `.from()` 5파일(qc-stats·keys-verify·proxy·settings·callback) 재배선 | P3.2 | S | raw supabase 접근 0건 |
+
+### Phase 4 — 서빙/런타임 검증 (규모 M)
+| ID | 작업 | 선행 | 규모 | AC |
+|---|---|---|---|---|
+| P4.1 | `/site/[slug]` 서빙·preview·코드저장 트랜잭션(INSERT+UPDATE)·버전 고유성 SQLite 경로 검증 | P1.4 | M | 게시→서브도메인 서빙 E2E 통과 |
+| P4.2 | 인메모리 상태(generationTracker·proxyCache·errorRateMonitor) 유지 확인(단일 인스턴스라 무변경) | — | S | 회귀 없음 |
+| P4.3 | 배포 상태머신(projects.status 전이) + 배포 레이트리밋/환불 SQLite 검증 | P1.5,P4.1 | S | 배포 흐름·환불 동작 |
+
+### Phase 5 — 설정·번들 데이터 (규모 S)
+| ID | 작업 | 선행 | 규모 | AC |
+|---|---|---|---|---|
+| P5.1 | `api_catalog`(49행) 시드 → SQLite 시드 스크립트(기존 seed.sql 변환) | P1.2 | S | 시드 후 23 활성 동작 |
+| P5.2 | `verification_status` cron `--write` 경로를 SQLite write로 전환 | P5.1,P1.4 | S | cron이 SQLite 갱신 |
+| P5.3 | `feature_flags`(7) → SQLite 시드 또는 config 파일 | P1.2 | S | 플래그 읽기 동작 |
+
+### Phase 6 — 인프라/배포 (규모 M)
+| ID | 작업 | 선행 | 규모 | AC |
+|---|---|---|---|---|
+| P6.1 | Dockerfile: `better-sqlite3` 네이티브 빌드(빌드 의존), 볼륨 경로, 부팅 시 마이그레이션 실행 | P1.2 | M | 컨테이너 부팅→마이그레이션→서비스 정상 |
+| P6.2 | 환경변수 정리(Supabase 제거), `DB_PROVIDER=sqlite`·`AUTH_PROVIDER` 단일화, supabase-js 의존 제거 | P3.3,P2.2 | S | Supabase env 0건에서 부팅 |
+| P6.3 | (옵션) Litestream 사이드카(S3 허용 시) 또는 주기 `.backup` 크론(자체보관) | P0.4 | M | 백업 산출물 생성·복구 리허설 |
+| P6.4 | `pnpm test:prod` standalone 헬스체크 + 배포 검증 | P6.1,P6.2 | S | 헬스 200, 핵심 플로우 동작 |
+
+### Phase 7 — 테스트 재작성 (규모 L)
+| ID | 작업 | 선행 | 규모 | AC |
+|---|---|---|---|---|
+| P7.1 | 레포 구현 테스트 14파일 → SQLite `:memory:` 실DB 테스트로 **단순화**(손모킹 폐기 — 오히려 쉬워짐) | P1.4 | L | 레포 커버리지 회복 |
+| P7.2 | 인증 테스트(Auth.js JWT), 미들웨어 테스트 재작성 | P2.2 | M | 인증 경로 커버 |
+| P7.3 | API 라우트 21·서비스 4 테스트의 모킹 타깃 교체(인터페이스 경계 덕에 저영향) | P3.3 | M | 라우트 테스트 통과 |
+| P7.4 | factory/connection/failover 인프라 테스트 단일화·정리 | P6.2 | S | 죽은 테스트 제거 |
+
+### Phase 8 — 데이터 이관·컷오버·문서 (규모 M)
+| ID | 작업 | 선행 | 규모 | AC |
+|---|---|---|---|---|
+| P8.1 | (기존 데이터 보존 시) Supabase→SQLite 이관 스크립트 + 검증. 셀프호스트 신규 시작이면 생략 | P0.2,P1.2 | M | 행수·무결성 대조 통과 |
+| P8.2 | Supabase/postgres/Drizzle-pg 경로 및 미사용 의존 제거 | P7.4 | M | 빌드·테스트 그린, 의존 정리 |
+| P8.3 | 문서 전면 갱신(CLAUDE.md·README·아키텍처·ADR), 배포/백업 운영 가이드 | P8.2 | M | 코드-문서 정합 |
+
+## 5. 마일스톤(권장 순서)
+
+1. **M1 기반**: P0 전체 + P1.1~P1.3 (볼륨·백업·SQLite 연결·provider 분기) — *데이터 소실 방지 확보*
+2. **M2 데이터계층**: P1.4~P1.6 + P7.1 (레포 + 레이트리밋 + 레포 테스트)
+3. **M3 인증**: P2 전체 + P7.2 (Supabase Auth 탈피)
+4. **M4 배선정리**: P3 + P4 + P5 (직접-DB 제거, 서빙·설정 검증)
+5. **M5 배포·정리**: P6 + P7.3~P7.4 + P8 (인프라·테스트·컷오버·문서)
+
+## 6. 리스크 & 완화 (감사+리서치)
+
+| 리스크 | 심각도 | 완화 |
+|---|---|---|
+| 볼륨 없이 SQLite 채택 시 데이터 영구 소실 | High | **P0.1을 절대 선행**. 볼륨 검증 전 컷오버 금지 |
+| 원자적 레이트리밋 약화 → Claude 과금 폭증 | High | `BEGIN IMMEDIATE` 직렬화 + 증가/환불 동일 DB. 단일 사용자라 동시성 낮아 위험 추가 감소 |
+| 권한 경계 회귀(노출) | Med→Low | 단일 사용자라 격리 부담 급감. 그래도 `assertOwner` 게이트 + 회귀 테스트 |
+| 단일 인스턴스 천장(확장 불가) | Med | 현 규모 무해. 성장 시 외부 저장소 재이관 경로를 ADR로 사전 문서화. IRepository 유지로 재이관 비용 최소화 |
+| ~1s 백업 손실창(Litestream) / 스냅샷 간격 | Med | 자체보관 기본 + 주기 짧게. 크리티컬 쓰기 `synchronous=FULL` |
+| better-sqlite3 네이티브 빌드(Docker·Node 22) | Med | 멀티스테이지 빌드 검증, 프리빌트 확인 |
+
+## 7. 미결정(실행 중 확정) — 추천 default 명시
+- **백업 매체**: 자체보관(볼륨 스냅샷 + `.backup`) *권장 기본*; S3 허용 시 Litestream 추가(옵션).
+- **인증 방식**: Auth.js Credentials 단일 관리자 *권장*; OAuth 유지 원하면 Auth.js OAuth provider(외부 IdP 호출).
+- **카탈로그 보관**: SQLite 테이블 유지 *권장*(cron write 단순); 대안은 JSON 번들(countries 방식).
+- **기존 데이터**: 셀프호스트 신규 시작이면 이관 생략; 보존 필요 시 P8.1.
+
+## 8. 출처(딥리서치)
+- Railway Volumes/Scaling: docs.railway.com/volumes/reference, /deployments/scaling
+- Litestream: litestream.io/how-it-works, /alternatives, /tips; fly.io/blog/litestream-revamped
+- Drizzle SQLite: orm.drizzle.team/docs/get-started-sqlite
+- better-sqlite3 WAL/synchronous: github.com/WiseLibs/better-sqlite3 (docs/performance.md)
+- Auth.js 세션/edge: authjs.dev/concepts/session-strategies, /guides/edge-compatibility

--- a/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
+++ b/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
@@ -1,9 +1,23 @@
 # DB 제거 → 임베디드 SQLite 전환 (단일 사용자·셀프호스트) — WBS 계획
 
-- 날짜: 2026-06-22
-- 상태: **계획(승인 대기)** — 실행 전 사용자 승인 필요
+- 날짜: 2026-06-22 (착수 2026-06-23)
+- 상태: **실행 중** — 승인 완료(현 프로덕션 제자리 전환). 진행 현황은 §0 참조.
 - 근거: 정합성 감사(7차원 persistence surface) + 딥리서치(SQLite/Railway/Auth.js, 출처 포함) + 사용자 범위 결정 3건
 - 관련: [Supabase 사용 요소](../../../CLAUDE.md), provider 추상화([src/lib/config/providers.ts](../../../src/lib/config/providers.ts))
+
+## 0. 진행 현황 (2026-06-23)
+
+브랜치 `feat/sqlite-migration` (origin 백업됨). 누적 테스트 204 통과, type-check·lint clean. **프로덕션 무영향**(sqlite·local 모두 `DB_PROVIDER`/`AUTH_PROVIDER` opt-in, 기존 Supabase 기본값 유지).
+
+| Phase | 상태 | 커밋 |
+|---|---|---|
+| **Phase 1 — 데이터 계층** (P1.1~1.6) | ✅ 완료 | `69ac078`, `122819d` |
+| **Phase 2 — 인증** | 🔵 코어(P2.1) 완료, 나머지 대기 | `18e4d64` |
+| Phase 3~8 | ⬜ 대기 | — |
+
+- **완료**: SQLite 스키마(9테이블)·연결(WAL/FK)·마이그레이션(`drizzle/sqlite/`, 커밋)·`DB_PROVIDER=sqlite` / 7개 SQLite 레포(159테스트)·원자적 레이트리밋(`db.transaction`+`UPDATE…WHERE count<limit RETURNING`)·factory 배선 / `AUTH_PROVIDER=local`(Auth.js Credentials 단일 관리자 + JWT 무상태, scrypt 비번, `getAuthUser` 분기).
+- **다음(Phase 2 나머지)**: ① `/api/auth/[...nextauth]/route.ts` 핸들러 ② 미들웨어 local 세션 검증 전환(Supabase `updateSession` 대체) ③ 로그인 페이지 Credentials 폼 ④ 관리자 `users` 시드 + `scripts/hashAdminPassword.ts`.
+- **컷오버 전 사용자 준비물**: Railway 영속 볼륨(P0.1), env `AUTH_SECRET`·`ADMIN_EMAIL`·`ADMIN_PASSWORD_HASH`·(선택)`SQLITE_PATH`·`ADMIN_USER_ID`.
 
 ## 1. 목표 & 확정 제약
 

--- a/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
+++ b/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
@@ -15,8 +15,9 @@
 | **Phase 2 — 인증** | ✅ 기능 완료 (P2.1~P2.3; P2.4 정리는 Phase 3 동반) | `18e4d64`, `c67ec18` |
 | **Phase 3 — 직접-DB/RPC 정리** | ✅ 완료 (callback·repo `.rpc`는 Phase 8 이연) | `a9688f2`, `4b7b75a`, `768da35`, `7cddeef` |
 | **Phase 4 — 서빙/런타임 검증** | 🔵 P4.1 서빙 검증 완료, P4.3 일부 대기 | (검증, 코드 무변경) |
-| **Phase 5 — 설정·번들 데이터 시드** | 🔵 P5.1·P5.3 완료, P5.2 이연 | (이번 커밋) |
-| Phase 6~8 | ⬜ 대기 | — |
+| **Phase 5 — 설정·번들 데이터 시드** | 🔵 P5.1·P5.3 완료, P5.2 이연 | `1ff1834` |
+| **Phase 6 — 인프라/배포** | 🔵 P6.1·P6.4 완료(docker 검증), P6.2 일부·P6.3 이연 | (이번 커밋) |
+| Phase 7~8 | ⬜ 대기 | — |
 
 - **완료(Phase 1)**: SQLite 스키마(9테이블)·연결(WAL/FK)·마이그레이션(`drizzle/sqlite/`, 커밋)·`DB_PROVIDER=sqlite` / 7개 SQLite 레포(159테스트)·원자적 레이트리밋(`db.transaction`+`UPDATE…WHERE count<limit RETURNING`)·factory 배선.
 - **완료(Phase 2)**: `AUTH_PROVIDER=local`(Auth.js Credentials 단일 관리자 + JWT 무상태, scrypt 비번, `getAuthUser` 분기) / **P2.2** edge-safe 분할 설정(`local-auth-base`+`local-auth-edge`) + 미들웨어 `local` 세션 게이팅(`enforceAuthGate`) / `/api/auth/[...nextauth]/route.ts` provider 디스패치 핸들러 / **P2.3·P2.4** 로그인 페이지 Credentials 폼 + 관리자 `users` 멱등 시드(`seedAdmin`)·부팅 부트스트랩(`bootstrap`, instrumentation 배선 — P6.1 부팅 마이그레이션 일부 선반영) + `scripts/hashAdminPassword.ts`(`pnpm admin:hash`).
@@ -31,7 +32,13 @@
   - **검증**: 실 sqlite 서버 스모크 5/5 — 부팅 후 DB `catalog=49·active=23·flags=7·users=1`, `GET /api/v1/catalog`가 시드 데이터 서빙. seedCatalog 단위 4/4(:memory:).
   - **P5.2 이연**(verification_status cron SQLite write): 현 cron(`scripts/verifyCatalog.ts`)은 CI에서 Supabase에 쓴다. sqlite 셀프호스트는 검증을 컨테이너 내부에서 돌려야 하므로(볼륨 접근) Phase 6 배포 설계와 함께 다룬다. 시드된 `verification_status`(프로덕션 기준)가 baseline.
 - **검증(Phase 4)**: **P4.1 서빙 E2E 검증 완료** — 실 dev 서버(`DB_PROVIDER=sqlite`+`AUTH_PROVIDER=local`) 스모크 6/6: 부팅 부트스트랩(마이그레이션+admin 시드) → 게시 프로젝트+코드 시드 → `GET /site/demo` 200(`findBySlug`+`findByProject`+`assembleHtml` 모두 sqlite 경로 동작)·`SITE_CSP` 헤더·미존재 slug 404. P4.2(인메모리 상태)는 코드 무변경이라 자명. **P4.3**(배포 상태머신/레이트리밋 환불)은 레포 단위(SqliteRateLimitRepository 원자적 카운터·환불) 검증됨, 외부 배포(GitHub/Railway) 통합은 실배포에서 확인 필요.
-- **컷오버 전 사용자 준비물**: Railway 영속 볼륨(P0.1), env `AUTH_SECRET`·`ADMIN_EMAIL`·`ADMIN_PASSWORD_HASH`(`pnpm admin:hash`로 생성)·(선택)`ADMIN_NAME`·`SQLITE_PATH`·`ADMIN_USER_ID`.
+- **완료(Phase 6 — 인프라/배포)**: Dockerfile이 sqlite 모드를 빌드·실행 지원.
+  - **Dockerfile**: deps `apk add g++ make python3`(better-sqlite3 네이티브, 프리빌트 부재 시 소스 컴파일) / runner `libstdc++`(네이티브 바인딩 런타임) + `/data` 디렉터리(nextjs 소유)·`VOLUME /data` / **`drizzle/sqlite` 명시 복사**(standalone이 비추적 자산을 자동 포함 안 함 — 미포함 시 부팅 시 `runSqliteMigrations`가 journal 못 찾아 크래시) / `NEXT_PUBLIC_AUTH_PROVIDER` build arg(로그인 폼 빌드타임 인라인). `next.config`에 `better-sqlite3` serverExternalPackages(네이티브 모듈 webpack 번들 금지).
+  - **검증(docker build + run)**: 이미지 빌드 성공 → 컨테이너(`DB_PROVIDER=sqlite`+`AUTH_PROVIDER=local`, **supabase env 0개**) 부팅 → 부트스트랩이 볼륨에 마이그레이션+시드(`catalog=49·active=23·flags=7·users=1`) → `/api/v1/health` 200·`/dashboard` 307→`/login`·`/site/nope` 404·`/api/v1/catalog` 시드 서빙·부팅 에러 0. **P6.2 "supabase env 0 부팅" AC 충족**.
+  - ⚠️ **테스트 함정**(코드 무관): Git Bash(MSYS)가 `docker run -e SQLITE_PATH=/data/app.db`의 `/data/...`를 `C:/Program Files/Git/...`로 변환 → "directory does not exist". `MSYS_NO_PATHCONV=1`로 우회(SQLITE_PATH 미지정 시 코드 기본값 `/data/app.db`는 문자열 리터럴이라 무영향).
+  - **컷오버 빌드/런타임**: 빌드 `--build-arg NEXT_PUBLIC_AUTH_PROVIDER=local`(+기존 supabase args 불필요 시 빈 값), 런타임 env `DB_PROVIDER=sqlite`·`AUTH_PROVIDER=local`·`AUTH_SECRET`·`ADMIN_EMAIL`·`ADMIN_PASSWORD_HASH`. **Railway Volume을 `/data`에 마운트 필수**.
+  - **P6.2 잔여**: `@supabase/*` 의존 제거는 Phase 8(supabase 경로 제거와 함께). **P6.3 이연**(옵션 백업 크론) + P5.2 verification cron 컨테이너 내부화.
+- **컷오버 전 사용자 준비물**: **Railway 영속 볼륨(P0.1) `/data` 마운트**(없으면 재배포마다 소실), env `AUTH_SECRET`·`ADMIN_EMAIL`·`ADMIN_PASSWORD_HASH`(`pnpm admin:hash`로 생성)·(선택)`ADMIN_NAME`·`SQLITE_PATH`·`ADMIN_USER_ID`, 빌드 `--build-arg NEXT_PUBLIC_AUTH_PROVIDER=local`.
 
 ## 1. 목표 & 확정 제약
 
@@ -121,7 +128,7 @@
 | P5.2 | `verification_status` cron `--write` 경로를 SQLite write로 전환 | P5.1,P1.4 | S | cron이 SQLite 갱신 |
 | P5.3 | `feature_flags`(7) → SQLite 시드 또는 config 파일 | P1.2 | S | 플래그 읽기 동작 |
 
-### Phase 6 — 인프라/배포 (규모 M)
+### Phase 6 — 인프라/배포 (규모 M) — 🔵 P6.1·P6.4 완료(docker build+run 검증), P6.2 일부·P6.3 이연
 | ID | 작업 | 선행 | 규모 | AC |
 |---|---|---|---|---|
 | P6.1 | Dockerfile: `better-sqlite3` 네이티브 빌드(빌드 의존), 볼륨 경로, 부팅 시 마이그레이션 실행 | P1.2 | M | 컨테이너 부팅→마이그레이션→서비스 정상 |

--- a/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
+++ b/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
@@ -13,8 +13,9 @@
 |---|---|---|
 | **Phase 1 — 데이터 계층** (P1.1~1.6) | ✅ 완료 | `69ac078`, `122819d` |
 | **Phase 2 — 인증** | ✅ 기능 완료 (P2.1~P2.3; P2.4 정리는 Phase 3 동반) | `18e4d64`, `c67ec18` |
-| **Phase 3 — 직접-DB/RPC 정리** | ✅ 완료 (callback·repo `.rpc`는 Phase 8 이연) | `a9688f2`, `4b7b75a`, `768da35` + (이번 커밋) |
-| Phase 4~8 | ⬜ 대기 | — |
+| **Phase 3 — 직접-DB/RPC 정리** | ✅ 완료 (callback·repo `.rpc`는 Phase 8 이연) | `a9688f2`, `4b7b75a`, `768da35`, `7cddeef` |
+| **Phase 4 — 서빙/런타임 검증** | 🔵 P4.1 서빙 검증 완료, P4.3 일부 대기 | (검증, 코드 무변경) |
+| Phase 5~8 | ⬜ 대기 | — |
 
 - **완료(Phase 1)**: SQLite 스키마(9테이블)·연결(WAL/FK)·마이그레이션(`drizzle/sqlite/`, 커밋)·`DB_PROVIDER=sqlite` / 7개 SQLite 레포(159테스트)·원자적 레이트리밋(`db.transaction`+`UPDATE…WHERE count<limit RETURNING`)·factory 배선.
 - **완료(Phase 2)**: `AUTH_PROVIDER=local`(Auth.js Credentials 단일 관리자 + JWT 무상태, scrypt 비번, `getAuthUser` 분기) / **P2.2** edge-safe 분할 설정(`local-auth-base`+`local-auth-edge`) + 미들웨어 `local` 세션 게이팅(`enforceAuthGate`) / `/api/auth/[...nextauth]/route.ts` provider 디스패치 핸들러 / **P2.3·P2.4** 로그인 페이지 Credentials 폼 + 관리자 `users` 멱등 시드(`seedAdmin`)·부팅 부트스트랩(`bootstrap`, instrumentation 배선 — P6.1 부팅 마이그레이션 일부 선반영) + `scripts/hashAdminPassword.ts`(`pnpm admin:hash`).
@@ -23,6 +24,7 @@
   - 라우트/페이지 전환: health·user-api-keys·suggest-modification·preview / **eventPersister**(sqlite 버그 수정) / **proxy**(진입 + 개인키 해결: 내부 헬퍼 raw `.from`→`createProjectRepository`/`createUserApiKeyRepository`) / **settings/api-keys**(`findAllByUser`) / **admin 4종**(qc-stats·keys-verify·trigger-qc·test-generation) 모두 레포 경유.
   - 신규 레포 메서드(3 구현체 + 인터페이스): `IEventRepository.countByTypeSince`/`findPayloadsByTypeSince`, `ICodeRepository.findMetadataByDateRange` — qc-stats `platform_events`/`generated_codes` 집계용(집계는 DB 오류 throw로 0-메트릭 은폐 방지).
   - 이연(Phase 8 동반): `callback`(raw `.from('users')`)은 Supabase Auth OAuth 전용 아티팩트(local 모드 미사용). repo 내부 `.rpc()` 6은 Supabase 레포 전용(sqlite 레포는 트랜잭션 대체 완료) → supabase 제거 시 동반 소멸.
+- **검증(Phase 4)**: **P4.1 서빙 E2E 검증 완료** — 실 dev 서버(`DB_PROVIDER=sqlite`+`AUTH_PROVIDER=local`) 스모크 6/6: 부팅 부트스트랩(마이그레이션+admin 시드) → 게시 프로젝트+코드 시드 → `GET /site/demo` 200(`findBySlug`+`findByProject`+`assembleHtml` 모두 sqlite 경로 동작)·`SITE_CSP` 헤더·미존재 slug 404. P4.2(인메모리 상태)는 코드 무변경이라 자명. **P4.3**(배포 상태머신/레이트리밋 환불)은 레포 단위(SqliteRateLimitRepository 원자적 카운터·환불) 검증됨, 외부 배포(GitHub/Railway) 통합은 실배포에서 확인 필요.
 - **컷오버 전 사용자 준비물**: Railway 영속 볼륨(P0.1), env `AUTH_SECRET`·`ADMIN_EMAIL`·`ADMIN_PASSWORD_HASH`(`pnpm admin:hash`로 생성)·(선택)`ADMIN_NAME`·`SQLITE_PATH`·`ADMIN_USER_ID`.
 
 ## 1. 목표 & 확정 제약
@@ -99,7 +101,7 @@
 | P3.2 | `createServiceClient` 10파일(12 호출 지점) → SQLite 레포 + 단일 사용자 인가로 재작성(proxy 키 resolve·user-api-keys·suggest-modification·health·eventPersister·admin 4종·preview) | P1.4,P2.3 | M | service-role 개념 소거, 키 resolve 동작 |
 | P3.3 | raw `.from()` 5파일·10 호출 지점(qc-stats×4·keys-verify·proxy×2·settings/api-keys·callback×2) 재배선 | P3.2 | S | raw supabase 접근 0건 |
 
-### Phase 4 — 서빙/런타임 검증 (규모 M)
+### Phase 4 — 서빙/런타임 검증 (규모 M) — 🔵 P4.1 검증 완료(dev 스모크 6/6)
 | ID | 작업 | 선행 | 규모 | AC |
 |---|---|---|---|---|
 | P4.1 | `/site/[slug]` 서빙·preview·코드저장 트랜잭션(INSERT+UPDATE)·버전 고유성 SQLite 경로 검증 | P1.4 | M | 게시→서브도메인 서빙 E2E 통과 |

--- a/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
+++ b/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
@@ -17,8 +17,11 @@
 
 - **완료(Phase 1)**: SQLite 스키마(9테이블)·연결(WAL/FK)·마이그레이션(`drizzle/sqlite/`, 커밋)·`DB_PROVIDER=sqlite` / 7개 SQLite 레포(159테스트)·원자적 레이트리밋(`db.transaction`+`UPDATE…WHERE count<limit RETURNING`)·factory 배선.
 - **완료(Phase 2)**: `AUTH_PROVIDER=local`(Auth.js Credentials 단일 관리자 + JWT 무상태, scrypt 비번, `getAuthUser` 분기) / **P2.2** edge-safe 분할 설정(`local-auth-base`+`local-auth-edge`) + 미들웨어 `local` 세션 게이팅(`enforceAuthGate`) / `/api/auth/[...nextauth]/route.ts` provider 디스패치 핸들러 / **P2.3·P2.4** 로그인 페이지 Credentials 폼 + 관리자 `users` 멱등 시드(`seedAdmin`)·부팅 부트스트랩(`bootstrap`, instrumentation 배선 — P6.1 부팅 마이그레이션 일부 선반영) + `scripts/hashAdminPassword.ts`(`pnpm admin:hash`).
-  - ⚠️ 미들웨어 `await auth()` 의 **실 Edge 런타임 동작은 Phase 4(서빙 검증)에서 실서버로 확인** 필요(단위 테스트는 edge 설정 모킹으로 분기 로직만 검증).
-- **다음(Phase 3 — 직접-DB/RPC/service-role 정리)**: `.rpc()` 6 호출(레포 계층) / `createServiceClient` 10파일(12 호출 지점) / raw `.from()` 5파일(10 호출 지점: qc-stats·keys-verify·proxy·settings·callback)을 SQLite 레포 + 단일 사용자 인가로 재배선.
+  - ✅ 미들웨어 `await auth()`의 **실 Edge 런타임 동작 검증 완료**(dev 서버 스모크 7/7: 미인증 /dashboard→307 /login, 로그인→JWT 발급, 인증 /dashboard→게이트 통과). 분할 설정이 end-to-end 동작 확인. (전체 서빙·sqlite 통합은 Phase 4에서 계속.)
+- **진행 중(Phase 3 — 직접-DB/RPC/service-role 정리)**: 패턴 = 인라인 가드 `getDbProvider()==='supabase' ? await createServiceClient() : undefined` 후 `createXRepository(client)`.
+  - ✅ **이미 가드 적용**(감사 과대계산 정정): health·user-api-keys·proxy 진입(L270)·suggest-modification·preview / **eventPersister**(이번에 sqlite 버그 수정·패턴 확립).
+  - ⬜ **남은 실작업**: **proxy 내부 헬퍼**(raw `.from('projects')`·`.from('user_api_keys')` → repo) — hot path / **admin 4종**(qc-stats: platform_events 집계×4·keys-verify: api_catalog·test-generation·trigger-qc — 가드 미적용, 일부 새 repo 메서드 필요) / **settings/api-keys 페이지**(user_api_keys).
+  - 이연: `callback`(raw `.from('users')`)은 Supabase Auth OAuth 전용 아티팩트(local 모드 미사용) → P2.4/Phase 8에서 제거. `.rpc()` 6은 Supabase 레포 내부(sqlite 레포는 트랜잭션으로 대체 완료) → Phase 8 supabase 제거 시 동반 소멸.
 - **컷오버 전 사용자 준비물**: Railway 영속 볼륨(P0.1), env `AUTH_SECRET`·`ADMIN_EMAIL`·`ADMIN_PASSWORD_HASH`(`pnpm admin:hash`로 생성)·(선택)`ADMIN_NAME`·`SQLITE_PATH`·`ADMIN_USER_ID`.
 
 ## 1. 목표 & 확정 제약

--- a/drizzle.config.sqlite.ts
+++ b/drizzle.config.sqlite.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'drizzle-kit';
+
+// 임베디드 SQLite 경로용 drizzle-kit 설정 (DB_PROVIDER=sqlite).
+// 마이그레이션 산출물은 ./drizzle/sqlite 에 생성·커밋한다.
+export default {
+  schema: './src/lib/db/sqlite/schema.ts',
+  out: './drizzle/sqlite',
+  dialect: 'sqlite',
+  dbCredentials: {
+    url: process.env.SQLITE_PATH ?? './data/app.db',
+  },
+} satisfies Config;

--- a/drizzle/sqlite/0000_flaky_roulette.sql
+++ b/drizzle/sqlite/0000_flaky_roulette.sql
@@ -1,0 +1,138 @@
+CREATE TABLE `api_catalog` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`category` text,
+	`base_url` text,
+	`auth_type` text DEFAULT 'none',
+	`auth_config` text,
+	`rate_limit` text,
+	`changelog` text,
+	`is_active` integer DEFAULT true,
+	`icon_url` text,
+	`docs_url` text,
+	`endpoints` text,
+	`tags` text,
+	`api_version` text,
+	`deprecated_at` text,
+	`successor_id` text,
+	`cors_supported` integer DEFAULT true,
+	`requires_proxy` integer DEFAULT false,
+	`credit_required` integer,
+	`cache_ttl_seconds` integer,
+	`verification_status` text DEFAULT 'unverified',
+	`verified_at` text,
+	`last_verification_note` text,
+	`created_at` text,
+	`updated_at` text
+);
+--> statement-breakpoint
+CREATE TABLE `feature_flags` (
+	`id` text PRIMARY KEY NOT NULL,
+	`flag_name` text NOT NULL,
+	`enabled` integer DEFAULT false,
+	`description` text,
+	`rules` text,
+	`updated_at` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `feature_flags_flag_name_unique` ON `feature_flags` (`flag_name`);--> statement-breakpoint
+CREATE TABLE `generated_codes` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`version` integer NOT NULL,
+	`code_html` text,
+	`code_css` text,
+	`code_js` text,
+	`framework` text DEFAULT 'vanilla',
+	`ai_provider` text,
+	`ai_model` text,
+	`ai_prompt_used` text,
+	`generation_time_ms` integer,
+	`token_usage` text,
+	`dependencies` text,
+	`metadata` text,
+	`created_at` text,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `generated_codes_project_id_version_unique` ON `generated_codes` (`project_id`,`version`);--> statement-breakpoint
+CREATE TABLE `platform_events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`type` text NOT NULL,
+	`payload` text,
+	`user_id` text,
+	`project_id` text,
+	`created_at` text,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `project_apis` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`api_id` text NOT NULL,
+	`config` text,
+	`created_at` text,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`api_id`) REFERENCES `api_catalog`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `project_apis_project_id_api_id_unique` ON `project_apis` (`project_id`,`api_id`);--> statement-breakpoint
+CREATE TABLE `projects` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`organization_id` text,
+	`name` text NOT NULL,
+	`context` text,
+	`status` text DEFAULT 'draft',
+	`deploy_url` text,
+	`deploy_platform` text,
+	`repo_url` text,
+	`preview_url` text,
+	`metadata` text,
+	`current_version` integer DEFAULT 0,
+	`slug` text,
+	`suggested_slugs` text,
+	`published_at` text,
+	`created_at` text,
+	`updated_at` text,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `user_api_keys` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`api_id` text NOT NULL,
+	`encrypted_key` text NOT NULL,
+	`is_verified` integer DEFAULT false,
+	`verified_at` text,
+	`created_at` text,
+	`updated_at` text,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`api_id`) REFERENCES `api_catalog`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_api_keys_user_id_api_id_unique` ON `user_api_keys` (`user_id`,`api_id`);--> statement-breakpoint
+CREATE TABLE `user_daily_limits` (
+	`user_id` text NOT NULL,
+	`usage_date` text NOT NULL,
+	`generation_count` integer DEFAULT 0,
+	`deploy_count` integer DEFAULT 0,
+	PRIMARY KEY(`user_id`, `usage_date`),
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `users` (
+	`id` text PRIMARY KEY NOT NULL,
+	`email` text NOT NULL,
+	`name` text,
+	`avatar_url` text,
+	`email_verified` text,
+	`image` text,
+	`preferences` text,
+	`created_at` text,
+	`updated_at` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `users_email_unique` ON `users` (`email`);

--- a/drizzle/sqlite/meta/0000_snapshot.json
+++ b/drizzle/sqlite/meta/0000_snapshot.json
@@ -1,0 +1,966 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "baff95eb-8fe5-4cdf-8017-53c7aabf0be4",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "api_catalog": {
+      "name": "api_catalog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changelog": {
+          "name": "changelog",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "docs_url": {
+          "name": "docs_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoints": {
+          "name": "endpoints",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_version": {
+          "name": "api_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deprecated_at": {
+          "name": "deprecated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "successor_id": {
+          "name": "successor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cors_supported": {
+          "name": "cors_supported",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "requires_proxy": {
+          "name": "requires_proxy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "credit_required": {
+          "name": "credit_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_ttl_seconds": {
+          "name": "cache_ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'unverified'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_verification_note": {
+          "name": "last_verification_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feature_flags": {
+      "name": "feature_flags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flag_name": {
+          "name": "flag_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "feature_flags_flag_name_unique": {
+          "name": "feature_flags_flag_name_unique",
+          "columns": [
+            "flag_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "generated_codes": {
+      "name": "generated_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_html": {
+          "name": "code_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code_css": {
+          "name": "code_css",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code_js": {
+          "name": "code_js",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "framework": {
+          "name": "framework",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'vanilla'"
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_prompt_used": {
+          "name": "ai_prompt_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation_time_ms": {
+          "name": "generation_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_usage": {
+          "name": "token_usage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "generated_codes_project_id_version_unique": {
+          "name": "generated_codes_project_id_version_unique",
+          "columns": [
+            "project_id",
+            "version"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "generated_codes_project_id_projects_id_fk": {
+          "name": "generated_codes_project_id_projects_id_fk",
+          "tableFrom": "generated_codes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "platform_events": {
+      "name": "platform_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "platform_events_user_id_users_id_fk": {
+          "name": "platform_events_user_id_users_id_fk",
+          "tableFrom": "platform_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "platform_events_project_id_projects_id_fk": {
+          "name": "platform_events_project_id_projects_id_fk",
+          "tableFrom": "platform_events",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_apis": {
+      "name": "project_apis",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_id": {
+          "name": "api_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_apis_project_id_api_id_unique": {
+          "name": "project_apis_project_id_api_id_unique",
+          "columns": [
+            "project_id",
+            "api_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_apis_project_id_projects_id_fk": {
+          "name": "project_apis_project_id_projects_id_fk",
+          "tableFrom": "project_apis",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "project_apis_api_id_api_catalog_id_fk": {
+          "name": "project_apis_api_id_api_catalog_id_fk",
+          "tableFrom": "project_apis",
+          "tableTo": "api_catalog",
+          "columnsFrom": [
+            "api_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "deploy_url": {
+          "name": "deploy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deploy_platform": {
+          "name": "deploy_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_url": {
+          "name": "preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suggested_slugs": {
+          "name": "suggested_slugs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_api_keys": {
+      "name": "user_api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_id": {
+          "name": "api_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_api_keys_user_id_api_id_unique": {
+          "name": "user_api_keys_user_id_api_id_unique",
+          "columns": [
+            "user_id",
+            "api_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_api_keys_user_id_users_id_fk": {
+          "name": "user_api_keys_user_id_users_id_fk",
+          "tableFrom": "user_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_api_keys_api_id_api_catalog_id_fk": {
+          "name": "user_api_keys_api_id_api_catalog_id_fk",
+          "tableFrom": "user_api_keys",
+          "tableTo": "api_catalog",
+          "columnsFrom": [
+            "api_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_daily_limits": {
+      "name": "user_daily_limits",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage_date": {
+          "name": "usage_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation_count": {
+          "name": "generation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deploy_count": {
+          "name": "deploy_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_daily_limits_user_id_users_id_fk": {
+          "name": "user_daily_limits_user_id_users_id_fk",
+          "tableFrom": "user_daily_limits",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_daily_limits_user_id_usage_date_pk": {
+          "columns": [
+            "user_id",
+            "usage_date"
+          ],
+          "name": "user_daily_limits_user_id_usage_date_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/sqlite/meta/_journal.json
+++ b/drizzle/sqlite/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1782140740768,
+      "tag": "0000_flaky_roulette",
+      "breakpoints": true
+    }
+  ]
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,9 +4,10 @@ import { withSentryConfig } from '@sentry/nextjs';
 const nextConfig: NextConfig = {
   output: 'standalone',
   poweredByHeader: false,
-  // playwright-core is used only for rendering QC (ENABLE_RENDERING_QC=true).
-  // It must not be bundled by webpack — standalone mode copies it to node_modules.
-  serverExternalPackages: ['playwright-core'],
+  // playwright-core: rendering QC 전용(ENABLE_RENDERING_QC=true).
+  // better-sqlite3: 네이티브 모듈(DB_PROVIDER=sqlite). 둘 다 webpack 번들 금지 —
+  // standalone 모드가 node_modules로 복사하고, 네이티브 .node 바인딩이 보존된다.
+  serverExternalPackages: ['playwright-core', 'better-sqlite3'],
   images: {
     remotePatterns: [
       { protocol: 'https', hostname: '*.supabase.co' },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@sentry/nextjs": "^10.59.0",
     "@supabase/ssr": "^0.12.0",
     "@supabase/supabase-js": "^2.108.2",
+    "better-sqlite3": "^12.11.1",
     "drizzle-orm": "^0.45.2",
     "isomorphic-dompurify": "^3.18.0",
     "libsodium-wrappers": "^0.8.4",
@@ -55,6 +56,7 @@
     "@tailwindcss/postcss": "^4.3.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.9.2",
     "@types/pg": "^8.20.0",
     "@types/react": "^19.2.17",
@@ -77,6 +79,9 @@
     "overrides": {
       "vite": "^8.0.16",
       "undici": "^7.28.0"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:prod": "pnpm build && node -e \"const s=require('child_process').spawn('node',['.next/standalone/server.js'],{stdio:'inherit'});setTimeout(()=>{const h=require('http');h.get('http://localhost:3000/api/v1/health',r=>{console.log('healthcheck:',r.statusCode);s.kill();process.exit(r.statusCode===200?0:1)}).on('error',e=>{console.error('FAIL',e.message);s.kill();process.exit(1)})},4000)\"",
     "catalog:healthcheck": "tsx scripts/verifyCatalog.ts",
     "catalog:healthcheck:write": "tsx scripts/verifyCatalog.ts --write",
-    "keys:verify": "tsx scripts/verifyPlatformKeys.ts"
+    "keys:verify": "tsx scripts/verifyPlatformKeys.ts",
+    "admin:hash": "tsx scripts/hashAdminPassword.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.105.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "catalog:healthcheck:write": "tsx scripts/verifyCatalog.ts --write",
     "keys:verify": "tsx scripts/verifyPlatformKeys.ts",
     "admin:hash": "tsx scripts/hashAdminPassword.ts",
-    "seed:generate": "tsx scripts/generateSqliteSeed.ts"
+    "seed:generate": "tsx scripts/generateSqliteSeed.ts",
+    "cutover:migrate": "tsx scripts/migrateSupabaseToSqlite.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.105.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "catalog:healthcheck": "tsx scripts/verifyCatalog.ts",
     "catalog:healthcheck:write": "tsx scripts/verifyCatalog.ts --write",
     "keys:verify": "tsx scripts/verifyPlatformKeys.ts",
-    "admin:hash": "tsx scripts/hashAdminPassword.ts"
+    "admin:hash": "tsx scripts/hashAdminPassword.ts",
+    "seed:generate": "tsx scripts/generateSqliteSeed.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.105.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,9 +39,12 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.108.2
         version: 2.108.2
+      better-sqlite3:
+        specifier: ^12.11.1
+        version: 12.11.1
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(pg@8.22.0)
       isomorphic-dompurify:
         specifier: ^3.18.0
         version: 3.18.0
@@ -94,6 +97,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
@@ -910,89 +916,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1110,24 +1132,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.9':
     resolution: {integrity: sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.9':
     resolution: {integrity: sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.9':
     resolution: {integrity: sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.9':
     resolution: {integrity: sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==}
@@ -1251,36 +1277,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -1360,66 +1392,79 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -1688,24 +1733,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
     resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
     resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
@@ -1768,6 +1817,9 @@ packages:
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1918,51 +1970,61 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -2241,13 +2303,26 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.38:
     resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
@@ -2271,6 +2346,9 @@ packages:
   buffer-image-size@0.6.4:
     resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
     engines: {node: '>=4.0'}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2297,6 +2375,9 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -2388,6 +2469,14 @@ packages:
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -2530,6 +2619,9 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
@@ -2751,6 +2843,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -2799,6 +2895,9 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -2820,6 +2919,9 @@ packages:
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -2870,6 +2972,9 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2964,6 +3069,9 @@ packages:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2983,6 +3091,12 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -3256,24 +3370,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3359,6 +3477,10 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -3372,6 +3494,9 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
@@ -3402,6 +3527,9 @@ packages:
     resolution: {integrity: sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
@@ -3450,6 +3578,10 @@ packages:
         optional: true
       sass:
         optional: true
+
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
 
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
@@ -3505,6 +3637,9 @@ packages:
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3650,6 +3785,12 @@ packages:
   preact@10.24.3:
     resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -3668,12 +3809,19 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
@@ -3695,6 +3843,10 @@ packages:
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -3751,6 +3903,9 @@ packages:
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -3833,6 +3988,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3902,6 +4063,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -3909,6 +4073,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -3951,6 +4119,13 @@ packages:
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
   terser-webpack-plugin@5.6.1:
@@ -4058,6 +4233,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -4123,6 +4301,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -4285,6 +4466,9 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -5656,6 +5840,10 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 25.9.4
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -6190,11 +6378,28 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.38: {}
+
+  better-sqlite3@12.11.1:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
 
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   brace-expansion@1.1.14:
     dependencies:
@@ -6223,6 +6428,11 @@ snapshots:
     dependencies:
       '@types/node': 25.9.2
 
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -6247,6 +6457,8 @@ snapshots:
   caniuse-lite@1.0.30001799: {}
 
   chai@6.2.2: {}
+
+  chownr@1.1.4: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -6328,6 +6540,12 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -6365,10 +6583,12 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.22.4
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(pg@8.22.0):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
+      '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.20.0
+      better-sqlite3: 12.11.1
       pg: 8.22.0
 
   dunder-proto@1.0.1:
@@ -6382,6 +6602,10 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.21.6:
     dependencies:
@@ -6820,6 +7044,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -6862,6 +7088,8 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -6883,6 +7111,8 @@ snapshots:
       is-callable: 1.2.7
 
   fraction.js@5.3.4: {}
+
+  fs-constants@1.0.0: {}
 
   fsevents@2.3.2:
     optional: true
@@ -6943,6 +7173,8 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -7038,6 +7270,8 @@ snapshots:
 
   iceberg-js@0.8.1: {}
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -7055,6 +7289,10 @@ snapshots:
       module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -7423,6 +7661,8 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-response@3.1.0: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -7434,6 +7674,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
+
+  mkdirp-classic@0.5.3: {}
 
   module-details-from-path@1.0.4: {}
 
@@ -7469,6 +7711,8 @@ snapshots:
   nanoid@3.3.12: {}
 
   nanoid@3.3.14: {}
+
+  napi-build-utils@2.0.0: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -7507,6 +7751,10 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.8.5
 
   node-exports-info@1.6.0:
     dependencies:
@@ -7566,6 +7814,10 @@ snapshots:
       es-object-atoms: 1.1.2
 
   obug@2.1.3: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -7698,6 +7950,21 @@ snapshots:
 
   preact@10.24.3: {}
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.92.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   pretty-format@27.5.1:
@@ -7716,9 +7983,21 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
@@ -7734,6 +8013,12 @@ snapshots:
   react-is@17.0.2: {}
 
   react@19.2.7: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -7846,6 +8131,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
+
+  safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -7971,6 +8258,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -8063,11 +8358,17 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
 
   strip-bom@3.0.0: {}
+
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -8095,6 +8396,21 @@ snapshots:
   tailwindcss@4.3.1: {}
 
   tapable@2.3.3: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   terser-webpack-plugin@5.6.1(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.106.1(esbuild@0.28.0)(postcss@8.5.15)):
     dependencies:
@@ -8165,6 +8481,10 @@ snapshots:
       esbuild: 0.28.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   type-check@0.4.0:
     dependencies:
@@ -8271,6 +8591,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
 
   vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4):
     dependencies:
@@ -8447,6 +8769,8 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrappy@1.0.2: {}
 
   ws@8.21.0: {}
 

--- a/scripts/generateSqliteSeed.ts
+++ b/scripts/generateSqliteSeed.ts
@@ -1,0 +1,70 @@
+// scripts/generateSqliteSeed.ts
+// 프로덕션 api_catalog/feature_flags를 읽어 src/data/{apiCatalog,featureFlags}.json을 재생성한다.
+// 이 JSON은 SQLite 부팅 시드(src/lib/db/sqlite/seedCatalog.ts)가 import하는 원본이다
+// (countries.json 생성 패턴과 동일한 준-정적 산출물 — 커밋·번들).
+//
+// 실행: railway run pnpm seed:generate   (또는 .env.local에 SUPABASE 키 설정 후 pnpm seed:generate)
+// 키 값은 출력하지 않는다.
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// .env.local 로드 (verifyPlatformKeys.ts와 동일)
+const envPath = path.resolve(process.cwd(), '.env.local');
+if (fs.existsSync(envPath)) {
+  for (const line of fs.readFileSync(envPath, 'utf-8').replace(/^﻿/, '').replace(/\r/g, '').split('\n')) {
+    const t = line.trim();
+    if (!t || t.startsWith('#')) continue;
+    const i = t.indexOf('=');
+    if (i === -1) continue;
+    const k = t.slice(0, i).trim();
+    const v = t.slice(i + 1).trim().replace(/^["']|["']$/g, '');
+    if (k && !process.env[k]) process.env[k] = v;
+  }
+}
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY.');
+  process.exit(1);
+}
+
+// SQLite 스키마와 1:1 정렬되는 컬럼만 선택(seedCatalog가 그대로 insert).
+const CATALOG_COLUMNS = [
+  'id', 'name', 'description', 'category', 'base_url', 'auth_type', 'auth_config',
+  'rate_limit', 'changelog', 'is_active', 'icon_url', 'docs_url', 'endpoints', 'tags',
+  'api_version', 'deprecated_at', 'successor_id', 'cors_supported', 'requires_proxy',
+  'credit_required', 'cache_ttl_seconds', 'verification_status', 'verified_at',
+  'last_verification_note', 'created_at', 'updated_at',
+].join(',');
+
+async function main(): Promise<void> {
+  const supabase = createClient(SUPABASE_URL!, SUPABASE_KEY!);
+
+  const { data: catalog, error: e1 } = await supabase
+    .from('api_catalog')
+    .select(CATALOG_COLUMNS)
+    .order('category', { ascending: true })
+    .order('name', { ascending: true });
+  if (e1) throw e1;
+
+  const { data: flags, error: e2 } = await supabase
+    .from('feature_flags')
+    .select('flag_name,enabled,description,rules')
+    .order('flag_name', { ascending: true });
+  if (e2) throw e2;
+
+  const dataDir = path.resolve(process.cwd(), 'src/data');
+  fs.writeFileSync(path.join(dataDir, 'apiCatalog.json'), JSON.stringify(catalog ?? [], null, 2) + '\n', 'utf-8');
+  fs.writeFileSync(path.join(dataDir, 'featureFlags.json'), JSON.stringify(flags ?? [], null, 2) + '\n', 'utf-8');
+
+  const active = (catalog ?? []).filter((r) => (r as { is_active?: boolean }).is_active).length;
+  console.log(`✓ src/data/apiCatalog.json: ${catalog?.length ?? 0} rows (${active} active)`);
+  console.log(`✓ src/data/featureFlags.json: ${flags?.length ?? 0} flags`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/hashAdminPassword.ts
+++ b/scripts/hashAdminPassword.ts
@@ -1,0 +1,41 @@
+// scripts/hashAdminPassword.ts
+// 단일 관리자(AUTH_PROVIDER=local) 비밀번호의 scrypt 해시를 생성한다.
+//
+// 사용법:
+//   pnpm admin:hash '<평문 비밀번호>'
+//   # 또는 (CI/비대화식) 환경변수로:
+//   ADMIN_PASSWORD='<평문>' pnpm admin:hash
+//
+// 출력된 "salt:hash" 값을 배포 환경변수 ADMIN_PASSWORD_HASH 에 등록한다.
+// 평문 비밀번호는 어디에도 저장·출력하지 않는다 (해시만 stdout으로 출력).
+//
+// 검증 로직은 src/lib/auth/adminCredentials.ts(hashPassword, 단위 테스트 대상)에 위임한다.
+
+import { hashPassword, verifyPassword } from '../src/lib/auth/adminCredentials';
+
+const password = process.argv[2] ?? process.env.ADMIN_PASSWORD ?? '';
+
+if (!password.trim()) {
+  console.error('비밀번호가 비어 있습니다.');
+  console.error("사용법: pnpm admin:hash '<평문 비밀번호>'");
+  console.error("   또는: ADMIN_PASSWORD='<평문>' pnpm admin:hash");
+  process.exit(1);
+}
+
+const hash = hashPassword(password);
+
+// 자가 검증 — 생성한 해시가 실제로 round-trip 되는지 확인(설정 실수 조기 차단).
+if (!verifyPassword(password, hash)) {
+  console.error('내부 오류: 생성된 해시 검증에 실패했습니다.');
+  process.exit(1);
+}
+
+console.log('\n# ── 단일 관리자 비밀번호 해시 (AUTH_PROVIDER=local) ──');
+console.log('# 아래 값을 배포 환경변수 ADMIN_PASSWORD_HASH 에 등록하세요.');
+console.log(`ADMIN_PASSWORD_HASH=${hash}`);
+console.log('\n# 함께 설정해야 하는 변수:');
+console.log('#   AUTH_PROVIDER=local');
+console.log('#   AUTH_SECRET=<openssl rand -base64 32 로 생성한 임의 시크릿>');
+console.log('#   ADMIN_EMAIL=<로그인 이메일>');
+console.log('#   (선택) ADMIN_NAME=<표시 이름>, ADMIN_USER_ID=<고정 UUID>');
+console.log('');

--- a/scripts/migrateSupabaseToSqlite.ts
+++ b/scripts/migrateSupabaseToSqlite.ts
@@ -1,0 +1,179 @@
+// scripts/migrateSupabaseToSqlite.ts
+// (선택적, P8.1) 기존 Supabase 프로덕션 데이터를 단일-사용자 SQLite로 이관한다.
+// 셀프호스트 신규 시작이면 불필요 — 부팅 시 카탈로그·관리자만 시드되면 충분하다.
+//
+// 동작: 완결적(self-contained) — 대상 SQLite 파일을 만들고 마이그레이션 + 카탈로그/플래그/관리자
+// 시드(번들 JSON) + Supabase 사용자 데이터(projects·project_apis·generated_codes·user_api_keys·
+// user_daily_limits)를 복사한다. 모든 user_id는 단일 관리자(ADMIN_USER_ID)로 리맵한다.
+// 산출된 app.db를 Railway 볼륨(/data/app.db)으로 올리면 된다. 앱 부팅의 시드는 멱등이라 충돌 없음.
+//
+// 사용: railway run pnpm tsx scripts/migrateSupabaseToSqlite.ts --out ./app.db [--user <supabaseUserId>]
+//   (또는 .env.local 에 NEXT_PUBLIC_SUPABASE_URL·SUPABASE_SERVICE_ROLE_KEY 설정)
+// ⚠️ user_api_keys.encrypted_key는 ENCRYPTION_KEY로 암호화돼 있다 — 새 배포가 동일 ENCRYPTION_KEY를
+//    써야 복호화된다. catalog api_id는 번들 카탈로그가 프로덕션 id를 보존하므로 FK가 해소된다.
+import { createClient } from '@supabase/supabase-js';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import * as fs from 'fs';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+
+// ── .env.local 로드 (verifyPlatformKeys.ts와 동일) ──
+const envPath = path.resolve(process.cwd(), '.env.local');
+if (fs.existsSync(envPath)) {
+  for (const line of fs.readFileSync(envPath, 'utf-8').replace(/^﻿/, '').replace(/\r/g, '').split('\n')) {
+    const t = line.trim();
+    if (!t || t.startsWith('#')) continue;
+    const i = t.indexOf('=');
+    if (i === -1) continue;
+    const k = t.slice(0, i).trim();
+    const v = t.slice(i + 1).trim().replace(/^["']|["']$/g, '');
+    if (k && !process.env[k]) process.env[k] = v;
+  }
+}
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(name);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+const OUT = arg('--out') ?? './app.db';
+const USER_FILTER = arg('--user'); // 지정 시 해당 Supabase user의 데이터만 이관(슬러그 충돌 회피 권장)
+const ADMIN_USER_ID = process.env.ADMIN_USER_ID ?? '00000000-0000-0000-0000-000000000001';
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL ?? 'admin@example.com';
+const ADMIN_NAME = process.env.ADMIN_NAME ?? 'Admin';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY.');
+  process.exit(1);
+}
+
+// 컬럼별 변환: object→JSON 문자열, boolean→0/1, undefined→null
+function coerce(v: unknown): unknown {
+  if (v === undefined) return null;
+  if (v !== null && typeof v === 'object') return JSON.stringify(v);
+  if (typeof v === 'boolean') return v ? 1 : 0;
+  return v;
+}
+
+function makeInserter(db: Database.Database, table: string, columns: string[]) {
+  const stmt = db.prepare(
+    `INSERT OR IGNORE INTO ${table} (${columns.join(',')}) VALUES (${columns.map(() => '?').join(',')})`,
+  );
+  return (row: Record<string, unknown>): void => {
+    stmt.run(...columns.map((c) => coerce(row[c])));
+  };
+}
+
+const CATALOG_COLS = [
+  'id', 'name', 'description', 'category', 'base_url', 'auth_type', 'auth_config', 'rate_limit',
+  'changelog', 'is_active', 'icon_url', 'docs_url', 'endpoints', 'tags', 'api_version',
+  'deprecated_at', 'successor_id', 'cors_supported', 'requires_proxy', 'credit_required',
+  'cache_ttl_seconds', 'verification_status', 'verified_at', 'last_verification_note',
+  'created_at', 'updated_at',
+];
+const PROJECT_COLS = [
+  'id', 'user_id', 'organization_id', 'name', 'context', 'status', 'deploy_url', 'deploy_platform',
+  'repo_url', 'preview_url', 'metadata', 'current_version', 'slug', 'suggested_slugs',
+  'published_at', 'created_at', 'updated_at',
+];
+const PROJECT_API_COLS = ['id', 'project_id', 'api_id', 'config', 'created_at'];
+const CODE_COLS = [
+  'id', 'project_id', 'version', 'code_html', 'code_css', 'code_js', 'framework', 'ai_provider',
+  'ai_model', 'ai_prompt_used', 'generation_time_ms', 'token_usage', 'dependencies', 'metadata',
+  'created_at',
+];
+const KEY_COLS = ['id', 'user_id', 'api_id', 'encrypted_key', 'is_verified', 'verified_at', 'created_at', 'updated_at'];
+const LIMIT_COLS = ['user_id', 'usage_date', 'generation_count', 'deploy_count'];
+
+async function main(): Promise<void> {
+  const supabase = createClient(SUPABASE_URL!, SUPABASE_KEY!);
+
+  // ── 대상 SQLite 생성 + 마이그레이션 ──
+  if (fs.existsSync(OUT)) {
+    console.error(`대상 파일이 이미 존재합니다: ${OUT} (덮어쓰지 않습니다. 삭제 후 재실행)`);
+    process.exit(1);
+  }
+  const db = new Database(OUT);
+  db.pragma('foreign_keys = ON');
+  migrate(drizzle(db), { migrationsFolder: './drizzle/sqlite' });
+
+  // ── 카탈로그/플래그/관리자 시드(번들 JSON, FK 해소용) ──
+  const catalog = JSON.parse(fs.readFileSync('./src/data/apiCatalog.json', 'utf-8')) as Record<string, unknown>[];
+  const insCatalog = makeInserter(db, 'api_catalog', CATALOG_COLS);
+  for (const r of catalog) insCatalog(r);
+
+  const flags = JSON.parse(fs.readFileSync('./src/data/featureFlags.json', 'utf-8')) as Record<string, unknown>[];
+  const insFlag = makeInserter(db, 'feature_flags', ['id', 'flag_name', 'enabled', 'description', 'rules', 'updated_at']);
+  const nowIso = new Date().toISOString();
+  for (const r of flags) insFlag({ id: randomUUID(), updated_at: nowIso, ...r });
+
+  db.prepare('INSERT OR IGNORE INTO users (id,email,name,created_at,updated_at) VALUES (?,?,?,?,?)').run(
+    ADMIN_USER_ID, ADMIN_EMAIL, ADMIN_NAME, nowIso, nowIso,
+  );
+
+  // ── Supabase 사용자 데이터 읽기(선택적 user 필터) ──
+  let pq = supabase.from('projects').select('*');
+  if (USER_FILTER) pq = pq.eq('user_id', USER_FILTER);
+  const { data: projects, error: pe } = await pq;
+  if (pe) throw pe;
+  const projectIds = (projects ?? []).map((p) => p.id as string);
+
+  const insProject = makeInserter(db, 'projects', PROJECT_COLS);
+  for (const p of projects ?? []) insProject({ ...p, user_id: ADMIN_USER_ID });
+
+  // project_apis / generated_codes 는 이관된 project로 한정
+  const inChunks = async (
+    table: string,
+    fk: string,
+    ids: string[],
+    cb: (rows: Record<string, unknown>[]) => void,
+  ): Promise<void> => {
+    for (let i = 0; i < ids.length; i += 100) {
+      const slice = ids.slice(i, i + 100);
+      const { data, error } = await supabase.from(table).select('*').in(fk, slice);
+      if (error) throw error;
+      cb(data ?? []);
+    }
+  };
+
+  const insProjectApi = makeInserter(db, 'project_apis', PROJECT_API_COLS);
+  await inChunks('project_apis', 'project_id', projectIds, (rows) => rows.forEach(insProjectApi));
+
+  const insCode = makeInserter(db, 'generated_codes', CODE_COLS);
+  await inChunks('generated_codes', 'project_id', projectIds, (rows) => rows.forEach(insCode));
+
+  // user_api_keys / user_daily_limits — user 필터, admin으로 리맵
+  let kq = supabase.from('user_api_keys').select('*');
+  if (USER_FILTER) kq = kq.eq('user_id', USER_FILTER);
+  const { data: keys, error: ke } = await kq;
+  if (ke) throw ke;
+  const insKey = makeInserter(db, 'user_api_keys', KEY_COLS);
+  for (const k of keys ?? []) insKey({ ...k, user_id: ADMIN_USER_ID });
+
+  let lq = supabase.from('user_daily_limits').select('*');
+  if (USER_FILTER) lq = lq.eq('user_id', USER_FILTER);
+  const { data: limits, error: le } = await lq;
+  if (le) throw le;
+  const insLimit = makeInserter(db, 'user_daily_limits', LIMIT_COLS);
+  for (const l of limits ?? []) insLimit({ ...l, user_id: ADMIN_USER_ID });
+
+  // ── 검증 리포트 ──
+  const count = (t: string): number => (db.prepare(`SELECT count(*) c FROM ${t}`).get() as { c: number }).c;
+  console.log('── 이관 완료 ──');
+  console.log(`대상: ${OUT}`);
+  console.log(`api_catalog=${count('api_catalog')} feature_flags=${count('feature_flags')} users=${count('users')}`);
+  console.log(`projects=${count('projects')} project_apis=${count('project_apis')} generated_codes=${count('generated_codes')}`);
+  console.log(`user_api_keys=${count('user_api_keys')} user_daily_limits=${count('user_daily_limits')}`);
+  console.log(`모든 user_id → ${ADMIN_USER_ID} 로 리맵됨${USER_FILTER ? ` (필터 user=${USER_FILTER})` : ' (전체 사용자)'}`);
+  console.log('이 파일을 Railway 볼륨 /data/app.db 로 업로드한 뒤 DB_PROVIDER=sqlite로 배포하세요.');
+  db.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/__tests__/api/admin-keys-verify.test.ts
+++ b/src/__tests__/api/admin-keys-verify.test.ts
@@ -1,25 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// 카탈로그 행 1개(키 의존)를 반환하는 supabase 체인 모킹
-const keyedRow = {
+// 카탈로그 레포가 반환하는 도메인 항목(키 의존 1개) — camelCase
+const keyedItem = {
+  id: 'cat-1',
   name: '카카오 로컬 (지도·장소 검색)',
-  base_url: 'https://dapi.kakao.com',
-  auth_type: 'api_key',
-  auth_config: { env_var: 'API_KEY_TEST', param_in: 'header', param_name: 'Authorization', prefix: 'KakaoAK ' },
+  baseUrl: 'https://dapi.kakao.com',
+  authType: 'api_key',
+  authConfig: { env_var: 'API_KEY_TEST', param_in: 'header', param_name: 'Authorization', prefix: 'KakaoAK ' },
   endpoints: [{ path: '/v2/local/search/keyword.json', method: 'GET', parameters: { query: 'string' } }],
+  isActive: true,
 };
 
-const mockChain = {
-  select: vi.fn().mockReturnThis(),
-  eq: vi.fn().mockReturnThis(),
-  order: vi.fn().mockResolvedValue({ data: [keyedRow], error: null }),
-};
+const findMany = vi.fn();
 
-vi.mock('@/lib/supabase/server', () => ({
-  createServiceClient: vi.fn().mockResolvedValue({
-    from: vi.fn().mockReturnValue(mockChain),
-  }),
-}));
+vi.mock('@/lib/config/providers', () => ({ getDbProvider: vi.fn(() => 'supabase') }));
+vi.mock('@/repositories/factory', () => ({ createCatalogRepository: vi.fn(() => ({ findMany })) }));
+vi.mock('@/lib/supabase/server', () => ({ createServiceClient: vi.fn().mockResolvedValue({}) }));
 
 const VALID_ADMIN_KEY = 'test-admin-secret-key';
 
@@ -35,7 +31,7 @@ describe('GET /api/v1/admin/keys-verify', () => {
     vi.resetModules();
     process.env.ADMIN_API_KEY = VALID_ADMIN_KEY;
     delete process.env.API_KEY_TEST;
-    mockChain.order.mockResolvedValue({ data: [keyedRow], error: null });
+    findMany.mockResolvedValue({ items: [keyedItem], total: 1 });
   });
 
   it('Authorization 헤더 없음 → 403', async () => {

--- a/src/__tests__/api/admin-test-generation.test.ts
+++ b/src/__tests__/api/admin-test-generation.test.ts
@@ -46,6 +46,11 @@ vi.mock('@/lib/supabase/server', () => ({
   createServiceClient: vi.fn().mockResolvedValue({ from: vi.fn() }),
 }));
 
+// 라우트가 getDbProvider를 import한다(Phase 3). 모킹해 native pg cold-init을 차단(플래키 방지).
+vi.mock('@/lib/config/providers', () => ({
+  getDbProvider: vi.fn().mockReturnValue('supabase'),
+}));
+
 vi.mock('@/services/factory', () => ({
   createCatalogService: vi.fn(() => catalogServiceMock),
   createProjectService: vi.fn(() => ({ updateStatus: vi.fn().mockResolvedValue(undefined) })),

--- a/src/__tests__/api/admin.test.ts
+++ b/src/__tests__/api/admin.test.ts
@@ -13,6 +13,11 @@ vi.mock('@/lib/supabase/server', () => ({
   }),
 }));
 
+// qc-stats·trigger-qc 라우트가 getDbProvider를 import한다(Phase 3). 모킹해 native cold-init 차단.
+vi.mock('@/lib/config/providers', () => ({
+  getDbProvider: vi.fn().mockReturnValue('supabase'),
+}));
+
 vi.mock('@/repositories/codeRepository', () => ({
   CodeRepository: vi.fn(function() {
     return {

--- a/src/__tests__/api/auth-nextauth-route.test.ts
+++ b/src/__tests__/api/auth-nextauth-route.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * /api/auth/[...nextauth] 라우트 — AUTH_PROVIDER에 따른 핸들러 디스패치 검증.
+ *
+ * 전체/edge config는 module-load 시 NextAuth를 초기화하므로 mock한다. supabase 모드에서는
+ * 어떤 NextAuth config도 동적 import 되지 않아야 한다(404).
+ */
+const localHandlers = { GET: vi.fn(), POST: vi.fn() };
+const authjsHandlers = { GET: vi.fn(), POST: vi.fn() };
+
+vi.mock('@/lib/auth/local-auth-config', () => ({ handlers: localHandlers }));
+vi.mock('@/lib/auth/authjs-config', () => ({ handlers: authjsHandlers }));
+
+describe('/api/auth/[...nextauth] dispatch', () => {
+  const ORIG = process.env.AUTH_PROVIDER;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (ORIG === undefined) delete process.env.AUTH_PROVIDER;
+    else process.env.AUTH_PROVIDER = ORIG;
+  });
+
+  it('supabase/미설정 모드는 404를 반환하고 NextAuth를 로드하지 않는다', async () => {
+    delete process.env.AUTH_PROVIDER;
+    const { GET } = await import('@/app/api/auth/[...nextauth]/route');
+    const res = await GET(new Request('http://localhost/api/auth/session') as never);
+    expect(res.status).toBe(404);
+    expect(localHandlers.GET).not.toHaveBeenCalled();
+    expect(authjsHandlers.GET).not.toHaveBeenCalled();
+  });
+
+  it('local 모드 GET은 local-auth-config 핸들러로 위임한다', async () => {
+    process.env.AUTH_PROVIDER = 'local';
+    const sentinel = new Response('ok');
+    localHandlers.GET.mockResolvedValue(sentinel);
+
+    const { GET } = await import('@/app/api/auth/[...nextauth]/route');
+    const req = new Request('http://localhost/api/auth/session');
+    const res = await GET(req as never);
+
+    expect(localHandlers.GET).toHaveBeenCalledWith(req);
+    expect(res).toBe(sentinel);
+  });
+
+  it('local 모드 POST(로그인)도 위임한다', async () => {
+    process.env.AUTH_PROVIDER = 'local';
+    const sentinel = new Response('ok');
+    localHandlers.POST.mockResolvedValue(sentinel);
+
+    const { POST } = await import('@/app/api/auth/[...nextauth]/route');
+    const req = new Request('http://localhost/api/auth/callback/credentials', { method: 'POST' });
+
+    expect(await POST(req as never)).toBe(sentinel);
+    expect(localHandlers.POST).toHaveBeenCalledWith(req);
+  });
+
+  it('authjs 모드는 authjs-config 핸들러로 위임한다', async () => {
+    process.env.AUTH_PROVIDER = 'authjs';
+    const sentinel = new Response('ok');
+    authjsHandlers.GET.mockResolvedValue(sentinel);
+
+    const { GET } = await import('@/app/api/auth/[...nextauth]/route');
+    expect(await GET(new Request('http://localhost/api/auth/session') as never)).toBe(sentinel);
+    expect(authjsHandlers.GET).toHaveBeenCalled();
+    expect(localHandlers.GET).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/api/proxy.test.ts
+++ b/src/__tests__/api/proxy.test.ts
@@ -13,6 +13,8 @@ vi.mock('@/lib/auth/index', () => ({
 
 vi.mock('@/repositories/factory', () => ({
   createCatalogRepository: vi.fn(),
+  createProjectRepository: vi.fn(),
+  createUserApiKeyRepository: vi.fn(),
 }));
 
 vi.mock('@/lib/config/providers', () => ({
@@ -439,23 +441,16 @@ describe('GET /api/v1/proxy', () => {
       };
       process.env.PLATFORM_API_KEY = 'platform-fallback-key';
 
-      const mockSupabase = {
-        from: vi.fn().mockReturnValue({
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              single: vi.fn().mockRejectedValue(new Error('DB 오류')),
-            }),
-          }),
-        }),
-      };
-
-      const { createCatalogRepository } = await import('@/repositories/factory');
+      const { createCatalogRepository, createProjectRepository } = await import(
+        '@/repositories/factory'
+      );
       vi.mocked(createCatalogRepository).mockReturnValue({
         findById: vi.fn().mockResolvedValue(apiWithKey),
       } as never);
-
-      const { createServiceClient } = await import('@/lib/supabase/server');
-      vi.mocked(createServiceClient).mockResolvedValue(mockSupabase as never);
+      // 프로젝트 조회 실패(레포 throw) → 플랫폼 키로 폴백
+      vi.mocked(createProjectRepository).mockReturnValue({
+        findById: vi.fn().mockRejectedValue(new Error('DB 오류')),
+      } as never);
 
       const url = new URL('http://localhost/api/v1/proxy');
       url.searchParams.set('apiId', VALID_API_ID);
@@ -486,45 +481,22 @@ describe('GET /api/v1/proxy', () => {
       };
       process.env.PLATFORM_FALLBACK_KEY = 'platform-key-value';
 
-      const mockSupabase = {
-        from: vi.fn().mockImplementation((table: string) => {
-          if (table === 'projects') {
-            return {
-              select: vi.fn().mockReturnValue({
-                eq: vi.fn().mockReturnValue({
-                  single: vi.fn().mockResolvedValue({ data: { user_id: 'owner-user-id' }, error: null }),
-                }),
-              }),
-            };
-          }
-          // user_api_keys 테이블 → encrypted_key 반환
-          return {
-            select: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                eq: vi.fn().mockReturnValue({
-                  single: vi.fn().mockResolvedValue({
-                    data: { encrypted_key: 'corrupted-cipher' },
-                    error: null,
-                  }),
-                }),
-              }),
-            }),
-          };
-        }),
-      };
-
       const { decryptApiKey } = await import('@/lib/encryption');
       vi.mocked(decryptApiKey).mockImplementationOnce(() => {
         throw new Error('복호화 실패');
       });
 
-      const { createCatalogRepository } = await import('@/repositories/factory');
+      const { createCatalogRepository, createProjectRepository, createUserApiKeyRepository } =
+        await import('@/repositories/factory');
       vi.mocked(createCatalogRepository).mockReturnValue({
         findById: vi.fn().mockResolvedValue(apiWithKey),
       } as never);
-
-      const { createServiceClient } = await import('@/lib/supabase/server');
-      vi.mocked(createServiceClient).mockResolvedValue(mockSupabase as never);
+      vi.mocked(createProjectRepository).mockReturnValue({
+        findById: vi.fn().mockResolvedValue({ id: 'p-1', userId: 'owner-user-id' }),
+      } as never);
+      vi.mocked(createUserApiKeyRepository).mockReturnValue({
+        findByUserAndApi: vi.fn().mockResolvedValue({ encryptedKey: 'corrupted-cipher' }),
+      } as never);
 
       const url = new URL('http://localhost/api/v1/proxy');
       url.searchParams.set('apiId', VALID_API_ID);
@@ -540,6 +512,46 @@ describe('GET /api/v1/proxy', () => {
       expect([200, 502]).toContain(res.status);
 
       delete process.env.PLATFORM_FALLBACK_KEY;
+    });
+
+    it('프로젝트 오너 개인 키를 레포로 조회해 복호화에 사용한다(모든 provider)', async () => {
+      const { getAuthUser } = await import('@/lib/auth/index');
+      vi.mocked(getAuthUser).mockResolvedValue(mockUser);
+
+      const apiWithKey = {
+        ...mockPublicApi,
+        authType: 'api_key',
+        authConfig: { param_name: 'X-API-Key', param_in: 'header', env_var: 'UNUSED_PLATFORM_KEY' },
+      };
+
+      const { createCatalogRepository, createProjectRepository, createUserApiKeyRepository } =
+        await import('@/repositories/factory');
+      vi.mocked(createCatalogRepository).mockReturnValue({
+        findById: vi.fn().mockResolvedValue(apiWithKey),
+      } as never);
+      vi.mocked(createProjectRepository).mockReturnValue({
+        findById: vi.fn().mockResolvedValue({ id: 'p-1', userId: 'owner-user-id' }),
+      } as never);
+      const findByUserAndApi = vi.fn().mockResolvedValue({ encryptedKey: 'enc-personal' });
+      vi.mocked(createUserApiKeyRepository).mockReturnValue({ findByUserAndApi } as never);
+
+      const { decryptApiKey } = await import('@/lib/encryption');
+      vi.mocked(decryptApiKey).mockReturnValue('decrypted-personal-key');
+
+      const url = new URL('http://localhost/api/v1/proxy');
+      url.searchParams.set('apiId', VALID_API_ID);
+      url.searchParams.set('proxyPath', '/data');
+      url.searchParams.set('projectId', 'aaaabbbb-cccc-dddd-eeee-111111111111');
+      const req = new Request(url.toString());
+
+      const { GET } = await import('@/app/api/v1/proxy/route');
+      const res = await GET(req);
+
+      // 개인 키가 레포 경로로 조회되어(raw .from 아님) 복호화에 사용됨
+      expect(findByUserAndApi).toHaveBeenCalledWith('owner-user-id', VALID_API_ID);
+      expect(decryptApiKey).toHaveBeenCalledWith('enc-personal');
+      expect(mockFetch).toHaveBeenCalled();
+      expect([200, 502]).toContain(res.status);
     });
 
     it('매우 긴 userId(1000자) 시 rate limit 정상 동작', async () => {

--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -98,3 +98,60 @@ describe('LoginPage OAuth redirect', () => {
     expect(mocks.signInWithOAuth).not.toHaveBeenCalled();
   });
 });
+
+describe('LoginPage local(Credentials) mode', () => {
+  const originalProvider = process.env.NEXT_PUBLIC_AUTH_PROVIDER;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = 'local';
+    setWindowUrl('https://xzawed.xyz/login');
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_AUTH_PROVIDER = originalProvider;
+  });
+
+  it('이메일/비밀번호 폼을 렌더하고 OAuth 버튼은 표시하지 않는다', () => {
+    renderComponent(<LoginPage />);
+
+    expect(screen.getByLabelText('이메일')).toBeTruthy();
+    expect(screen.getByLabelText('비밀번호')).toBeTruthy();
+    expect(screen.getByRole('button', { name: '로그인' })).toBeTruthy();
+    expect(screen.queryByText('Google로 계속하기')).toBeNull();
+    expect(screen.queryByText('GitHub로 계속하기')).toBeNull();
+  });
+
+  it('제출 시 credentials signIn을 redirect:false로 호출한다', async () => {
+    mocks.signIn.mockResolvedValue({ error: null, ok: true });
+    renderComponent(<LoginPage />);
+
+    const emailInput = screen.getByLabelText('이메일');
+    fireEvent.change(emailInput, { target: { value: 'admin@example.com' } });
+    fireEvent.change(screen.getByLabelText('비밀번호'), { target: { value: 'hunter2' } });
+    fireEvent.submit(emailInput.closest('form')!);
+
+    await waitFor(() => {
+      expect(mocks.signIn).toHaveBeenCalledWith('credentials', {
+        email: 'admin@example.com',
+        password: 'hunter2',
+        redirect: false,
+      });
+    });
+    expect(mocks.signInWithOAuth).not.toHaveBeenCalled();
+  });
+
+  it('자격증명 오류 시 에러 메시지를 표시한다', async () => {
+    mocks.signIn.mockResolvedValue({ error: 'CredentialsSignin' });
+    renderComponent(<LoginPage />);
+
+    const emailInput = screen.getByLabelText('이메일');
+    fireEvent.change(emailInput, { target: { value: 'admin@example.com' } });
+    fireEvent.change(screen.getByLabelText('비밀번호'), { target: { value: 'wrong' } });
+    fireEvent.submit(emailInput.closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByText('이메일 또는 비밀번호가 올바르지 않습니다.')).toBeTruthy();
+    });
+  });
+});

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -14,6 +14,29 @@ export default function LoginPage() {
   const [oauthError, setOauthError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<'google' | 'github' | null>(null);
 
+  // AUTH_PROVIDER=local (셀프호스트 단일 관리자) — OAuth 대신 Credentials(이메일/비번) 폼.
+  const isLocal = process.env.NEXT_PUBLIC_AUTH_PROVIDER === 'local';
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [credError, setCredError] = useState<string | null>(null);
+  const [credLoading, setCredLoading] = useState(false);
+
+  const handleCredentialsLogin = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setCredError(null);
+    setCredLoading(true);
+
+    const res = await signIn('credentials', { email, password, redirect: false });
+
+    if (res?.error) {
+      setCredError('이메일 또는 비밀번호가 올바르지 않습니다.');
+      setCredLoading(false);
+      return;
+    }
+
+    window.location.assign(getSafeRedirectParam() ?? '/dashboard');
+  };
+
   const handleOAuthLogin = async (provider: 'google' | 'github') => {
     setOauthError(null);
     setIsLoading(provider);
@@ -65,12 +88,56 @@ export default function LoginPage() {
           <p className="mt-2 text-sm text-slate-400">무료 API로 나만의 웹서비스를 만드세요</p>
         </div>
 
-        {oauthError && (
+        {(oauthError || credError) && (
           <div className="mb-4 rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-center text-sm text-rose-400">
-            {oauthError}
+            {oauthError ?? credError}
           </div>
         )}
 
+        {isLocal ? (
+          <form className="space-y-3" onSubmit={handleCredentialsLogin}>
+            <div className="space-y-1.5">
+              <label htmlFor="email" className="block text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                이메일
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="username"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full rounded-xl px-4 py-3 text-sm outline-none transition-all focus:ring-2 focus:ring-cyan-500/40"
+                style={{ background: 'var(--bg-card)', border: '1px solid var(--glass-border)', color: 'var(--text-primary)' }}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label htmlFor="password" className="block text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                비밀번호
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                autoComplete="current-password"
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full rounded-xl px-4 py-3 text-sm outline-none transition-all focus:ring-2 focus:ring-cyan-500/40"
+                style={{ background: 'var(--bg-card)', border: '1px solid var(--glass-border)', color: 'var(--text-primary)' }}
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={credLoading}
+              className="flex w-full items-center justify-center gap-3 rounded-xl px-4 py-3.5 text-sm font-semibold transition-all hover:shadow-lg disabled:cursor-not-allowed disabled:opacity-50"
+              style={{ background: 'var(--accent-gradient, linear-gradient(135deg,#06b6d4,#8b5cf6))', color: '#fff' }}
+            >
+              {credLoading ? '로그인 중...' : '로그인'}
+            </button>
+          </form>
+        ) : (
         <div className="space-y-3">
           <button
             type="button"
@@ -113,6 +180,7 @@ export default function LoginPage() {
             {isLoading === 'github' ? '로그인 중...' : 'GitHub로 계속하기'}
           </button>
         </div>
+        )}
 
         <p className="mt-6 text-center text-[11px] text-slate-500">
           로그인하면 <span className="text-slate-400 underline">이용약관</span>에 동의하는 것으로

--- a/src/app/(main)/settings/api-keys/page.tsx
+++ b/src/app/(main)/settings/api-keys/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'next/navigation';
 import { getAuthUser } from '@/lib/auth/index';
 import { getDbProvider } from '@/lib/config/providers';
 import { createClient } from '@/lib/supabase/server';
-import { createCatalogRepository } from '@/repositories/factory';
+import { createCatalogRepository, createUserApiKeyRepository } from '@/repositories/factory';
 import { decryptApiKey, maskApiKey } from '@/lib/encryption';
 import { ApiKeyPageClient } from './ApiKeyPageClient';
 
@@ -20,15 +20,8 @@ export default async function ApiKeysPage() {
   const { items: allApis } = await catalogRepo.findMany({ isActive: true }, { limit: 100 });
   const apiKeyApis = allApis.filter((api) => api.authType === 'api_key');
 
-  // 사용자가 이미 등록한 키 목록 (Supabase 전용 직접 조회)
-  let savedKeys: { api_id: string; encrypted_key: string; is_verified: boolean | null }[] = [];
-  if (supabase) {
-    const { data } = await supabase
-      .from('user_api_keys')
-      .select('api_id, encrypted_key, is_verified')
-      .eq('user_id', user.id);
-    savedKeys = data ?? [];
-  }
+  // 사용자가 이미 등록한 키 목록 (모든 provider — 레포 경유)
+  const savedKeys = await createUserApiKeyRepository(supabase).findAllByUser(user.id);
 
   return (
     <div className="mx-auto max-w-2xl px-4 py-10">
@@ -45,8 +38,8 @@ export default async function ApiKeysPage() {
         apis={apiKeyApis}
         initialSavedKeys={savedKeys.map((k) => {
           let maskedKey = '****';
-          try { maskedKey = maskApiKey(decryptApiKey(k.encrypted_key)); } catch { /* 복호화 실패 시 기본값 */ }
-          return { apiId: k.api_id, maskedKey, isVerified: k.is_verified ?? false };
+          try { maskedKey = maskApiKey(decryptApiKey(k.encryptedKey)); } catch { /* 복호화 실패 시 기본값 */ }
+          return { apiId: k.apiId, maskedKey, isVerified: k.isVerified };
         })}
       />
     </div>

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,38 @@
+import { type NextRequest } from 'next/server';
+
+// Auth.js v5 catch-all 라우트 — AUTH_PROVIDER에 따라 핸들러를 선택한다.
+// 이 라우트는 Node 런타임(기본)에서 실행되므로 node:crypto 의존(local-auth-config)이 안전하다.
+//
+// - local  → Credentials 단일 관리자(local-auth-config)
+// - authjs → OAuth + DrizzleAdapter(authjs-config)
+// - supabase/미설정 → 404 (Supabase Auth가 /callback에서 OAuth를 처리, NextAuth 미사용)
+//
+// 동적 import로 활성 provider의 config만 로드한다(supabase 모드는 NextAuth를 초기화하지 않음).
+
+type AuthRouteHandlers = {
+  GET: (req: Request) => Promise<Response>;
+  POST: (req: Request) => Promise<Response>;
+};
+
+async function resolveHandlers(): Promise<AuthRouteHandlers | null> {
+  const provider = process.env.AUTH_PROVIDER;
+  if (provider === 'local') {
+    return (await import('@/lib/auth/local-auth-config')).handlers as AuthRouteHandlers;
+  }
+  if (provider === 'authjs') {
+    return (await import('@/lib/auth/authjs-config')).handlers as AuthRouteHandlers;
+  }
+  return null;
+}
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const handlers = await resolveHandlers();
+  if (!handlers) return new Response('Not Found', { status: 404 });
+  return handlers.GET(req);
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const handlers = await resolveHandlers();
+  if (!handlers) return new Response('Not Found', { status: 404 });
+  return handlers.POST(req);
+}

--- a/src/app/api/v1/admin/keys-verify/route.ts
+++ b/src/app/api/v1/admin/keys-verify/route.ts
@@ -1,4 +1,6 @@
 import { createServiceClient } from '@/lib/supabase/server';
+import { getDbProvider } from '@/lib/config/providers';
+import { createCatalogRepository } from '@/repositories/factory';
 import { adminCorsHeaders, verifyAdminKey, withAdminCors } from '@/lib/utils/adminAuth';
 import { handleApiError, jsonResponse } from '@/lib/utils/errors';
 import { verifyApiKey, type KeyCheckApi, type KeyFetch, type KeyCheckResult } from '@/lib/catalog/keyCheck';
@@ -17,13 +19,6 @@ const realFetch: KeyFetch = async (url, headers) => {
   }
 };
 
-interface CatalogRow {
-  name: string;
-  base_url: string;
-  auth_config: KeyCheckApi['authConfig'] & { default_key?: string };
-  endpoints: KeyCheckApi['endpoints'];
-}
-
 export async function OPTIONS(): Promise<Response> {
   return new Response(null, { status: 204, headers: adminCorsHeaders });
 }
@@ -39,28 +34,30 @@ export async function GET(request: Request): Promise<Response> {
     try {
       verifyAdminKey(request);
 
-      const supabase = await createServiceClient();
-      const { data, error } = await supabase
-        .from('api_catalog')
-        .select('name, base_url, auth_type, auth_config, endpoints')
-        .eq('is_active', true)
-        .eq('auth_type', 'api_key')
-        .order('name', { ascending: true });
-      if (error) throw error;
+      // raw .from 대신 카탈로그 레포 경유(모든 provider). 활성 + auth_type=api_key 필터.
+      const supabase = getDbProvider() === 'supabase' ? await createServiceClient() : undefined;
+      const { items } = await createCatalogRepository(supabase).findMany(
+        { isActive: true },
+        { limit: 200, orderBy: 'name', orderDirection: 'asc' },
+      );
 
-      const keyed = ((data ?? []) as CatalogRow[]).filter(
-        (a) => a.auth_config?.env_var && !a.auth_config?.default_key,
+      const keyed = items.filter(
+        (a) =>
+          a.authType === 'api_key' &&
+          Boolean(a.authConfig?.env_var) &&
+          !a.authConfig?.default_key,
       );
 
       const results: KeyCheckResult[] = [];
       for (const a of keyed) {
         const api: KeyCheckApi = {
           name: a.name,
-          baseUrl: a.base_url,
-          authConfig: a.auth_config,
-          endpoints: a.endpoints,
+          baseUrl: a.baseUrl,
+          authConfig: a.authConfig as KeyCheckApi['authConfig'],
+          endpoints: a.endpoints as unknown as KeyCheckApi['endpoints'],
         };
-        const key = a.auth_config?.env_var ? process.env[a.auth_config.env_var] : undefined;
+        const envVar = a.authConfig?.env_var as string | undefined;
+        const key = envVar ? process.env[envVar] : undefined;
         results.push(await verifyApiKey(api, key, realFetch));
       }
 

--- a/src/app/api/v1/admin/qc-stats/qc-stats.test.ts
+++ b/src/app/api/v1/admin/qc-stats/qc-stats.test.ts
@@ -1,22 +1,17 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('@/lib/supabase/server', () => ({
-  createServiceClient: vi.fn().mockImplementation(async () => ({
-    from: () => ({
-      select: () => ({
-        eq: () => ({
-          gte: () => Promise.resolve({ count: 0, data: [] }),
-        }),
-      }),
-    }),
-  })),
+// 레포는 factory를 통해 주입된다(provider-무관). vi.hoisted로 mock 팩토리에서 참조한다.
+const { codeRepo, eventRepo } = vi.hoisted(() => ({
+  codeRepo: { findMetadataByDateRange: vi.fn() },
+  eventRepo: { countByTypeSince: vi.fn(), findPayloadsByTypeSince: vi.fn() },
 }));
 
-vi.mock('@/repositories/codeRepository', () => ({
-  CodeRepository: vi.fn(function (this: { findMetadataByDateRange: ReturnType<typeof vi.fn> }) {
-    this.findMetadataByDateRange = vi.fn().mockResolvedValue([]);
-  }),
+vi.mock('@/lib/config/providers', () => ({ getDbProvider: vi.fn(() => 'supabase') }));
+vi.mock('@/repositories/factory', () => ({
+  createCodeRepository: vi.fn(() => codeRepo),
+  createEventRepository: vi.fn(() => eventRepo),
 }));
+vi.mock('@/lib/supabase/server', () => ({ createServiceClient: vi.fn().mockResolvedValue({}) }));
 
 vi.mock('@/lib/utils/adminAuth', () => ({
   adminCorsHeaders: {},
@@ -31,6 +26,13 @@ function makeRequest(search = '') {
 }
 
 describe('GET /api/v1/admin/qc-stats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    codeRepo.findMetadataByDateRange.mockResolvedValue([]);
+    eventRepo.countByTypeSince.mockResolvedValue(0);
+    eventRepo.findPayloadsByTypeSince.mockResolvedValue([]);
+  });
+
   it('days 파라미터 미설정 시 정상 응답한다', async () => {
     const response = await GET(makeRequest());
     expect(response.status).toBe(200);
@@ -64,19 +66,31 @@ describe('GET /api/v1/admin/qc-stats', () => {
     expect(json.data.period.days).toBe(14);
   });
 
-  it('Supabase 쿼리 에러 시 0 메트릭으로 은폐하지 않고 500을 반환한다', async () => {
-    const { createServiceClient } = await import('@/lib/supabase/server');
-    vi.mocked(createServiceClient).mockResolvedValueOnce({
-      from: () => ({
-        select: () => ({
-          eq: () => ({
-            gte: () =>
-              Promise.resolve({ count: null, data: null, error: { code: 'XX000', message: 'db down' } }),
-          }),
-        }),
-      }),
-    } as never);
+  it('집계 메서드가 STAGE_SKIPPED/QUALITY_LOOP payload를 반영한다', async () => {
+    codeRepo.findMetadataByDateRange.mockResolvedValue([
+      { metadata: { structuralScore: 80, mobileScore: 70 } },
+    ]);
+    eventRepo.countByTypeSince.mockImplementation(async (type: string) =>
+      type === 'CODE_GENERATION_FAILED' ? 2 : 0,
+    );
+    eventRepo.findPayloadsByTypeSince.mockImplementation(async (type: string) =>
+      type === 'STAGE_SKIPPED'
+        ? [{ stage: 'stage2' }, { stage: 'stage3' }, { stage: 'stage2' }]
+        : [{ iterations: 2, improved: true }],
+    );
 
+    const response = await GET(makeRequest());
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.data.failureCount).toBe(2);
+    expect(json.data.stage2SkipCount).toBe(2);
+    expect(json.data.stage3SkipCount).toBe(1);
+    expect(json.data.avgQualityLoopIterations).toBe(2);
+    expect(json.data.qualityLoopImprovementRate).toBe(1);
+  });
+
+  it('집계 쿼리 에러 시 0 메트릭으로 은폐하지 않고 500을 반환한다', async () => {
+    eventRepo.countByTypeSince.mockRejectedValueOnce(new Error('db down'));
     const response = await GET(makeRequest());
     expect(response.status).toBe(500);
   });

--- a/src/app/api/v1/admin/qc-stats/route.ts
+++ b/src/app/api/v1/admin/qc-stats/route.ts
@@ -1,5 +1,6 @@
 import { createServiceClient } from '@/lib/supabase/server';
-import { CodeRepository } from '@/repositories/codeRepository';
+import { getDbProvider } from '@/lib/config/providers';
+import { createCodeRepository, createEventRepository } from '@/repositories/factory';
 import { adminCorsHeaders, verifyAdminKey, withAdminCors } from '@/lib/utils/adminAuth';
 import { handleApiError, jsonResponse } from '@/lib/utils/errors';
 
@@ -18,50 +19,27 @@ export async function GET(request: Request): Promise<Response> {
       const now = new Date();
       const from = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
 
-      const supabase = await createServiceClient();
-      const codeRepo = new CodeRepository(supabase);
-      const [codes, failureCountResult, stage3FallbackResult, stageSkippedResult, qualityLoopResult] = await Promise.all([
-        codeRepo.findMetadataByDateRange(from),
-        supabase
-          .from('platform_events')
-          .select('id', { count: 'exact', head: true })
-          .eq('type', 'CODE_GENERATION_FAILED')
-          .gte('created_at', from.toISOString()),
-        supabase
-          .from('platform_events')
-          .select('id', { count: 'exact', head: true })
-          .eq('type', 'STAGE3_FALLBACK_USED')
-          .gte('created_at', from.toISOString()),
-        supabase
-          .from('platform_events')
-          .select('payload')
-          .eq('type', 'STAGE_SKIPPED')
-          .gte('created_at', from.toISOString()),
-        supabase
-          .from('platform_events')
-          .select('payload')
-          .eq('type', 'QUALITY_LOOP_COMPLETED')
-          .gte('created_at', from.toISOString()),
-      ]);
+      // raw .from 대신 레포 경유(모든 provider). 집계 메서드는 DB 오류를 throw하므로
+      // 장애가 0-메트릭으로 은폐되지 않고 outer try/catch → 500으로 surface된다.
+      const supabase = getDbProvider() === 'supabase' ? await createServiceClient() : undefined;
+      const codeRepo = createCodeRepository(supabase);
+      const eventRepo = createEventRepository(supabase);
+      const [codes, failureCount, stage3FallbackCount, stageSkippedPayloads, qualityLoopPayloads] =
+        await Promise.all([
+          codeRepo.findMetadataByDateRange(from),
+          eventRepo.countByTypeSince('CODE_GENERATION_FAILED', from),
+          eventRepo.countByTypeSince('STAGE3_FALLBACK_USED', from),
+          eventRepo.findPayloadsByTypeSince('STAGE_SKIPPED', from),
+          eventRepo.findPayloadsByTypeSince('QUALITY_LOOP_COMPLETED', from),
+        ]);
 
-      // Supabase 쿼리 에러를 검사한다. 무시하면 count/data가 0·빈배열로 폴백되어 DB 장애 시에도
-      // 정상(0 메트릭)으로 보고되는 은폐가 발생한다 → 에러를 surface하여 500으로 응답.
-      const queryError =
-        failureCountResult.error ??
-        stage3FallbackResult.error ??
-        stageSkippedResult.error ??
-        qualityLoopResult.error;
-      if (queryError) throw queryError;
-
-      const failureCount = failureCountResult.count ?? 0;
-      const stage3FallbackCount = stage3FallbackResult.count ?? 0;
-      const stageSkippedRows = (stageSkippedResult.data ?? []) as Array<{ payload: { stage?: string } | null }>;
-      const stage2SkipCount = stageSkippedRows.filter((r) => r.payload?.stage === 'stage2').length;
-      const stage3SkipCount = stageSkippedRows.filter((r) => r.payload?.stage === 'stage3').length;
-      const qualityLoopRows = (qualityLoopResult.data ?? []) as Array<{ payload: { iterations?: number; improved?: boolean } | null }>;
+      const stageSkippedRows = stageSkippedPayloads as Array<{ stage?: string } | null>;
+      const stage2SkipCount = stageSkippedRows.filter((p) => p?.stage === 'stage2').length;
+      const stage3SkipCount = stageSkippedRows.filter((p) => p?.stage === 'stage3').length;
+      const qualityLoopRows = qualityLoopPayloads as Array<{ iterations?: number; improved?: boolean } | null>;
       const qualityLoopEventCount = qualityLoopRows.length;
-      const sumIterations = qualityLoopRows.reduce((s, r) => s + (typeof r.payload?.iterations === 'number' ? r.payload.iterations : 0), 0);
-      const improvedCount = qualityLoopRows.filter((r) => r.payload?.improved === true).length;
+      const sumIterations = qualityLoopRows.reduce((s, p) => s + (typeof p?.iterations === 'number' ? p.iterations : 0), 0);
+      const improvedCount = qualityLoopRows.filter((p) => p?.improved === true).length;
       const avgQualityLoopIterations = qualityLoopEventCount > 0 ? Math.round((sumIterations / qualityLoopEventCount) * 100) / 100 : 0;
       const qualityLoopImprovementRate = qualityLoopEventCount > 0 ? Math.round((improvedCount / qualityLoopEventCount) * 100) / 100 : 0;
       const total = codes.length;

--- a/src/app/api/v1/admin/test-generation/route.ts
+++ b/src/app/api/v1/admin/test-generation/route.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { createServiceClient } from '@/lib/supabase/server';
+import { getDbProvider } from '@/lib/config/providers';
 import { adminCorsHeaders, verifyAdminKey, withAdminCors } from '@/lib/utils/adminAuth';
 import { handleApiError, jsonResponse, ValidationError } from '@/lib/utils/errors';
 import { createCatalogService, createProjectService } from '@/services/factory';
@@ -46,7 +47,7 @@ export async function POST(request: Request): Promise<Response> {
       const projectContext = ctx ?? DEFAULT_CONTEXT;
       const shouldCleanup = cleanup ?? true;
 
-      const supabase = await createServiceClient();
+      const supabase = getDbProvider() === 'supabase' ? await createServiceClient() : undefined;
       const catalogService = createCatalogService(supabase);
       const projectRepo = createProjectRepository(supabase);
 
@@ -144,7 +145,7 @@ export async function POST(request: Request): Promise<Response> {
     } catch (error) {
       if (createdProjectId) {
         try {
-          const supabase = await createServiceClient();
+          const supabase = getDbProvider() === 'supabase' ? await createServiceClient() : undefined;
           const projectRepo = createProjectRepository(supabase);
           await projectRepo.delete(createdProjectId);
         } catch {

--- a/src/app/api/v1/admin/trigger-qc/route.ts
+++ b/src/app/api/v1/admin/trigger-qc/route.ts
@@ -1,5 +1,6 @@
 import { createServiceClient } from '@/lib/supabase/server';
-import { CodeRepository } from '@/repositories/codeRepository';
+import { getDbProvider } from '@/lib/config/providers';
+import { createCodeRepository } from '@/repositories/factory';
 import { assembleHtml } from '@/lib/ai/codeParser';
 import { runFastQc, runDeepQc, isQcEnabled } from '@/lib/qc';
 import { adminCorsHeaders, verifyAdminKey, withAdminCors } from '@/lib/utils/adminAuth';
@@ -22,8 +23,8 @@ export async function POST(request: Request): Promise<Response> {
       const body = await request.json();
       const { projectId } = triggerQcSchema.parse(body);
 
-      const supabase = await createServiceClient();
-      const codeRepo = new CodeRepository(supabase);
+      const supabase = getDbProvider() === 'supabase' ? await createServiceClient() : undefined;
+      const codeRepo = createCodeRepository(supabase);
       const code = await codeRepo.findByProject(projectId);
 
       if (!code) {

--- a/src/app/api/v1/proxy/route.ts
+++ b/src/app/api/v1/proxy/route.ts
@@ -1,7 +1,11 @@
 import dns from 'dns/promises';
 import { createServiceClient } from '@/lib/supabase/server';
 import { getDbProvider } from '@/lib/config/providers';
-import { createCatalogRepository } from '@/repositories/factory';
+import {
+  createCatalogRepository,
+  createProjectRepository,
+  createUserApiKeyRepository,
+} from '@/repositories/factory';
 import { decryptApiKey } from '@/lib/encryption';
 import { getAuthUser } from '@/lib/auth/index';
 import { LRUMap } from '@/lib/utils/lruMap';
@@ -199,26 +203,19 @@ async function resolveApiKey(
 ): Promise<void> {
   let resolvedKey: string | undefined;
 
-  // 1) 프로젝트 오너의 개인 API 키 조회 (projectId가 있을 때, Supabase 모드만)
+  // 1) 프로젝트 오너의 개인 API 키 조회 (projectId가 있을 때 — 모든 provider)
+  //    raw .from 대신 레포를 사용해 DB_PROVIDER(supabase/postgres/sqlite)에 무관하게 동작.
   const projectId = searchParams.get('projectId');
-  if (supabase && projectId && UUID_RE.test(projectId)) {
+  if (projectId && UUID_RE.test(projectId)) {
     try {
-      const { data: project } = await supabase
-        .from('projects')
-        .select('user_id')
-        .eq('id', projectId)
-        .single();
-
-      if (project?.user_id) {
-        const { data: userKey } = await supabase
-          .from('user_api_keys')
-          .select('encrypted_key')
-          .eq('user_id', project.user_id)
-          .eq('api_id', apiId)
-          .single();
-
-        if (userKey?.encrypted_key) {
-          try { resolvedKey = decryptApiKey(userKey.encrypted_key); } catch { /* skip */ }
+      const project = await createProjectRepository(supabase).findById(projectId);
+      if (project?.userId) {
+        const userKey = await createUserApiKeyRepository(supabase).findByUserAndApi(
+          project.userId,
+          apiId,
+        );
+        if (userKey?.encryptedKey) {
+          try { resolvedKey = decryptApiKey(userKey.encryptedKey); } catch { /* skip */ }
         }
       }
     } catch { /* 조회 실패 시 플랫폼 키로 폴백 */ }

--- a/src/data/apiCatalog.json
+++ b/src/data/apiCatalog.json
@@ -1,0 +1,2493 @@
+[
+  {
+    "id": "3014199c-8a07-4800-bc96-30b9145a41cd",
+    "name": "Countries (Self-hosted)",
+    "description": "250개 나라의 수도, 지역, 국기, 언어, 통화, 국가번호, 면적 정보를 제공해요. REST Countries 대체 API로, 가입·키 없이 바로 사용할 수 있어요.",
+    "category": "data",
+    "base_url": "https://xzawed.xyz",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": null,
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": null,
+    "endpoints": [
+      {
+        "path": "/api/v1/countries",
+        "method": "GET",
+        "parameters": {
+          "region": "string",
+          "search": "string"
+        },
+        "description": "전체 나라 목록 (region·search 쿼리로 필터 가능)"
+      },
+      {
+        "path": "/api/v1/countries/KR",
+        "method": "GET",
+        "parameters": {
+          "code": "string"
+        },
+        "description": "국가 코드(cca2/cca3)로 단건 조회. 경로의 KR을 원하는 코드로 바꾸세요 (예: KOR, US, JP)"
+      }
+    ],
+    "tags": [
+      "data",
+      "countries",
+      "geography",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": 86400,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:40:55.923+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-06-22T11:25:27.305719+00:00",
+    "updated_at": "2026-06-22T21:40:56.90952+00:00"
+  },
+  {
+    "id": "04e79764-c27c-46d8-b63c-2794fbe5a3f7",
+    "name": "JSONPlaceholder",
+    "description": "가짜 게시글, 댓글, 할일 목록, 사진 앨범 데이터. 연습용 또는 프로토타입 만들 때 유용해요.",
+    "category": "data",
+    "base_url": "https://jsonplaceholder.typicode.com",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "500",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://jsonplaceholder.typicode.com/guide/",
+    "endpoints": [
+      {
+        "path": "/posts",
+        "method": "GET",
+        "description": "게시글 목록",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=04e79764-c27c-46d8-b63c-2794fbe5a3f7&proxyPath=%2Fposts');\nconst items = await res.json(); // [{id, userId, title, body}]"
+      },
+      {
+        "path": "/todos",
+        "method": "GET",
+        "description": "할일 목록",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=04e79764-c27c-46d8-b63c-2794fbe5a3f7&proxyPath=%2Ftodos');\nconst items = await res.json(); // [{id, userId, title, completed}]"
+      },
+      {
+        "path": "/users",
+        "method": "GET",
+        "description": "사용자 목록",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=04e79764-c27c-46d8-b63c-2794fbe5a3f7&proxyPath=%2Fusers');\nconst items = await res.json(); // [{id, name, username, email}]"
+      }
+    ],
+    "tags": [
+      "data",
+      "mock",
+      "placeholder",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:00.262+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:41:00.400736+00:00"
+  },
+  {
+    "id": "448bc30c-2f3e-452d-9bd7-e88072f89bc4",
+    "name": "Open Library",
+    "description": "전 세계 도서 검색. 책 제목이나 저자로 검색하면 표지, 출판 정보를 알려줘요.",
+    "category": "data",
+    "base_url": "https://openlibrary.org",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "100",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://openlibrary.org/developers/api",
+    "endpoints": [
+      {
+        "path": "/search.json",
+        "method": "GET",
+        "parameters": {
+          "q": "string",
+          "title": "string",
+          "author": "string"
+        },
+        "description": "도서 검색"
+      }
+    ],
+    "tags": [
+      "data",
+      "books",
+      "library",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:01.291+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:41:01.425516+00:00"
+  },
+  {
+    "id": "6890346f-fa79-483c-bce2-f841ad3420fd",
+    "name": "Random User",
+    "description": "가짜 사용자 프로필 자동 생성. 이름, 사진, 주소, 이메일 등 테스트 데이터를 만들 때 유용해요.",
+    "category": "data",
+    "base_url": "https://randomuser.me",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "500",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://randomuser.me/documentation",
+    "endpoints": [
+      {
+        "path": "/api/",
+        "method": "GET",
+        "parameters": {
+          "nat": "string",
+          "gender": "string",
+          "results": "number"
+        },
+        "description": "랜덤 사용자 프로필 생성",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=6890346f-fa79-483c-bce2-f841ad3420fd&proxyPath=%2Fapi%2F');\nconst data = await res.json();\nconst items = data.results; // [{name, email, picture, location}]",
+        "responseDataPath": "results"
+      }
+    ],
+    "tags": [
+      "data",
+      "users",
+      "mock",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v1.4",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:02.716+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:41:02.855707+00:00"
+  },
+  {
+    "id": "e611b79a-98d5-46f8-9f5e-8999f65e258b",
+    "name": "REST Countries",
+    "description": "250개 나라의 수도, 인구, 국기, 언어, 통화 정보. 여행 준비나 세계 퀴즈 만들기에 딱!",
+    "category": "data",
+    "base_url": "https://restcountries.com",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "500",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://restcountries.com/",
+    "endpoints": [
+      {
+        "path": "/v3.1/all",
+        "method": "GET",
+        "description": "전체 나라 목록"
+      },
+      {
+        "path": "/v3.1/name/{name}",
+        "method": "GET",
+        "parameters": {
+          "name": "string"
+        },
+        "description": "나라 이름으로 검색"
+      }
+    ],
+    "tags": [
+      "data",
+      "countries",
+      "geography",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v3.1",
+    "deprecated_at": "2026-06-21T11:50:39.804157+00:00",
+    "successor_id": "3014199c-8a07-4800-bc96-30b9145a41cd",
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "broken",
+    "verified_at": null,
+    "last_verification_note": "2026-06-21 라이브 검증: v3.1 전 엔드포인트(name/alpha/all) deprecated. HTTP 200이나 본문이 deprecation 에러 객체이며 legacy.json으로 301(경로 stripping). 무료 키리스 대체 없음(v5는 유료·키 필요). 권장 대체: mledoze/countries 데이터셋 번들/셀프호스트.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T11:25:27.305719+00:00"
+  },
+  {
+    "id": "01fc3764-a2e5-4b04-91ca-34f11659366b",
+    "name": "Wikipedia",
+    "description": "위키피디아 문서 요약과 검색. 궁금한 것을 검색하면 짧은 요약문을 보여줘요. 한국어도 지원.",
+    "category": "data",
+    "base_url": "https://ko.wikipedia.org/api/rest_v1",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "200",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://en.wikipedia.org/api/rest_v1/",
+    "endpoints": [
+      {
+        "path": "/page/summary/{title}",
+        "method": "GET",
+        "parameters": {
+          "title": "string"
+        },
+        "description": "문서 요약 조회"
+      },
+      {
+        "path": "/page/random/summary",
+        "method": "GET",
+        "description": "랜덤 문서 요약"
+      }
+    ],
+    "tags": [
+      "data",
+      "wikipedia",
+      "encyclopedia",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:04.644+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:41:04.780443+00:00"
+  },
+  {
+    "id": "ca6f16be-fe50-4eb9-be5d-430859be10cc",
+    "name": "KOPIS 공연예술",
+    "description": "공연예술통합전산망(KOPIS) 공연 정보. 공연 목록·상세·공연장 조회. XML 응답 (DOMParser 파싱 필요). (KOPIS 키 필요)",
+    "category": "entertainment",
+    "base_url": "https://www.kopis.or.kr/openApi/restful",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_KOPIS",
+      "param_in": "query",
+      "param_name": "service"
+    },
+    "rate_limit": "100",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://www.kopis.or.kr/por/cs/openapi/openApiUsageGuide.do",
+    "endpoints": [
+      {
+        "path": "/pblprfr",
+        "method": "GET",
+        "parameters": {
+          "rows": "10",
+          "cpage": "1",
+          "shcaf": "공연시설코드 (선택)",
+          "shcat": "공연분야코드 (선택)",
+          "eddate": "종료일 YYYYMMDD",
+          "stdate": "시작일 YYYYMMDD",
+          "shprfnm": "공연명 검색 (선택)"
+        },
+        "description": "공연 목록 조회 (XML 반환)",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=<이 API ID>&proxyPath=%2Fpblprfr&stdate=20250501&eddate=20250531&cpage=1&rows=10');\nconst xml = await res.text();\nconst parser = new DOMParser();\nconst doc = parser.parseFromString(xml, 'text/xml');\nconst items = doc.querySelectorAll('db');",
+        "responseDataPath": ""
+      },
+      {
+        "path": "/pblprfr/{mt20id}",
+        "method": "GET",
+        "parameters": {
+          "mt20id": "공연 ID"
+        },
+        "description": "공연 상세 정보 (XML 반환)",
+        "responseDataPath": ""
+      }
+    ],
+    "tags": [
+      "entertainment",
+      "performance",
+      "culture",
+      "theater",
+      "kr",
+      "api_key",
+      "xml"
+    ],
+    "api_version": null,
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "unverified",
+    "verified_at": null,
+    "last_verification_note": "2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-05-01T04:03:27.970352+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "5142c7db-5b34-40ca-8303-41e787d7383d",
+    "name": "Open Trivia DB",
+    "description": "4,000개 이상 퀴즈 문제. 난이도와 카테고리를 골라서 퀴즈 게임을 만들 수 있어요.",
+    "category": "entertainment",
+    "base_url": "https://opentdb.com",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "12/분(5초 간격)",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://opentdb.com/api_config.php",
+    "endpoints": [
+      {
+        "path": "/api.php",
+        "method": "GET",
+        "parameters": {
+          "amount": "number",
+          "category": "number",
+          "difficulty": "string"
+        },
+        "description": "퀴즈 문제 가져오기"
+      }
+    ],
+    "tags": [
+      "entertainment",
+      "trivia",
+      "quiz",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:01.564+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:41:01.713716+00:00"
+  },
+  {
+    "id": "02cea7ab-d89a-4e51-b9c5-32ed0fd00338",
+    "name": "PokéAPI",
+    "description": "포켓몬 도감. 1,000마리 이상 포켓몬의 능력치, 타입, 이미지를 확인할 수 있어요.",
+    "category": "entertainment",
+    "base_url": "https://pokeapi.co",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://pokeapi.co/docs/v2",
+    "endpoints": [
+      {
+        "path": "/api/v2/pokemon/{id_or_name}",
+        "method": "GET",
+        "parameters": {
+          "id_or_name": "string"
+        },
+        "description": "포켓몬 상세 정보"
+      },
+      {
+        "path": "/api/v2/pokemon",
+        "method": "GET",
+        "parameters": {
+          "limit": "number",
+          "offset": "number"
+        },
+        "description": "포켓몬 목록",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=02cea7ab-d89a-4e51-b9c5-32ed0fd00338&proxyPath=%2Fapi%2Fv2%2Fpokemon');\nconst data = await res.json();\nconst items = data.results; // [{name, url}]",
+        "responseDataPath": "results"
+      }
+    ],
+    "tags": [
+      "entertainment",
+      "pokemon",
+      "games",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v2",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:02.16+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:41:02.298908+00:00"
+  },
+  {
+    "id": "597c8c5b-afca-4528-b84e-e15c8bee5767",
+    "name": "RAWG",
+    "description": "500,000개 이상 게임 데이터베이스. 인기 게임 목록, 검색, 상세정보 제공.",
+    "category": "entertainment",
+    "base_url": "https://api.rawg.io/api",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_RAWG",
+      "param_in": "query",
+      "param_name": "key"
+    },
+    "rate_limit": "20000/월",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://api.rawg.io/docs",
+    "endpoints": [
+      {
+        "path": "/games",
+        "method": "GET",
+        "parameters": {
+          "genres": "string (예: action,rpg)",
+          "ordering": "-rating",
+          "page_size": "20"
+        },
+        "description": "게임 목록 조회",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=<이 API ID>&proxyPath=%2Fgames&page_size=20&ordering=-rating');\nconst data = await res.json();\nconst games = data.results; // [{name, rating, background_image, genres}]",
+        "responseDataPath": "results"
+      },
+      {
+        "path": "/games/{id}",
+        "method": "GET",
+        "parameters": {
+          "id": "게임 ID 또는 slug"
+        },
+        "description": "게임 상세 정보",
+        "responseDataPath": ""
+      },
+      {
+        "path": "/genres",
+        "method": "GET",
+        "description": "장르 목록",
+        "responseDataPath": "results"
+      }
+    ],
+    "tags": [
+      "entertainment",
+      "games",
+      "gaming",
+      "api_key"
+    ],
+    "api_version": null,
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-05-01T04:28:47.706287+00:00",
+    "last_verification_note": "2026-05-01: 무료 플랜 월 20,000건. 비상업적 프로젝트 무료. RAWG 역링크 필수.\n2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-05-01T04:02:26.332579+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "da2e14a4-e8c6-4164-835e-6ce8b212d59b",
+    "name": "TheMealDB",
+    "description": "전세계 레시피 데이터베이스. 랜덤 레시피, 검색, 카테고리별 필터 제공. ⚠️ 무료 키(v1/1)는 100건 이하·단일 재료 필터·기본 기능만 지원. v2 기능(랜덤 10개 등)은 Patreon 구독 키 필요.",
+    "category": "entertainment",
+    "base_url": "https://www.themealdb.com/api/json/v1/1",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": null,
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://www.themealdb.com/api.php",
+    "endpoints": [
+      {
+        "path": "/random.php",
+        "method": "GET",
+        "description": "랜덤 레시피 1개",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=<이 API ID>&proxyPath=%2Frandom.php');\nconst data = await res.json();\nconst meal = data.meals[0]; // {strMeal, strCategory, strInstructions, strMealThumb}",
+        "responseDataPath": "meals[0]"
+      },
+      {
+        "path": "/search.php",
+        "method": "GET",
+        "parameters": {
+          "s": "요리명 (예: chicken)"
+        },
+        "description": "레시피 검색",
+        "responseDataPath": "meals"
+      },
+      {
+        "path": "/filter.php",
+        "method": "GET",
+        "parameters": {
+          "c": "Chicken | Beef | Seafood | Vegetarian 등"
+        },
+        "description": "카테고리별 레시피",
+        "responseDataPath": "meals"
+      }
+    ],
+    "tags": [
+      "fun",
+      "food",
+      "recipe",
+      "cooking",
+      "free",
+      "no-auth"
+    ],
+    "api_version": null,
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:04.095+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-05-01T04:02:26.332579+00:00",
+    "updated_at": "2026-06-22T21:41:04.229482+00:00"
+  },
+  {
+    "id": "902c0017-1315-4517-9682-d5d501e43f5d",
+    "name": "TMDB",
+    "description": "영화·TV 데이터베이스. 인기 영화·드라마 목록, 검색, 상세정보 제공. 한국어(ko-KR) 지원.",
+    "category": "entertainment",
+    "base_url": "https://api.themoviedb.org/3",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_TMDB",
+      "param_in": "query",
+      "param_name": "api_key"
+    },
+    "rate_limit": null,
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://developer.themoviedb.org/docs",
+    "endpoints": [
+      {
+        "path": "/movie/popular",
+        "method": "GET",
+        "parameters": {
+          "page": "1",
+          "language": "ko-KR"
+        },
+        "description": "인기 영화 목록",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=<이 API ID>&proxyPath=%2Fmovie%2Fpopular&language=ko-KR&page=1');\nconst data = await res.json();\nconst movies = data.results;",
+        "responseDataPath": "results"
+      },
+      {
+        "path": "/search/movie",
+        "method": "GET",
+        "parameters": {
+          "query": "string",
+          "language": "ko-KR"
+        },
+        "description": "영화 검색",
+        "responseDataPath": "results"
+      },
+      {
+        "path": "/tv/popular",
+        "method": "GET",
+        "parameters": {
+          "language": "ko-KR"
+        },
+        "description": "인기 TV 프로그램 목록",
+        "responseDataPath": "results"
+      }
+    ],
+    "tags": [
+      "entertainment",
+      "movies",
+      "tv",
+      "film",
+      "api_key"
+    ],
+    "api_version": null,
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-05-01T04:28:47.706287+00:00",
+    "last_verification_note": "2026-05-01: 2019년 12월 rate limit 폐지. 현재 ~40req/s 비공식 상한선. 과도한 호출 시 429 응답. 비상업적 사용 무료.\n2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-05-01T04:02:26.332579+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "77b58b42-51b2-4301-9da4-e60850f22d07",
+    "name": "ExchangeRate-API",
+    "description": "150개국 환율 조회. 가입 없이 바로 사용 가능해요. 원화(KRW) 포함 모든 통화 지원.",
+    "category": "finance",
+    "base_url": "https://open.er-api.com",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "50",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://www.exchangerate-api.com/docs/free",
+    "endpoints": [
+      {
+        "path": "/v6/latest/{currency}",
+        "method": "GET",
+        "parameters": {
+          "currency": "string"
+        },
+        "description": "기준 통화 대비 전체 환율 조회"
+      }
+    ],
+    "tags": [
+      "finance",
+      "currency",
+      "exchange-rate",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v6",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:40:57.894+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:40:58.530617+00:00"
+  },
+  {
+    "id": "8e4bbbcf-61b4-40e6-8bcb-8f7d35ba0f38",
+    "name": "Frankfurter",
+    "description": "유럽중앙은행 기준 환율 조회. 30개국 통화를 실시간으로 변환할 수 있어요. 여행 환율 계산기에 딱!",
+    "category": "finance",
+    "base_url": "https://api.frankfurter.dev/v1",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://frankfurter.dev",
+    "endpoints": [
+      {
+        "path": "/latest",
+        "method": "GET",
+        "parameters": {
+          "to": "string",
+          "from": "string"
+        },
+        "description": "최신 환율 조회"
+      },
+      {
+        "path": "/{date}",
+        "method": "GET",
+        "parameters": {
+          "date": "string"
+        },
+        "description": "특정 날짜 환율 조회"
+      }
+    ],
+    "tags": [
+      "finance",
+      "currency",
+      "exchange-rate",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:40:58.671+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:40:59.28089+00:00"
+  },
+  {
+    "id": "6c5e7987-5f4f-49d6-a6f4-fea73ce5dc6b",
+    "name": "한국은행 경제통계 (ECOS)",
+    "description": "한국은행 경제통계 API. GDP, 금리, 환율, 물가 등 거시 경제 지표 조회. 인증키 발급: data.go.kr이 아닌 ecos.bok.or.kr 자체 회원가입 필요.",
+    "category": "finance",
+    "base_url": "https://ecos.bok.or.kr/api",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_ECOS",
+      "param_in": "path",
+      "param_name": "authkey"
+    },
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://ecos.bok.or.kr/api/#/",
+    "endpoints": [
+      {
+        "path": "/StatisticSearch/{authkey}/json/kr/1/10/{statCode}",
+        "method": "GET",
+        "parameters": {
+          "endDate": "string",
+          "statCode": "string",
+          "startDate": "string"
+        },
+        "description": "통계 항목 조회"
+      }
+    ],
+    "tags": [
+      "finance",
+      "economy",
+      "korea",
+      "api-key"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "unverified",
+    "verified_at": "2026-05-01T04:29:30.77912+00:00",
+    "last_verification_note": "2026-05-01: ecos.bok.or.kr 자체 발급 (공공데이터포털 경유 아님). HTTPS 정상.\n2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "f93805a1-d86f-4ef7-9b9c-e00aa0f5aaa8",
+    "name": "icanhazdadjoke",
+    "description": "아재 개그 무한 생성기. 영어 유머 연습용으로도 좋아요. 매번 다른 개그가 나와요.",
+    "category": "fun",
+    "base_url": "https://icanhazdadjoke.com",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://icanhazdadjoke.com/api",
+    "endpoints": [
+      {
+        "path": "/",
+        "method": "GET",
+        "description": "랜덤 아재 개그 (Accept: application/json 헤더 필요)"
+      }
+    ],
+    "tags": [
+      "fun",
+      "jokes",
+      "dad-jokes",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:40:59.704+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:40:59.840091+00:00"
+  },
+  {
+    "id": "09b8144b-6570-4d2c-aecd-b7a3f0505102",
+    "name": "JokeAPI",
+    "description": "카테고리별 랜덤 유머. 프로그래밍 개그, 아재 개그 등 분위기 전환에 딱이에요.",
+    "category": "fun",
+    "base_url": "https://v2.jokeapi.dev",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "120",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://jokeapi.dev/",
+    "endpoints": [
+      {
+        "path": "/joke/{category}",
+        "method": "GET",
+        "parameters": {
+          "lang": "string",
+          "type": "string",
+          "category": "string"
+        },
+        "description": "카테고리별 랜덤 유머 조회"
+      }
+    ],
+    "tags": [
+      "entertainment",
+      "jokes",
+      "humor",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v2",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:40:59.979+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:41:00.121204+00:00"
+  },
+  {
+    "id": "4c6f5228-e6ec-45bb-b0bb-e947dcdeb1c1",
+    "name": "ZenQuotes",
+    "description": "명언·격언 랜덤 표시. 오늘의 한마디, 동기부여 화면을 만들 때 좋아요. HTTPS 지원, 무료, 인증 불필요.",
+    "category": "fun",
+    "base_url": "https://zenquotes.io/api",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": null,
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://docs.zenquotes.io",
+    "endpoints": [
+      {
+        "path": "/random",
+        "method": "GET",
+        "description": "랜덤 명언 1개 조회",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=4c6f5228-e6ec-45bb-b0bb-e947dcdeb1c1&proxyPath=%2Frandom');\nconst data = await res.json();\nconst quote = data[0];\n// quote.q (명언), quote.a (저자)",
+        "responseDataPath": "[0]"
+      },
+      {
+        "path": "/quotes",
+        "method": "GET",
+        "description": "명언 50개 조회",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=4c6f5228-e6ec-45bb-b0bb-e947dcdeb1c1&proxyPath=%2Fquotes');\nconst data = await res.json();\n// data: [{q: '명언', a: '저자'}, ...]",
+        "responseDataPath": ""
+      }
+    ],
+    "tags": [
+      "fun",
+      "quotes",
+      "inspiration",
+      "free",
+      "no-auth",
+      "https"
+    ],
+    "api_version": null,
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:04.914+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: degraded",
+    "created_at": "2026-05-01T03:58:12.170498+00:00",
+    "updated_at": "2026-06-22T21:41:05.054228+00:00"
+  },
+  {
+    "id": "4bb5796d-5754-4ca8-9cee-6190fbe2a6b8",
+    "name": "HIRA 병원정보",
+    "description": "건강보험심사평가원 병원·의원 정보 조회. 주소·진료과로 병원 검색. (공공데이터포털 키 필요)",
+    "category": "health",
+    "base_url": "https://apis.data.go.kr/B551182/hospInfoServicev2",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_HIRA",
+      "param_in": "query",
+      "param_name": "serviceKey"
+    },
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://www.data.go.kr/data/15001698/openapi.do",
+    "endpoints": [
+      {
+        "path": "/getHospBasisList",
+        "method": "GET",
+        "parameters": {
+          "addr": "주소 (예: 서울특별시 강남구)",
+          "type": "json",
+          "pageNo": "1",
+          "dgsbjtCd": "진료과코드 (예: 01=내과, 11=정형외과)",
+          "numOfRows": "10"
+        },
+        "description": "병원 기본 정보 목록",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=<이 API ID>&proxyPath=%2FgetHospBasisList&addr=서울특별시&pageNo=1&numOfRows=5&type=json');\nconst data = await res.json();\nconst hospitals = data.response.body.items.item; // [{yadmNm, addr, telno, clCdNm}]",
+        "responseDataPath": "response.body.items.item"
+      }
+    ],
+    "tags": [
+      "health",
+      "hospital",
+      "medical",
+      "kr",
+      "api_key",
+      "data.go.kr"
+    ],
+    "api_version": null,
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "unverified",
+    "verified_at": null,
+    "last_verification_note": "2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-05-01T04:03:27.970352+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "f45de6c5-95e6-4c4a-989e-c60b060a9c7c",
+    "name": "식약처 식품영양성분",
+    "description": "식품의약품안전처 식품 영양성분 데이터. 식품명으로 열량·단백질·지방·탄수화물 등 조회. (공공데이터포털 키 필요)",
+    "category": "health",
+    "base_url": "https://apis.data.go.kr/1471000/FoodNtrIrdntInfoService1",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_MFDS",
+      "param_in": "query",
+      "param_name": "serviceKey"
+    },
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://www.data.go.kr/data/15100366/openapi.do",
+    "endpoints": [
+      {
+        "path": "/getFoodNtrItdntList1",
+        "method": "GET",
+        "parameters": {
+          "type": "json",
+          "pageNo": "1",
+          "desc_kor": "식품명 (한글)",
+          "numOfRows": "10"
+        },
+        "description": "식품 영양성분 목록 조회",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=<이 API ID>&proxyPath=%2FgetFoodNtrItdntList1&desc_kor=사과&pageNo=1&numOfRows=5&type=json');\nconst data = await res.json();\nconst items = data.body.items;",
+        "responseDataPath": "body.items"
+      }
+    ],
+    "tags": [
+      "health",
+      "food",
+      "nutrition",
+      "kr",
+      "api_key",
+      "data.go.kr"
+    ],
+    "api_version": null,
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "unverified",
+    "verified_at": "2026-05-01T05:05:04.336909+00:00",
+    "last_verification_note": "2026-05-01: ⚠️ HTTPS 호출 시 500 반환 확인 (다른 data.go.kr API는 401 반환). HTTP 폴백 여부 추가 검증 필요. 운영 전 실제 키로 HTTPS 동작 테스트 권장.\n2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-05-01T04:02:58.319122+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "7da97ff7-c9e2-4d1c-8c94-e179818ef530",
+    "name": "Dog API",
+    "description": "120종 강아지 사진 20,000장. 품종별로 귀여운 강아지 사진을 볼 수 있어요.",
+    "category": "image",
+    "base_url": "https://dog.ceo",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://dog.ceo/dog-api/",
+    "endpoints": [
+      {
+        "path": "/api/breeds/image/random",
+        "method": "GET",
+        "description": "랜덤 강아지 사진"
+      },
+      {
+        "path": "/api/breed/{breed}/images",
+        "method": "GET",
+        "parameters": {
+          "breed": "string"
+        },
+        "description": "품종별 사진 목록"
+      }
+    ],
+    "tags": [
+      "image",
+      "dogs",
+      "animals",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "broken",
+    "verified_at": "2026-06-22T12:59:07.588+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: broken",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:40:57.750812+00:00"
+  },
+  {
+    "id": "4ef4a3ef-5105-4da7-af24-6119fe2722fa",
+    "name": "Lorem Picsum",
+    "description": "랜덤 고화질 사진 생성. URL에 크기만 넣으면 예쁜 사진이 나와요. 배경 이미지로 딱!",
+    "category": "image",
+    "base_url": "https://picsum.photos",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://picsum.photos/",
+    "endpoints": [
+      {
+        "path": "/{width}/{height}",
+        "method": "GET",
+        "parameters": {
+          "width": "number",
+          "height": "number"
+        },
+        "description": "지정 크기 랜덤 이미지"
+      },
+      {
+        "path": "/v2/list",
+        "method": "GET",
+        "description": "이미지 목록 조회"
+      }
+    ],
+    "tags": [
+      "image",
+      "placeholder",
+      "photos",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v2",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "broken",
+    "verified_at": null,
+    "last_verification_note": "picsum.photos Cloudflare 522/timeout 지속(2026-06-21~) — 수동 비활성화(2026-06-22). 복구 시 재검증 후 is_active=true 복원",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T11:51:42.094121+00:00"
+  },
+  {
+    "id": "7b66ab19-4d00-4d39-a4f9-2c2b6c6367a4",
+    "name": "NASA 오늘의 천문 사진",
+    "description": "NASA가 매일 선정한 우주 사진 + 해설. DEMO_KEY로 가입 없이 바로 사용 가능해요.",
+    "category": "image",
+    "base_url": "https://api.nasa.gov",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_NASA",
+      "param_in": "query",
+      "param_name": "api_key",
+      "default_key": "DEMO_KEY"
+    },
+    "rate_limit": "30",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://api.nasa.gov/",
+    "endpoints": [
+      {
+        "path": "/planetary/apod",
+        "method": "GET",
+        "parameters": {
+          "date": "string",
+          "api_key": "string"
+        },
+        "description": "오늘의 천문 사진 조회"
+      }
+    ],
+    "tags": [
+      "image",
+      "space",
+      "nasa",
+      "astronomy",
+      "api-key"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:00.54+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:41:01.151132+00:00"
+  },
+  {
+    "id": "f1b6d26f-4cb4-4ea7-844b-8c6ba3b29a8a",
+    "name": "The Cat API",
+    "description": "랜덤 고양이 사진과 품종 정보. 집사라면 매일 다른 고양이 사진으로 힐링하세요.",
+    "category": "image",
+    "base_url": "https://api.thecatapi.com",
+    "auth_type": "none",
+    "auth_config": null,
+    "rate_limit": "10/분",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://docs.thecatapi.com/",
+    "endpoints": [
+      {
+        "path": "/v1/images/search",
+        "method": "GET",
+        "parameters": {
+          "limit": "number",
+          "breed_ids": "string"
+        },
+        "description": "랜덤 고양이 사진 검색"
+      }
+    ],
+    "tags": [
+      "image",
+      "cats",
+      "animals",
+      "api-key"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:03.547+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:41:03.681376+00:00"
+  },
+  {
+    "id": "2a31bfbe-2ce0-43c0-8a9f-c1ce7bf7235d",
+    "name": "Unsplash",
+    "description": "전문 사진작가들의 고퀄리티 무료 사진 검색. 풍경, 음식, 사람 등 모든 주제를 검색할 수 있어요.",
+    "category": "image",
+    "base_url": "https://api.unsplash.com",
+    "auth_type": "api_key",
+    "auth_config": {
+      "prefix": "Client-ID ",
+      "env_var": "API_KEY_UNSPLASH",
+      "param_in": "header",
+      "param_name": "Authorization"
+    },
+    "rate_limit": "50/시간 (Demo) → 1000/시간 (Production 심사 후)",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://unsplash.com/documentation",
+    "endpoints": [
+      {
+        "path": "/photos/random",
+        "method": "GET",
+        "description": "랜덤 사진 조회"
+      },
+      {
+        "path": "/search/photos",
+        "method": "GET",
+        "parameters": {
+          "query": "string"
+        },
+        "description": "키워드 사진 검색"
+      }
+    ],
+    "tags": [
+      "image",
+      "photos",
+      "stock",
+      "api-key"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-05-01T00:00:00+00:00",
+    "last_verification_note": "2026-06-21 비활성화: 플랫폼 env 키 미설정(빈 값) — /admin/keys-verify로 7개 전부 MISSING 확인. 키 의존 API가 키 없이 제공되어 401 실패. 실제 키 확보 시 재활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-21T14:39:28.883282+00:00"
+  },
+  {
+    "id": "15b51435-de0d-4c53-854c-dfcf08f4bcac",
+    "name": "공휴일 정보 (한국천문연구원)",
+    "description": "대한민국 공휴일, 기념일, 24절기 정보. 달력 앱이나 D-day 계산기 만들 때 필수!",
+    "category": "lifestyle",
+    "base_url": "https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_15B51435",
+      "param_in": "query",
+      "param_name": "serviceKey"
+    },
+    "rate_limit": "10000/일 (개발계정)",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://www.data.go.kr/data/15012690/openapi.do",
+    "endpoints": [
+      {
+        "path": "/getRestDeInfo",
+        "method": "GET",
+        "parameters": {
+          "solYear": "string",
+          "solMonth": "string"
+        },
+        "description": "공휴일 조회"
+      }
+    ],
+    "tags": [
+      "lifestyle",
+      "holiday",
+      "calendar",
+      "korea",
+      "공공데이터",
+      "api-key"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-05-01T00:00:00+00:00",
+    "last_verification_note": "2026-06-21 비활성화: 플랫폼 env 키 미설정(빈 값) — /admin/keys-verify로 7개 전부 MISSING 확인. 키 의존 API가 키 없이 제공되어 401 실패. 실제 키 확보 시 재활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-21T14:39:28.883282+00:00"
+  },
+  {
+    "id": "83823c31-2f86-4ce9-820c-8389e2acfee4",
+    "name": "국립중앙도서관 도서 검색",
+    "description": "국내 도서 검색. 도서관 소장 여부, 서지 정보를 확인할 수 있어요. 책 읽기 좋아하는 분께 추천.",
+    "category": "lifestyle",
+    "base_url": "https://www.nl.go.kr/NL/search/openApi/search.do",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_83823C31",
+      "param_in": "query",
+      "param_name": "key"
+    },
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://www.nl.go.kr/NL/contents/N31101030700.do",
+    "endpoints": [
+      {
+        "path": "/sas498",
+        "method": "GET",
+        "parameters": {
+          "kwd": "string"
+        },
+        "description": "도서 검색"
+      }
+    ],
+    "tags": [
+      "lifestyle",
+      "books",
+      "library",
+      "korea",
+      "api-key"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-05-01T04:27:38.517146+00:00",
+    "last_verification_note": "2026-05-01 검증: 기존 /NL/search/openApi base_url이 404 반환. 실제 엔드포인트 /search.do로 수정. HTTPS 지원.\n2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "40037e2f-a61e-4d03-a3f2-c6a2a1a60f88",
+    "name": "서울 열린데이터광장",
+    "description": "서울시 인구, 주차장, 문화행사, 와이파이 핫스팟 등 5,000개 데이터셋. 서울 생활에 유용한 정보 가득.",
+    "category": "lifestyle",
+    "base_url": "http://openapi.seoul.go.kr:8088",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_40037E2F",
+      "param_in": "path",
+      "param_name": "KEY"
+    },
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://data.seoul.go.kr/",
+    "endpoints": [
+      {
+        "path": "/{KEY}/json/{serviceName}/1/5/",
+        "method": "GET",
+        "parameters": {
+          "serviceName": "string"
+        },
+        "description": "서울시 공공데이터 조회"
+      }
+    ],
+    "tags": [
+      "lifestyle",
+      "seoul",
+      "opendata",
+      "korea",
+      "api-key"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "unverified",
+    "verified_at": "2026-05-01T04:30:05.427187+00:00",
+    "last_verification_note": "2026-05-01: HTTP 전용 서버(HTTPS 미지원). requires_proxy=true 설정으로 서버사이드 프록시 경유 호출 — Mixed Content 문제 없음.\n2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "f1ec6f97-2e13-4e9a-9a73-18738f7164b2",
+    "name": "카카오 로컬 (지도·장소 검색)",
+    "description": "한국 주소 검색, 좌표 변환, 장소 검색. \"강남역 맛집\" 같은 키워드로 주변 장소를 찾을 수 있어요.",
+    "category": "location",
+    "base_url": "https://dapi.kakao.com",
+    "auth_type": "api_key",
+    "auth_config": {
+      "prefix": "KakaoAK ",
+      "env_var": "API_KEY_F1EC6F97",
+      "param_in": "header",
+      "param_name": "Authorization"
+    },
+    "rate_limit": "100000/일",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://developers.kakao.com/docs/latest/ko/local/dev-guide",
+    "endpoints": [
+      {
+        "path": "/v2/local/search/keyword.json",
+        "method": "GET",
+        "parameters": {
+          "query": "string"
+        },
+        "description": "키워드 장소 검색"
+      },
+      {
+        "path": "/v2/local/search/address.json",
+        "method": "GET",
+        "parameters": {
+          "query": "string"
+        },
+        "description": "주소 검색"
+      }
+    ],
+    "tags": [
+      "location",
+      "map",
+      "kakao",
+      "korea",
+      "api-key"
+    ],
+    "api_version": "v2",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-05-01T00:00:00+00:00",
+    "last_verification_note": "2026-06-21 비활성화: 플랫폼 env 키 미설정(빈 값) — /admin/keys-verify로 7개 전부 MISSING 확인. 키 의존 API가 키 없이 제공되어 401 실패. 실제 키 확보 시 재활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-21T14:39:28.883282+00:00"
+  },
+  {
+    "id": "de8f5375-22dc-4573-9a64-2903c150fece",
+    "name": "Hacker News API",
+    "description": "IT·스타트업 뉴스 실시간 조회. 실리콘밸리에서 가장 핫한 기술 소식을 모아볼 수 있어요.",
+    "category": "news",
+    "base_url": "https://hacker-news.firebaseio.com",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "500",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://github.com/HackerNews/API",
+    "endpoints": [
+      {
+        "path": "/v0/topstories.json",
+        "method": "GET",
+        "description": "인기 뉴스 ID 목록 (최대 500개)",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=de8f5375-22dc-4573-9a64-2903c150fece&proxyPath=%2Fv0%2Ftopstories.json');\nconst storyIds = await res.json(); // [integer IDs]"
+      },
+      {
+        "path": "/v0/item/{id}.json",
+        "method": "GET",
+        "parameters": {
+          "id": "number"
+        },
+        "description": "뉴스 상세 조회"
+      }
+    ],
+    "tags": [
+      "news",
+      "tech",
+      "hacker-news",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v0",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:40:59.421+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:40:59.563578+00:00"
+  },
+  {
+    "id": "8461e4de-ba6d-4a4d-ae24-35bd7c47c0c7",
+    "name": "Spaceflight News API",
+    "description": "우주·항공 관련 뉴스 기사 검색. 로켓 발사, 우주 탐사 소식을 모아볼 수 있어요.",
+    "category": "news",
+    "base_url": "https://api.spaceflightnewsapi.net",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://api.spaceflightnewsapi.net/v4/docs/",
+    "endpoints": [
+      {
+        "path": "/v4/articles/",
+        "method": "GET",
+        "parameters": {
+          "limit": "number",
+          "search": "string"
+        },
+        "description": "우주 뉴스 기사 목록",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=8461e4de-ba6d-4a4d-ae24-35bd7c47c0c7&proxyPath=%2Fv4%2Farticles%2F');\nconst data = await res.json();\nconst items = data.results; // [{id, title, url, imageUrl, newsSite, summary, publishedAt}]",
+        "responseDataPath": "results"
+      }
+    ],
+    "tags": [
+      "news",
+      "space",
+      "spaceflight",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v4",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:02.995+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:41:03.131205+00:00"
+  },
+  {
+    "id": "329acf99-0a50-4577-baf4-e32512f37754",
+    "name": "NEIS 학교급식",
+    "description": "교육부 NEIS 학교 급식 식단 정보 API. 날짜·학교별 메뉴 조회. 무료 (교육행정정보시스템 키 필요).",
+    "category": "public",
+    "base_url": "https://open.neis.go.kr/hub",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_NEIS",
+      "param_in": "query",
+      "param_name": "KEY"
+    },
+    "rate_limit": "1000",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://open.neis.go.kr/portal/data/service/selectServicePage.do?page=1&rows=10&sortColumn=&sortDirection=&infId=OPEN17320190722180924242823&infSeq=2",
+    "endpoints": [
+      {
+        "path": "/mealServiceDietInfo",
+        "method": "GET",
+        "parameters": {
+          "Type": "json",
+          "pSize": "10",
+          "MLSV_YMD": "날짜 YYYYMMDD",
+          "SD_SCHUL_CODE": "학교코드",
+          "ATPT_OFCDC_SC_CODE": "시도교육청코드 (예: B10=서울)"
+        },
+        "description": "학교 급식 식단 정보 조회",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=<이 API ID>&proxyPath=%2FmealServiceDietInfo&ATPT_OFCDC_SC_CODE=B10&SD_SCHUL_CODE=7010056&MLSV_YMD=20250501&Type=json&pSize=5');\nconst data = await res.json();\nconst rows = data.mealServiceDietInfo[1].row;",
+        "responseDataPath": "mealServiceDietInfo[1].row"
+      },
+      {
+        "path": "/schoolInfo",
+        "method": "GET",
+        "parameters": {
+          "Type": "json",
+          "pSize": "10",
+          "SCHUL_NM": "학교명"
+        },
+        "description": "학교 정보 조회 (학교명·코드 검색용)",
+        "responseDataPath": "schoolInfo[1].row"
+      }
+    ],
+    "tags": [
+      "public",
+      "education",
+      "school",
+      "meal",
+      "kr",
+      "api_key"
+    ],
+    "api_version": null,
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "unverified",
+    "verified_at": null,
+    "last_verification_note": "2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-05-01T04:02:58.319122+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "17665554-5a7c-4df0-91a7-826dab855f05",
+    "name": "국토부 아파트 전월세",
+    "description": "국토교통부 아파트 전·월세 실거래 데이터. 지역코드·기간으로 임대 계약 내역 조회. (공공데이터포털 키 필요)",
+    "category": "public",
+    "base_url": "https://apis.data.go.kr/1613000/RTMSDataSvcAptRent",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_MOLIT",
+      "param_in": "query",
+      "param_name": "serviceKey"
+    },
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://www.data.go.kr/data/15058017/openapi.do",
+    "endpoints": [
+      {
+        "path": "/getRTMSDataSvcAptRent",
+        "method": "GET",
+        "parameters": {
+          "pageNo": "1",
+          "LAWD_CD": "법정동코드 앞 5자리 (예: 11680=강남구)",
+          "DEAL_YMD": "계약연월 YYYYMM",
+          "numOfRows": "10"
+        },
+        "description": "아파트 전월세 실거래 조회",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=<이 API ID>&proxyPath=%2FgetRTMSDataSvcAptRent&LAWD_CD=11680&DEAL_YMD=202504&pageNo=1&numOfRows=10');\nconst data = await res.json();\nconst items = data.response.body.items.item; // [{aptNm, deposit, monthlyRent, excluUseAr}]",
+        "responseDataPath": "response.body.items.item"
+      }
+    ],
+    "tags": [
+      "public",
+      "real-estate",
+      "apartment",
+      "rent",
+      "kr",
+      "api_key",
+      "data.go.kr"
+    ],
+    "api_version": null,
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "unverified",
+    "verified_at": null,
+    "last_verification_note": "2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-05-01T04:03:27.970352+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "bda9be95-bb3b-4f30-b1da-c304445b7c3c",
+    "name": "아파트 실거래가 (국토교통부)",
+    "description": "아파트 매매 실거래가 상세 자료. 지역코드·계약연월로 실거래 내역 조회. ℹ️ \"Dev\"는 개발/테스트용이 아닌 \"상세 자료\" 버전 정식 서비스명. (공공데이터포털 키 필요)",
+    "category": "realestate",
+    "base_url": "https://apis.data.go.kr/1613000/RTMSDataSvcAptTradeDev",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_BDA9BE95",
+      "param_in": "query",
+      "param_name": "serviceKey"
+    },
+    "rate_limit": "10000/일 (개발계정)",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://www.data.go.kr/data/15126469/openapi.do",
+    "endpoints": [
+      {
+        "path": "/getRTMSDataSvcAptTradeDev",
+        "method": "GET",
+        "parameters": {
+          "LAWD_CD": "string",
+          "DEAL_YMD": "string"
+        },
+        "description": "아파트 매매 실거래가 조회"
+      }
+    ],
+    "tags": [
+      "realestate",
+      "apartment",
+      "price",
+      "korea",
+      "공공데이터",
+      "api-key"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-05-01T00:00:00+00:00",
+    "last_verification_note": "2026-06-21 비활성화: 플랫폼 env 키 미설정(빈 값) — /admin/keys-verify로 7개 전부 MISSING 확인. 키 의존 API가 키 없이 제공되어 401 실패. 실제 키 확보 시 재활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-21T14:39:28.883282+00:00"
+  },
+  {
+    "id": "2937a35f-806e-402c-98c3-d0261e1ad2f4",
+    "name": "카카오 검색",
+    "description": "카카오 REST API 검색 서비스. 웹·이미지·동영상·블로그·뉴스·도서 검색. 무료 (카카오 Developers REST API 키 필요).",
+    "category": "search",
+    "base_url": "https://dapi.kakao.com/v2",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_F1EC6F97",
+      "param_in": "header",
+      "param_name": "Authorization",
+      "header_prefix": "KakaoAK "
+    },
+    "rate_limit": "50000/일",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://developers.kakao.com/docs/latest/ko/daum-search/dev-guide",
+    "endpoints": [
+      {
+        "path": "/search/web",
+        "method": "GET",
+        "parameters": {
+          "page": "1",
+          "size": "10",
+          "query": "검색어"
+        },
+        "description": "웹 문서 검색",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=<이 API ID>&proxyPath=%2Fsearch%2Fweb&query=날씨&size=5');\nconst data = await res.json();\nconst results = data.documents; // [{title, contents, url, datetime}]",
+        "responseDataPath": "documents"
+      },
+      {
+        "path": "/search/image",
+        "method": "GET",
+        "parameters": {
+          "size": "10",
+          "query": "string"
+        },
+        "description": "이미지 검색",
+        "responseDataPath": "documents"
+      },
+      {
+        "path": "/search/book",
+        "method": "GET",
+        "parameters": {
+          "size": "10",
+          "query": "string"
+        },
+        "description": "도서 검색",
+        "responseDataPath": "documents"
+      }
+    ],
+    "tags": [
+      "search",
+      "kakao",
+      "web",
+      "image",
+      "book",
+      "kr",
+      "api_key"
+    ],
+    "api_version": null,
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-05-01T00:00:00+00:00",
+    "last_verification_note": "2026-06-21 비활성화: 플랫폼 env 키 미설정(빈 값) — /admin/keys-verify로 7개 전부 MISSING 확인. 키 의존 API가 키 없이 제공되어 401 실패. 실제 키 확보 시 재활성화.",
+    "created_at": "2026-05-01T04:02:58.319122+00:00",
+    "updated_at": "2026-06-21T14:39:28.883282+00:00"
+  },
+  {
+    "id": "c76876b5-a4d8-49cf-a0c9-0240daf3eb5e",
+    "name": "한국관광공사 TourAPI",
+    "description": "전국 관광지, 맛집, 숙박, 축제 정보. 여행 계획 세울 때 지역별 볼거리·먹거리를 찾아보세요.",
+    "category": "tourism",
+    "base_url": "https://apis.data.go.kr/B551011/KorService1",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_TOURAPI",
+      "param_in": "query",
+      "param_name": "serviceKey"
+    },
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://api.visitkorea.or.kr/",
+    "endpoints": [
+      {
+        "path": "/areaBasedList1",
+        "method": "GET",
+        "parameters": {
+          "areaCode": "string",
+          "contentTypeId": "string"
+        },
+        "description": "지역 기반 관광지 목록"
+      },
+      {
+        "path": "/searchKeyword1",
+        "method": "GET",
+        "parameters": {
+          "keyword": "string"
+        },
+        "description": "키워드 검색"
+      }
+    ],
+    "tags": [
+      "tourism",
+      "travel",
+      "korea",
+      "공공데이터",
+      "api-key"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "unverified",
+    "verified_at": "2026-05-01T04:28:12.687985+00:00",
+    "last_verification_note": "2026-05-01: https 전환 확인. KorService1 현재 운영 중. 신버전 GW 버전 별도 존재하나 KorService1 정상. 개발계정 10,000건/일.\n2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "f68f1c00-7616-4f09-8cc5-64b751855ea0",
+    "name": "TAGO 전국 대중교통",
+    "description": "전국 버스·지하철 노선/도착정보 API. 서비스별 경로 분리 (BusRouteInfoInqireService 등). 개발계정 10,000건/일. (공공데이터포털 키 필요)",
+    "category": "transport",
+    "base_url": "https://apis.data.go.kr/1613000",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_TAGO",
+      "param_in": "query",
+      "param_name": "serviceKey"
+    },
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://www.data.go.kr/data/15098529/openapi.do",
+    "endpoints": [
+      {
+        "path": "/BusSttnInfoInqireService/getSttnNoList",
+        "method": "GET",
+        "parameters": {
+          "sttnNm": "string"
+        },
+        "description": "정류장 검색"
+      }
+    ],
+    "tags": [
+      "transport",
+      "bus",
+      "nationwide",
+      "korea",
+      "공공데이터",
+      "api-key"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "unverified",
+    "verified_at": "2026-05-01T04:29:30.77912+00:00",
+    "last_verification_note": "2026-05-01: /1613000은 기관코드 prefix. 실제 사용 시 서비스 경로 추가 필요.\n2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "4b98bb71-8cf4-43e7-9c49-938170165265",
+    "name": "서울시 버스 도착정보",
+    "description": "서울 버스 실시간 도착 시간. 정류장 이름으로 검색하면 몇 분 후 버스가 오는지 알려줘요.",
+    "category": "transport",
+    "base_url": "http://ws.bus.go.kr/api/rest",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_4B98BB71",
+      "param_in": "query",
+      "param_name": "serviceKey"
+    },
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://www.data.go.kr/data/15000314/openapi.do",
+    "endpoints": [
+      {
+        "path": "/arrive/getArrInfoByRouteAll",
+        "method": "GET",
+        "parameters": {
+          "busRouteId": "string"
+        },
+        "description": "노선별 도착 정보 조회"
+      }
+    ],
+    "tags": [
+      "transport",
+      "bus",
+      "seoul",
+      "korea",
+      "공공데이터",
+      "api-key"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "unverified",
+    "verified_at": "2026-05-01T04:30:05.427187+00:00",
+    "last_verification_note": "2026-05-01: HTTP 전용 서버(HTTPS 미지원). requires_proxy=true 설정으로 서버사이드 프록시 경유 호출 — Mixed Content 문제 없음.\n2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "70b9a73e-d2d4-4de9-88e6-7d5b26ae6fa3",
+    "name": "서울시 지하철 실시간 도착정보",
+    "description": "서울 지하철 실시간 도착 예정 시간. 역 이름만 입력하면 다음 열차까지 남은 시간을 알려줘요.",
+    "category": "transport",
+    "base_url": "http://swopenAPI.seoul.go.kr/api/subway",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_70B9A73E",
+      "param_in": "path",
+      "param_name": "KEY"
+    },
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://data.seoul.go.kr/dataList/OA-12764/F/1/datasetView.do",
+    "endpoints": [
+      {
+        "path": "/{KEY}/json/realtimeStationArrival/0/5/{stationName}",
+        "method": "GET",
+        "parameters": {
+          "stationName": "string"
+        },
+        "description": "역별 실시간 도착 정보"
+      }
+    ],
+    "tags": [
+      "transport",
+      "subway",
+      "metro",
+      "seoul",
+      "korea",
+      "api-key"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "unverified",
+    "verified_at": "2026-05-01T04:30:05.427187+00:00",
+    "last_verification_note": "2026-05-01: HTTP 전용 서버(HTTPS 미지원). requires_proxy=true 설정으로 서버사이드 프록시 경유 호출 — Mixed Content 문제 없음.\n2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "a3958ab7-a948-4884-82cb-056e2f7085af",
+    "name": "QR Code Generator",
+    "description": "텍스트나 URL을 QR코드 이미지로 변환. 명함, 링크 공유에 유용해요.",
+    "category": "utility",
+    "base_url": "https://api.qrserver.com",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://goqr.me/api/",
+    "endpoints": [
+      {
+        "path": "/v1/create-qr-code/",
+        "method": "GET",
+        "parameters": {
+          "data": "string",
+          "size": "string",
+          "color": "string"
+        },
+        "description": "QR코드 이미지 생성"
+      }
+    ],
+    "tags": [
+      "utility",
+      "qr-code",
+      "generator",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:02.438+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:41:02.578339+00:00"
+  },
+  {
+    "id": "3d19297e-a133-41f0-bdb4-549369c8b658",
+    "name": "Sunrise-Sunset",
+    "description": "원하는 위치의 일출·일몰 시각 조회. 캠핑, 낚시, 사진 촬영 계획 세울 때 유용해요.",
+    "category": "utility",
+    "base_url": "https://api.sunrise-sunset.org",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "300",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://sunrise-sunset.org/api",
+    "endpoints": [
+      {
+        "path": "/json",
+        "method": "GET",
+        "parameters": {
+          "lat": "number",
+          "lng": "number",
+          "date": "string"
+        },
+        "description": "일출·일몰 시각 조회"
+      }
+    ],
+    "tags": [
+      "utility",
+      "sunrise",
+      "sunset",
+      "astronomy",
+      "free",
+      "no-auth"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:03.267+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:41:03.409596+00:00"
+  },
+  {
+    "id": "522f7158-7de0-4447-80bb-ea71a8e56b50",
+    "name": "The Color API",
+    "description": "HEX/RGB 색상 코드로 색상 이름·보완색·팔레트 생성. 인증 불필요.",
+    "category": "utility",
+    "base_url": "https://www.thecolorapi.com",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": null,
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://www.thecolorapi.com/docs",
+    "endpoints": [
+      {
+        "path": "/id",
+        "method": "GET",
+        "parameters": {
+          "hex": "HEX 코드 (# 제외, 예: FF5733)"
+        },
+        "description": "색상 정보 조회 (이름, RGB, HSL)",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=<이 API ID>&proxyPath=%2Fid&hex=FF5733');\nconst data = await res.json();\n// data.name.value, data.rgb, data.hsl, data.image.bare",
+        "responseDataPath": ""
+      },
+      {
+        "path": "/scheme",
+        "method": "GET",
+        "parameters": {
+          "hex": "string",
+          "mode": "monochrome | analogic | complement | triad | quad",
+          "count": "5"
+        },
+        "description": "색상 팔레트 생성",
+        "responseDataPath": "colors"
+      }
+    ],
+    "tags": [
+      "utility",
+      "color",
+      "design",
+      "palette",
+      "free",
+      "no-auth"
+    ],
+    "api_version": null,
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:03.817+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-05-01T04:02:26.332579+00:00",
+    "updated_at": "2026-06-22T21:41:03.958031+00:00"
+  },
+  {
+    "id": "9a04cd18-15bb-4424-a4f1-10ddf728749b",
+    "name": "wheretheiss.at",
+    "description": "국제우주정거장(ISS) 실시간 위치 추적. 위도·경도·고도·속도 제공. HTTPS 지원, 무료.",
+    "category": "utility",
+    "base_url": "https://api.wheretheiss.at",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "60",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://wheretheiss.at/w/developer",
+    "endpoints": [
+      {
+        "path": "/v1/satellites/25544",
+        "method": "GET",
+        "description": "ISS 현재 위치 (위도·경도·고도·속도)",
+        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=9a04cd18-15bb-4424-a4f1-10ddf728749b&proxyPath=%2Fv1%2Fsatellites%2F25544');\nconst data = await res.json();\n// data.latitude, data.longitude, data.altitude, data.velocity",
+        "responseDataPath": ""
+      },
+      {
+        "path": "/v1/satellites",
+        "method": "GET",
+        "description": "추적 가능 위성 목록"
+      }
+    ],
+    "tags": [
+      "utility",
+      "space",
+      "iss",
+      "satellite",
+      "free",
+      "no-auth",
+      "https"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:04.368+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: degraded",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-22T21:41:04.509896+00:00"
+  },
+  {
+    "id": "a3f8d2e1-7c4b-4a9f-b6e5-1d2c3f4e5a6b",
+    "name": "Open-Meteo",
+    "description": "무료 날씨 API. 키 불필요, 비상업적 전용(CC BY 4.0). 위도/경도 기반 현재 날씨 및 예보 제공.",
+    "category": "weather",
+    "base_url": "https://api.open-meteo.com",
+    "auth_type": "none",
+    "auth_config": {},
+    "rate_limit": "10000/일",
+    "changelog": [],
+    "is_active": true,
+    "icon_url": null,
+    "docs_url": "https://open-meteo.com/en/docs",
+    "endpoints": [
+      {
+        "path": "/v1/forecast",
+        "method": "GET",
+        "description": "위도/경도 기반 날씨 예보",
+        "example_call": "/v1/forecast?latitude=37.5665&longitude=126.9780&current_weather=true"
+      }
+    ],
+    "tags": [
+      "weather",
+      "forecast",
+      "free",
+      "no-key"
+    ],
+    "api_version": null,
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "verified",
+    "verified_at": "2026-06-22T21:41:01.889+00:00",
+    "last_verification_note": "2026-06-22 자동 헬스체크: working",
+    "created_at": "2026-05-01T06:43:17.094337+00:00",
+    "updated_at": "2026-06-22T21:41:02.023617+00:00"
+  },
+  {
+    "id": "2b7d8eef-b498-4198-b504-05c8f8d3a213",
+    "name": "OpenWeatherMap",
+    "description": "현재 날씨, 5일 예보, 대기질 정보를 제공해요. 무료 가입 후 API 키를 발급받아 사용합니다.",
+    "category": "weather",
+    "base_url": "https://api.openweathermap.org",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_OPENWEATHERMAP",
+      "param_in": "query",
+      "param_name": "appid"
+    },
+    "rate_limit": "60",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://openweathermap.org/api",
+    "endpoints": [
+      {
+        "path": "/data/2.5/weather",
+        "method": "GET",
+        "parameters": {
+          "q": "string",
+          "lat": "number",
+          "lon": "number",
+          "units": "string"
+        },
+        "description": "도시명 또는 좌표로 현재 날씨 조회"
+      }
+    ],
+    "tags": [
+      "weather",
+      "forecast",
+      "api-key"
+    ],
+    "api_version": "v2.5",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": 0,
+    "cache_ttl_seconds": null,
+    "verification_status": "unverified",
+    "verified_at": null,
+    "last_verification_note": "2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "fc7572d1-1acb-4c12-9355-553a83718e39",
+    "name": "WeatherAPI.com",
+    "description": "14일 예보 + 일출·일몰 시각을 알려줘요. 월 100만 호출 무료. 캠핑·야외 활동 계획에 유용합니다.",
+    "category": "weather",
+    "base_url": "https://api.weatherapi.com",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_WEATHERAPICOM",
+      "param_in": "query",
+      "param_name": "key"
+    },
+    "rate_limit": "100000/월",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://www.weatherapi.com/docs/",
+    "endpoints": [
+      {
+        "path": "/v1/forecast.json",
+        "method": "GET",
+        "parameters": {
+          "q": "string",
+          "days": "number"
+        },
+        "description": "날씨 예보 조회 (최대 14일)"
+      }
+    ],
+    "tags": [
+      "weather",
+      "forecast",
+      "astronomy",
+      "api-key"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": true,
+    "requires_proxy": false,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "unverified",
+    "verified_at": "2026-05-01T04:28:47.706287+00:00",
+    "last_verification_note": "2026-05-01: 무료 플랜 월 100,000건. 신용카드 불필요. 3일 예보, 역사 데이터 1일 포함.\n2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  },
+  {
+    "id": "7cb8f428-e284-4eee-944a-af47274662d2",
+    "name": "기상청 단기예보",
+    "description": "우리 동네 날씨 예보. 기온, 비, 눈, 바람, 습도를 3시간 단위로 알려줘요. 공공데이터포털 무료 가입 후 사용.",
+    "category": "weather",
+    "base_url": "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_7CB8F428",
+      "param_in": "query",
+      "param_name": "serviceKey"
+    },
+    "rate_limit": "10000/일 (개발계정)",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://www.data.go.kr/data/15084084/openapi.do",
+    "endpoints": [
+      {
+        "path": "/getVilageFcst",
+        "method": "GET",
+        "parameters": {
+          "nx": "number",
+          "ny": "number",
+          "base_date": "string",
+          "base_time": "string"
+        },
+        "description": "동네 예보 조회 (3시간 단위)"
+      }
+    ],
+    "tags": [
+      "weather",
+      "korea",
+      "공공데이터",
+      "api-key"
+    ],
+    "api_version": "v2.0",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": 10800,
+    "verification_status": "verified",
+    "verified_at": "2026-05-01T00:00:00+00:00",
+    "last_verification_note": "2026-06-21 비활성화: 플랫폼 env 키 미설정(빈 값) — /admin/keys-verify로 7개 전부 MISSING 확인. 키 의존 API가 키 없이 제공되어 401 실패. 실제 키 확보 시 재활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-21T14:39:28.883282+00:00"
+  },
+  {
+    "id": "00412c2b-6c17-4b23-9a3d-46b7004285e4",
+    "name": "기상청 중기예보",
+    "description": "3~10일 후 날씨 전망. 이번 주 비가 올지, 기온이 어떨지 미리 확인할 수 있어요.",
+    "category": "weather",
+    "base_url": "https://apis.data.go.kr/1360000/MidFcstInfoService",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_00412C2B",
+      "param_in": "query",
+      "param_name": "serviceKey"
+    },
+    "rate_limit": "10000/일 (개발계정)",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://www.data.go.kr/data/15059468/openapi.do",
+    "endpoints": [
+      {
+        "path": "/getMidTa",
+        "method": "GET",
+        "parameters": {
+          "tmFc": "string",
+          "regId": "string"
+        },
+        "description": "중기 기온 예보 조회"
+      }
+    ],
+    "tags": [
+      "weather",
+      "korea",
+      "공공데이터",
+      "api-key"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": 21600,
+    "verification_status": "verified",
+    "verified_at": "2026-05-01T00:00:00+00:00",
+    "last_verification_note": "2026-06-21 비활성화: 플랫폼 env 키 미설정(빈 값) — /admin/keys-verify로 7개 전부 MISSING 확인. 키 의존 API가 키 없이 제공되어 401 실패. 실제 키 확보 시 재활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-06-21T14:39:28.883282+00:00"
+  },
+  {
+    "id": "c84860a1-336c-45f1-b1df-00f25bd810bd",
+    "name": "에어코리아 대기오염정보",
+    "description": "대기오염 측정 정보. 측정소별 미세먼지·초미세먼지·오존 등 실시간 조회. ⚠️ 개발계정 일일 한도 500건 (타 공공API 10,000건의 1/20). (공공데이터포털 키 필요)",
+    "category": "weather",
+    "base_url": "https://apis.data.go.kr/B552584/ArpltnInforInqireSvc",
+    "auth_type": "api_key",
+    "auth_config": {
+      "env_var": "API_KEY_C84860A1",
+      "param_in": "query",
+      "param_name": "serviceKey"
+    },
+    "rate_limit": "500/일",
+    "changelog": [],
+    "is_active": false,
+    "icon_url": null,
+    "docs_url": "https://www.data.go.kr/data/15073861/openapi.do",
+    "endpoints": [
+      {
+        "path": "/getMsrstnAcctoRltmMesureDnsty",
+        "method": "GET",
+        "parameters": {
+          "dataTerm": "string",
+          "stationName": "string"
+        },
+        "description": "측정소별 실시간 대기질 조회"
+      }
+    ],
+    "tags": [
+      "weather",
+      "air-quality",
+      "korea",
+      "공공데이터",
+      "api-key"
+    ],
+    "api_version": "v1",
+    "deprecated_at": null,
+    "successor_id": null,
+    "cors_supported": false,
+    "requires_proxy": true,
+    "credit_required": null,
+    "cache_ttl_seconds": null,
+    "verification_status": "unverified",
+    "verified_at": "2026-05-01T04:29:30.77912+00:00",
+    "last_verification_note": "2026-05-01: HTTPS 전환. 개발계정 500건/일은 타 API 대비 매우 낮음. 운영계정 신청 권장.\n2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
+    "created_at": "2026-03-26T11:51:21.691024+00:00",
+    "updated_at": "2026-05-01T05:56:30.495522+00:00"
+  }
+]

--- a/src/data/featureFlags.json
+++ b/src/data/featureFlags.json
@@ -1,0 +1,44 @@
+[
+  {
+    "flag_name": "enable_advanced_prompt",
+    "enabled": false,
+    "description": "Enable advanced prompt engineering options for code generation",
+    "rules": { "max_tokens": 4096 }
+  },
+  {
+    "flag_name": "enable_code_viewer",
+    "enabled": true,
+    "description": "Enable the code viewer panel for generated output",
+    "rules": { "default": true }
+  },
+  {
+    "flag_name": "enable_dark_mode",
+    "enabled": true,
+    "description": "Enable dark mode UI theme toggle",
+    "rules": { "default": true }
+  },
+  {
+    "flag_name": "enable_multi_language",
+    "enabled": false,
+    "description": "Enable multi-language UI support (i18n)",
+    "rules": { "supported": ["ko", "en", "ja"] }
+  },
+  {
+    "flag_name": "enable_ollama_fallback",
+    "enabled": false,
+    "description": "Fall back to local Ollama models when cloud AI is unavailable",
+    "rules": { "models": ["llama3", "codellama"] }
+  },
+  {
+    "flag_name": "enable_team_features",
+    "enabled": false,
+    "description": "Enable team collaboration and organization features",
+    "rules": { "min_plan": "pro" }
+  },
+  {
+    "flag_name": "enable_template_system",
+    "enabled": false,
+    "description": "Enable project templates for quick start",
+    "rules": { "categories": ["dashboard", "landing", "widget"] }
+  }
+]

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -6,6 +6,14 @@ export async function register() {
     // 발행한 이벤트(PROJECT_CREATED, DEPLOYMENT_* 등)가 영속화되지 않을 수 있었다.
     const { registerEventPersister } = await import('./lib/events/eventPersister');
     registerEventPersister();
+
+    // SQLite 영속성 부팅 부트스트랩: 마이그레이션 적용 + 단일 관리자 시드(둘 다 멱등).
+    // DB_PROVIDER=sqlite 에서만 동작 — 기존 Supabase 경로는 무영향(opt-in).
+    if (process.env.DB_PROVIDER === 'sqlite') {
+      const { getSqliteDb } = await import('./lib/db/sqlite/connection');
+      const { bootstrapSqlite } = await import('./lib/db/sqlite/bootstrap');
+      bootstrapSqlite(getSqliteDb());
+    }
   }
 
   if (process.env.NEXT_RUNTIME === 'edge') {

--- a/src/lib/auth/adminCredentials.test.ts
+++ b/src/lib/auth/adminCredentials.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  hashPassword,
+  verifyPassword,
+  verifyAdminCredentials,
+  getAdminUserId,
+} from './adminCredentials';
+
+describe('hashPassword / verifyPassword', () => {
+  it('해시 round-trip이 검증된다', () => {
+    const stored = hashPassword('s3cret-pw');
+    expect(stored).toMatch(/^[0-9a-f]+:[0-9a-f]+$/);
+    expect(verifyPassword('s3cret-pw', stored)).toBe(true);
+  });
+
+  it('틀린 비밀번호는 거부한다', () => {
+    const stored = hashPassword('correct');
+    expect(verifyPassword('wrong', stored)).toBe(false);
+  });
+
+  it('손상/빈 저장값은 false', () => {
+    expect(verifyPassword('x', undefined)).toBe(false);
+    expect(verifyPassword('x', '')).toBe(false);
+    expect(verifyPassword('x', 'no-colon')).toBe(false);
+    expect(verifyPassword('x', 'salt:nothex!')).toBe(false);
+  });
+});
+
+describe('verifyAdminCredentials', () => {
+  const ORIG = { ...process.env };
+  beforeEach(() => {
+    process.env.ADMIN_EMAIL = 'admin@example.com';
+    process.env.ADMIN_PASSWORD_HASH = hashPassword('hunter2');
+  });
+  afterEach(() => {
+    process.env = { ...ORIG };
+  });
+
+  it('이메일·비번 일치 시 관리자 AuthUser 반환', () => {
+    const u = verifyAdminCredentials('admin@example.com', 'hunter2');
+    expect(u).not.toBeNull();
+    expect(u?.email).toBe('admin@example.com');
+    expect(u?.id).toBe(getAdminUserId());
+    expect(u?.name).toBe('Admin');
+  });
+
+  it('이메일은 대소문자·공백 무시', () => {
+    expect(verifyAdminCredentials('  ADMIN@Example.com ', 'hunter2')).not.toBeNull();
+  });
+
+  it('틀린 비번/이메일은 null', () => {
+    expect(verifyAdminCredentials('admin@example.com', 'wrong')).toBeNull();
+    expect(verifyAdminCredentials('other@example.com', 'hunter2')).toBeNull();
+  });
+
+  it('env 미설정 시 null (로그인 비활성)', () => {
+    delete process.env.ADMIN_EMAIL;
+    delete process.env.ADMIN_PASSWORD_HASH;
+    expect(verifyAdminCredentials('admin@example.com', 'hunter2')).toBeNull();
+  });
+});

--- a/src/lib/auth/adminCredentials.ts
+++ b/src/lib/auth/adminCredentials.ts
@@ -1,0 +1,61 @@
+import { scryptSync, randomBytes, timingSafeEqual } from 'node:crypto';
+import type { AuthUser } from '@/lib/auth/types';
+
+/**
+ * 단일 관리자(셀프호스트) 자격증명 검증 — AUTH_PROVIDER=local 경로.
+ *
+ * 비밀번호는 env(`ADMIN_PASSWORD_HASH`)에 scrypt 해시("salt:hash" hex)로 보관하고,
+ * 평문은 어디에도 저장하지 않는다. 검증은 timing-safe 비교를 사용한다.
+ * 관리자 신원은 `users.id`(FK 앵커)와 일치해야 하므로 고정 id를 사용한다.
+ */
+
+const SCRYPT_KEYLEN = 64;
+
+/** 비밀번호를 scrypt 해시로 변환한다. 반환: "salt:hash"(hex). 관리자 비번 설정 시 1회 사용. */
+export function hashPassword(password: string): string {
+  const salt = randomBytes(16).toString('hex');
+  const hash = scryptSync(password, salt, SCRYPT_KEYLEN).toString('hex');
+  return `${salt}:${hash}`;
+}
+
+/** 평문 비밀번호가 저장된 "salt:hash"와 일치하는지 timing-safe 비교한다. */
+export function verifyPassword(password: string, stored: string | undefined): boolean {
+  if (!stored) return false;
+  const [salt, hash] = stored.split(':');
+  if (!salt || !hash) return false;
+  let expected: Buffer;
+  try {
+    expected = Buffer.from(hash, 'hex');
+  } catch {
+    return false;
+  }
+  if (expected.length !== SCRYPT_KEYLEN) return false;
+  const actual = scryptSync(password, salt, SCRYPT_KEYLEN);
+  return timingSafeEqual(actual, expected);
+}
+
+/** 단일 관리자 users.id (FK 앵커). 관리자 users 행 시드와 일치해야 한다. env로 재정의 가능. */
+export function getAdminUserId(): string {
+  return process.env.ADMIN_USER_ID ?? '00000000-0000-0000-0000-000000000001';
+}
+
+/**
+ * 단일 관리자 자격증명을 검증한다 (Auth.js Credentials authorize에서 호출).
+ * `ADMIN_EMAIL` + `ADMIN_PASSWORD_HASH`(env)와 대조해 일치 시 관리자 AuthUser, 아니면 null.
+ */
+export function verifyAdminCredentials(email: string, password: string): AuthUser | null {
+  const adminEmail = process.env.ADMIN_EMAIL;
+  const adminHash = process.env.ADMIN_PASSWORD_HASH;
+  if (!adminEmail || !adminHash) return null;
+
+  const emailMatches = email.trim().toLowerCase() === adminEmail.trim().toLowerCase();
+  const passwordMatches = verifyPassword(password, adminHash);
+  if (!emailMatches || !passwordMatches) return null;
+
+  return {
+    id: getAdminUserId(),
+    email: adminEmail,
+    name: process.env.ADMIN_NAME ?? 'Admin',
+    avatarUrl: null,
+  };
+}

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -6,6 +6,11 @@ export type { AuthUser };
 export async function getAuthUser(): Promise<AuthUser | null> {
   const provider = getAuthProvider();
 
+  if (provider === 'local') {
+    const { getLocalAuthUser } = await import('@/lib/auth/local-auth');
+    return getLocalAuthUser();
+  }
+
   if (provider === 'authjs') {
     const { getAuthJsUser } = await import('@/lib/auth/authjs-auth');
     return getAuthJsUser();

--- a/src/lib/auth/local-auth-base.test.ts
+++ b/src/lib/auth/local-auth-base.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { localAuthBaseConfig } from './local-auth-base';
+
+/**
+ * 공유 base 설정의 JWT 무상태 콜백 검증.
+ * (NextAuth 인스턴스 자체는 통합 영역 — 여기서는 순수 콜백 로직만 단위 검증한다.)
+ */
+describe('localAuthBaseConfig callbacks', () => {
+  const jwt = localAuthBaseConfig.callbacks.jwt;
+  const session = localAuthBaseConfig.callbacks.session;
+
+  it('jwt: 로그인 시 user.id를 token.sub에 고정한다', async () => {
+    const token = await jwt({ token: {}, user: { id: 'admin-1' } } as never);
+    expect(token.sub).toBe('admin-1');
+  });
+
+  it('jwt: 후속 요청(user 없음)은 기존 token을 보존한다', async () => {
+    const token = await jwt({ token: { sub: 'existing' }, user: undefined } as never);
+    expect(token.sub).toBe('existing');
+  });
+
+  it('session: token.sub를 session.user.id로 매핑한다', async () => {
+    const s = await session({ session: { user: {} }, token: { sub: 'admin-1' } } as never);
+    expect(s.user.id).toBe('admin-1');
+  });
+
+  it('JWT 무상태 세션 전략을 사용한다', () => {
+    expect(localAuthBaseConfig.session.strategy).toBe('jwt');
+  });
+});

--- a/src/lib/auth/local-auth-base.ts
+++ b/src/lib/auth/local-auth-base.ts
@@ -1,0 +1,23 @@
+// AUTH_PROVIDER=local 공유 설정 — edge-safe (node:crypto 등 Node 전용 모듈 미의존).
+//
+// 전체 설정(local-auth-config, Node 런타임 — Credentials authorize가 scrypt 사용)과
+// 미들웨어용 edge 설정(local-auth-edge)이 이 base를 공유한다. 동일 AUTH_SECRET·동일 JWT
+// 콜백을 사용하므로, 전체 설정이 로그인 시 발급한 JWT를 edge 설정이 미들웨어에서 검증할 수 있다.
+//
+// JWT 무상태 세션: 로그인 시 관리자 id를 token.sub에 고정 → 이후 요청은 토큰만으로 신원 확인.
+import type { NextAuthConfig } from 'next-auth';
+
+// providers는 각 config(전체/edge)가 채우므로 base에서는 생략한다(Omit).
+export const localAuthBaseConfig = {
+  session: { strategy: 'jwt' },
+  callbacks: {
+    jwt({ token, user }) {
+      if (user?.id) token.sub = user.id;
+      return token;
+    },
+    session({ session, token }) {
+      if (token.sub) session.user.id = token.sub;
+      return session;
+    },
+  },
+} satisfies Omit<NextAuthConfig, 'providers'>;

--- a/src/lib/auth/local-auth-config.ts
+++ b/src/lib/auth/local-auth-config.ts
@@ -6,9 +6,13 @@
 import NextAuth from 'next-auth';
 import Credentials from 'next-auth/providers/credentials';
 import { verifyAdminCredentials } from '@/lib/auth/adminCredentials';
+import { localAuthBaseConfig } from '@/lib/auth/local-auth-base';
 
+// 전체 설정(Node 런타임) — Credentials authorize가 scrypt(node:crypto)를 사용하므로 edge 불가.
+// 라우트 핸들러(/api/auth/[...nextauth])와 서버 측 getLocalAuthUser가 이 설정을 동적 import한다.
+// 세션 전략·JWT 콜백은 edge 설정과 동일한 localAuthBaseConfig를 공유한다(JWT 호환).
 export const { auth, handlers, signIn, signOut } = NextAuth({
-  session: { strategy: 'jwt' },
+  ...localAuthBaseConfig,
   providers: [
     Credentials({
       credentials: {
@@ -24,15 +28,4 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
       },
     }),
   ],
-  callbacks: {
-    jwt({ token, user }) {
-      // 로그인 시 관리자 id를 토큰 subject에 고정 (이후 요청은 토큰만으로 신원 확인 — 무상태)
-      if (user?.id) token.sub = user.id;
-      return token;
-    },
-    session({ session, token }) {
-      if (token.sub) session.user.id = token.sub;
-      return session;
-    },
-  },
 });

--- a/src/lib/auth/local-auth-config.ts
+++ b/src/lib/auth/local-auth-config.ts
@@ -1,0 +1,38 @@
+// AUTH_PROVIDER=local 전용 — Auth.js v5 Credentials + JWT 무상태 세션 (DB 어댑터 없음).
+//
+// authjs-config(OAuth+DrizzleAdapter)와 달리 module-load 시 getDb()를 호출하지 않으므로
+// Node 전용 DB 그래프를 끌어오지 않는다. 그래도 getAuthUser/미들웨어에서 동적 import로
+// 로드해 정적 체인을 끊는다(일관성·안전).
+import NextAuth from 'next-auth';
+import Credentials from 'next-auth/providers/credentials';
+import { verifyAdminCredentials } from '@/lib/auth/adminCredentials';
+
+export const { auth, handlers, signIn, signOut } = NextAuth({
+  session: { strategy: 'jwt' },
+  providers: [
+    Credentials({
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      authorize(credentials) {
+        const email = typeof credentials?.email === 'string' ? credentials.email : '';
+        const password = typeof credentials?.password === 'string' ? credentials.password : '';
+        const user = verifyAdminCredentials(email, password);
+        if (!user) return null;
+        return { id: user.id, email: user.email, name: user.name ?? undefined };
+      },
+    }),
+  ],
+  callbacks: {
+    jwt({ token, user }) {
+      // 로그인 시 관리자 id를 토큰 subject에 고정 (이후 요청은 토큰만으로 신원 확인 — 무상태)
+      if (user?.id) token.sub = user.id;
+      return token;
+    },
+    session({ session, token }) {
+      if (token.sub) session.user.id = token.sub;
+      return session;
+    },
+  },
+});

--- a/src/lib/auth/local-auth-edge.ts
+++ b/src/lib/auth/local-auth-edge.ts
@@ -1,0 +1,18 @@
+// AUTH_PROVIDER=local 미들웨어용 edge-safe 설정.
+//
+// 미들웨어(Edge 런타임)는 node:crypto를 끌어오는 local-auth-config(전체 설정)를 import할 수 없다.
+// 세션 검증(JWT 읽기)에는 Credentials authorize(scrypt)가 필요 없으므로, authorize 없는 stub
+// provider만 둔 edge 설정을 별도로 만든다. 동일 AUTH_SECRET·동일 base 콜백을 공유하므로,
+// 전체 설정이 로그인 시 발급한 JWT 쿠키를 이 설정의 auth()가 검증할 수 있다.
+//
+// "Edge 임포트 위반 0" — 이 모듈의 정적 import 체인에는 Node 전용 모듈이 없다.
+import NextAuth from 'next-auth';
+import Credentials from 'next-auth/providers/credentials';
+import { localAuthBaseConfig } from '@/lib/auth/local-auth-base';
+
+export const { auth } = NextAuth({
+  ...localAuthBaseConfig,
+  // verification 전용 stub — 미들웨어는 로그인을 수행하지 않으므로 authorize는 호출되지 않는다.
+  // (실제 자격증명 검증은 Node 런타임의 local-auth-config에만 존재한다.)
+  providers: [Credentials({ authorize: () => null })],
+});

--- a/src/lib/auth/local-auth.ts
+++ b/src/lib/auth/local-auth.ts
@@ -1,0 +1,15 @@
+// local-auth-config는 NextAuth를 module-load 시 초기화하므로 정적 import하지 않는다.
+// AUTH_PROVIDER=local 경로에서 호출 시점에 동적 import한다(supabase 모드 무영향).
+import type { AuthUser } from '@/lib/auth/types';
+
+export async function getLocalAuthUser(): Promise<AuthUser | null> {
+  const { auth } = await import('@/lib/auth/local-auth-config');
+  const session = await auth();
+  if (!session?.user?.id || !session.user.email) return null;
+  return {
+    id: session.user.id,
+    email: session.user.email,
+    name: session.user.name ?? null,
+    avatarUrl: session.user.image ?? null,
+  };
+}

--- a/src/lib/config/providers.test.ts
+++ b/src/lib/config/providers.test.ts
@@ -106,10 +106,24 @@ describe('getAuthProvider()', () => {
     });
   });
 
+  it('AUTH_PROVIDER=local 이고 AUTH_SECRET이 설정된 경우 local을 반환한다', () => {
+    withEnv({ AUTH_PROVIDER: 'local', AUTH_SECRET: 'super-secret' }, () => {
+      expect(getAuthProvider()).toBe('local');
+    });
+  });
+
+  it('AUTH_PROVIDER=local 이지만 AUTH_SECRET이 없으면 에러를 던진다', () => {
+    withEnv({ AUTH_PROVIDER: 'local', AUTH_SECRET: undefined }, () => {
+      expect(() => getAuthProvider()).toThrow(
+        'AUTH_PROVIDER=local 설정 시 AUTH_SECRET 환경변수가 필요합니다.'
+      );
+    });
+  });
+
   it('알 수 없는 AUTH_PROVIDER 값이면 에러를 던진다', () => {
     withEnv({ AUTH_PROVIDER: 'firebase' }, () => {
       expect(() => getAuthProvider()).toThrow(
-        '알 수 없는 AUTH_PROVIDER 값: "firebase". "supabase" 또는 "authjs"를 사용하세요.'
+        '알 수 없는 AUTH_PROVIDER 값: "firebase". "supabase", "authjs", "local" 중 하나를 사용하세요.'
       );
     });
   });

--- a/src/lib/config/providers.test.ts
+++ b/src/lib/config/providers.test.ts
@@ -64,10 +64,16 @@ describe('getDbProvider()', () => {
     });
   });
 
+  it('DB_PROVIDER=sqlite 이면 sqlite를 반환한다 (필수 env 없음)', () => {
+    withEnv({ DB_PROVIDER: 'sqlite', DATABASE_URL: undefined }, () => {
+      expect(getDbProvider()).toBe('sqlite');
+    });
+  });
+
   it('알 수 없는 DB_PROVIDER 값이면 에러를 던진다', () => {
     withEnv({ DB_PROVIDER: 'mysql' }, () => {
       expect(() => getDbProvider()).toThrow(
-        '알 수 없는 DB_PROVIDER 값: "mysql". "supabase" 또는 "postgres"를 사용하세요.'
+        '알 수 없는 DB_PROVIDER 값: "mysql". "supabase", "postgres", "sqlite" 중 하나를 사용하세요.'
       );
     });
   });

--- a/src/lib/config/providers.ts
+++ b/src/lib/config/providers.ts
@@ -1,7 +1,7 @@
 // Provider configuration: Supabase vs On-Premise PostgreSQL
 import { isInFailover } from '@/lib/db/failover';
 
-export type DbProvider = 'supabase' | 'postgres';
+export type DbProvider = 'supabase' | 'postgres' | 'sqlite';
 export type AuthProvider = 'supabase' | 'authjs';
 
 let _cachedDbProvider: DbProvider | undefined;
@@ -14,6 +14,7 @@ let _cachedAuthProvider: AuthProvider | undefined;
  *
  * - 미설정 또는 `"supabase"` → `'supabase'` (기본값)
  * - `"postgres"` → `'postgres'` (이 경우 `DATABASE_URL`이 반드시 설정되어야 합니다)
+ * - `"sqlite"` → `'sqlite'` (임베디드 단일 인스턴스. `SQLITE_PATH` 미설정 시 `/data/app.db` 기본)
  * - 그 외 값 → 에러를 던집니다
  *
  * @throws {Error} DB_PROVIDER가 알 수 없는 값이거나 postgres 선택 시 DATABASE_URL이 없을 때
@@ -33,8 +34,13 @@ export function getDbProvider(): DbProvider {
       throw new Error('DB_PROVIDER=postgres 설정 시 DATABASE_URL 환경변수가 필요합니다.');
     }
     result = 'postgres';
+  } else if (provider === 'sqlite') {
+    // SQLITE_PATH 미설정 시 /data/app.db(Railway 볼륨) 기본값 사용 — 별도 필수 env 없음
+    result = 'sqlite';
   } else {
-    throw new Error(`알 수 없는 DB_PROVIDER 값: "${provider}". "supabase" 또는 "postgres"를 사용하세요.`);
+    throw new Error(
+      `알 수 없는 DB_PROVIDER 값: "${provider}". "supabase", "postgres", "sqlite" 중 하나를 사용하세요.`,
+    );
   }
   _cachedDbProvider = result;
   return _cachedDbProvider;

--- a/src/lib/config/providers.ts
+++ b/src/lib/config/providers.ts
@@ -2,7 +2,7 @@
 import { isInFailover } from '@/lib/db/failover';
 
 export type DbProvider = 'supabase' | 'postgres' | 'sqlite';
-export type AuthProvider = 'supabase' | 'authjs';
+export type AuthProvider = 'supabase' | 'authjs' | 'local';
 
 let _cachedDbProvider: DbProvider | undefined;
 let _cachedAuthProvider: AuthProvider | undefined;
@@ -52,10 +52,11 @@ export function getDbProvider(): DbProvider {
  * authjs 모드에서 failover가 활성화된 경우 'supabase'를 반환합니다.
  *
  * - 미설정 또는 `"supabase"` → `'supabase'` (기본값)
- * - `"authjs"` → `'authjs'` (이 경우 `AUTH_SECRET`이 반드시 설정되어야 합니다)
+ * - `"authjs"` → `'authjs'` (OAuth + DrizzleAdapter. `AUTH_SECRET` 필요)
+ * - `"local"` → `'local'` (Auth.js Credentials 단일 관리자 + JWT 무상태. `AUTH_SECRET` 필요)
  * - 그 외 값 → 에러를 던집니다
  *
- * @throws {Error} AUTH_PROVIDER가 알 수 없는 값이거나 authjs 선택 시 AUTH_SECRET이 없을 때
+ * @throws {Error} AUTH_PROVIDER가 알 수 없는 값이거나 authjs/local 선택 시 AUTH_SECRET이 없을 때
  */
 export function getAuthProvider(): AuthProvider {
   // failover 활성 시 supabase 반환 (캐시값이 authjs인 경우에만 적용)
@@ -72,8 +73,15 @@ export function getAuthProvider(): AuthProvider {
       throw new Error('AUTH_PROVIDER=authjs 설정 시 AUTH_SECRET 환경변수가 필요합니다.');
     }
     result = 'authjs';
+  } else if (provider === 'local') {
+    if (!process.env.AUTH_SECRET) {
+      throw new Error('AUTH_PROVIDER=local 설정 시 AUTH_SECRET 환경변수가 필요합니다.');
+    }
+    result = 'local';
   } else {
-    throw new Error(`알 수 없는 AUTH_PROVIDER 값: "${provider}". "supabase" 또는 "authjs"를 사용하세요.`);
+    throw new Error(
+      `알 수 없는 AUTH_PROVIDER 값: "${provider}". "supabase", "authjs", "local" 중 하나를 사용하세요.`,
+    );
   }
   _cachedAuthProvider = result;
   return _cachedAuthProvider;

--- a/src/lib/db/sqlite/bootstrap.test.ts
+++ b/src/lib/db/sqlite/bootstrap.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { createSqliteConnection, type SqliteDb } from './connection';
+import * as schema from './schema';
+import { getAdminUserId } from '@/lib/auth/adminCredentials';
+import { bootstrapSqlite } from './bootstrap';
+
+/**
+ * bootstrapSqlite — 부팅 시 마이그레이션 적용 후 관리자 시드(멱등)를 검증한다.
+ * 핵심: 순서 보장 — 시드가 마이그레이션보다 먼저면 users 테이블이 없어 throw한다.
+ */
+describe('bootstrapSqlite', () => {
+  let db: SqliteDb;
+  let raw: Database.Database;
+  const ORIG = { ...process.env };
+
+  beforeEach(() => {
+    const conn = createSqliteConnection(':memory:');
+    db = conn.db;
+    raw = conn.raw;
+    process.env.ADMIN_EMAIL = 'admin@example.com';
+    delete process.env.ADMIN_USER_ID;
+    delete process.env.ADMIN_NAME;
+  });
+
+  afterEach(() => {
+    raw.close();
+    process.env = { ...ORIG };
+  });
+
+  it('빈 DB에서 마이그레이션을 적용한 뒤 관리자 행을 시드한다', () => {
+    bootstrapSqlite(db);
+
+    const row = db
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, getAdminUserId()))
+      .get();
+    expect(row?.email).toBe('admin@example.com');
+  });
+
+  it('두 번 호출해도 마이그레이션·시드가 멱등이다(throw 없음, 행 1개)', () => {
+    bootstrapSqlite(db);
+    expect(() => bootstrapSqlite(db)).not.toThrow();
+
+    expect(db.select().from(schema.users).all()).toHaveLength(1);
+  });
+
+  it('ADMIN_EMAIL 미설정 시에도 마이그레이션은 적용되고(테이블 존재) 시드만 건너뛴다', () => {
+    delete process.env.ADMIN_EMAIL;
+    bootstrapSqlite(db);
+
+    // 테이블이 생성됐으므로 조회가 throw하지 않고 빈 결과를 반환한다
+    expect(db.select().from(schema.users).all()).toHaveLength(0);
+  });
+});

--- a/src/lib/db/sqlite/bootstrap.test.ts
+++ b/src/lib/db/sqlite/bootstrap.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type Database from 'better-sqlite3';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { createSqliteConnection, type SqliteDb } from './connection';
 import * as schema from './schema';
 import { getAdminUserId } from '@/lib/auth/adminCredentials';
@@ -29,7 +29,7 @@ describe('bootstrapSqlite', () => {
     process.env = { ...ORIG };
   });
 
-  it('빈 DB에서 마이그레이션을 적용한 뒤 관리자 행을 시드한다', () => {
+  it('빈 DB에서 마이그레이션을 적용한 뒤 관리자·카탈로그·플래그를 시드한다', () => {
     bootstrapSqlite(db);
 
     const row = db
@@ -38,6 +38,12 @@ describe('bootstrapSqlite', () => {
       .where(eq(schema.users.id, getAdminUserId()))
       .get();
     expect(row?.email).toBe('admin@example.com');
+
+    // 카탈로그(프로덕션 미러 49행)·플래그(7개)도 함께 시드된다
+    const catalog = db.select({ c: sql<number>`count(*)` }).from(schema.apiCatalog).get();
+    expect(catalog?.c).toBe(49);
+    const flags = db.select({ c: sql<number>`count(*)` }).from(schema.featureFlags).get();
+    expect(flags?.c).toBe(7);
   });
 
   it('두 번 호출해도 마이그레이션·시드가 멱등이다(throw 없음, 행 1개)', () => {

--- a/src/lib/db/sqlite/bootstrap.ts
+++ b/src/lib/db/sqlite/bootstrap.ts
@@ -1,13 +1,16 @@
 import { runSqliteMigrations, type SqliteDb } from './connection';
 import { seedAdminUser } from './seedAdmin';
+import { seedCatalog, seedFeatureFlags } from './seedCatalog';
 
 /**
  * SQLite 부팅 부트스트랩 (DB_PROVIDER=sqlite 경로, instrumentation에서 호출).
  *
- * 순서가 중요하다: 마이그레이션으로 테이블을 먼저 만든 뒤 관리자 행을 시드한다.
- * 둘 다 멱등이므로 재배포·재시작 시 안전하게 반복 호출된다.
+ * 순서가 중요하다: 마이그레이션으로 테이블을 먼저 만든 뒤 관리자·카탈로그·플래그를 시드한다.
+ * 모두 멱등(빈 테이블일 때만 삽입)이므로 재배포·재시작 시 안전하게 반복 호출된다.
  */
 export function bootstrapSqlite(db: SqliteDb): void {
   runSqliteMigrations(db);
   seedAdminUser(db);
+  seedCatalog(db);
+  seedFeatureFlags(db);
 }

--- a/src/lib/db/sqlite/bootstrap.ts
+++ b/src/lib/db/sqlite/bootstrap.ts
@@ -1,0 +1,13 @@
+import { runSqliteMigrations, type SqliteDb } from './connection';
+import { seedAdminUser } from './seedAdmin';
+
+/**
+ * SQLite 부팅 부트스트랩 (DB_PROVIDER=sqlite 경로, instrumentation에서 호출).
+ *
+ * 순서가 중요하다: 마이그레이션으로 테이블을 먼저 만든 뒤 관리자 행을 시드한다.
+ * 둘 다 멱등이므로 재배포·재시작 시 안전하게 반복 호출된다.
+ */
+export function bootstrapSqlite(db: SqliteDb): void {
+  runSqliteMigrations(db);
+  seedAdminUser(db);
+}

--- a/src/lib/db/sqlite/connection.test.ts
+++ b/src/lib/db/sqlite/connection.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+import type DatabaseType from 'better-sqlite3';
+import { createSqliteConnection, runSqliteMigrations } from './connection';
+import * as schema from './schema';
+
+let raw: DatabaseType.Database | undefined;
+
+afterEach(() => {
+  raw?.close();
+  raw = undefined;
+});
+
+function freshDb() {
+  const conn = createSqliteConnection(':memory:');
+  raw = conn.raw;
+  runSqliteMigrations(conn.db);
+  return conn.db;
+}
+
+describe('createSqliteConnection', () => {
+  it('권장 pragma(foreign_keys·busy_timeout)를 적용한다', () => {
+    const conn = createSqliteConnection(':memory:');
+    raw = conn.raw;
+    expect(conn.raw.pragma('foreign_keys', { simple: true })).toBe(1);
+    expect(conn.raw.pragma('busy_timeout', { simple: true })).toBe(5000);
+  });
+});
+
+describe('SQLite 스키마 round-trip', () => {
+  it('boolean·json·배열·timestamp·기본값이 왕복한다', () => {
+    const db = freshDb();
+
+    const [u] = db
+      .insert(schema.users)
+      .values({ email: 'admin@example.com', name: 'Admin', preferences: { theme: 'dark' } })
+      .returning()
+      .all();
+    expect(u.id).toBeTruthy();
+    expect(u.preferences).toEqual({ theme: 'dark' });
+    expect(u.created_at).toBeTruthy();
+
+    const [api] = db
+      .insert(schema.apiCatalog)
+      .values({ name: 'Test API', is_active: true, tags: ['a', 'b'], endpoints: [{ path: '/x' }] })
+      .returning()
+      .all();
+    expect(api.is_active).toBe(true); // integer(mode:boolean) → boolean
+    expect(api.tags).toEqual(['a', 'b']); // text(mode:json) array
+    expect(api.endpoints).toEqual([{ path: '/x' }]);
+    expect(api.verification_status).toBe('unverified'); // 스칼라 기본값
+
+    const [p] = db.insert(schema.projects).values({ user_id: u.id, name: 'P1' }).returning().all();
+    expect(p.status).toBe('draft'); // 기본값
+    expect(p.current_version).toBe(0);
+
+    const found = db.select().from(schema.projects).where(eq(schema.projects.id, p.id)).all();
+    expect(found).toHaveLength(1);
+  });
+
+  it('foreign_keys 제약을 강제한다 (존재하지 않는 user_id)', () => {
+    const db = freshDb();
+    expect(() =>
+      db.insert(schema.projects).values({ user_id: 'nonexistent', name: 'X' }).run(),
+    ).toThrow();
+  });
+
+  it('UNIQUE 제약을 강제한다 (generated_codes project_id+version)', () => {
+    const db = freshDb();
+    const [u] = db.insert(schema.users).values({ email: 'u@x.com' }).returning().all();
+    const [p] = db.insert(schema.projects).values({ user_id: u.id, name: 'P' }).returning().all();
+    db.insert(schema.generatedCodes).values({ project_id: p.id, version: 1 }).run();
+    expect(() =>
+      db.insert(schema.generatedCodes).values({ project_id: p.id, version: 1 }).run(),
+    ).toThrow();
+  });
+});

--- a/src/lib/db/sqlite/connection.ts
+++ b/src/lib/db/sqlite/connection.ts
@@ -1,0 +1,62 @@
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import * as schema from './schema';
+
+export type SqliteDb = ReturnType<typeof drizzle<typeof schema>>;
+
+let _db: SqliteDb | null = null;
+let _raw: Database.Database | null = null;
+
+/** SQLite 파일 경로. 프로덕션은 Railway 영속 볼륨(/data) 하위를 기본으로 한다. */
+export function getSqlitePath(): string {
+  return process.env.SQLITE_PATH ?? '/data/app.db';
+}
+
+/**
+ * 새 SQLite 연결을 만들고 권장 pragma를 적용한다.
+ * 테스트는 ':memory:' 를 주입해 격리된 인메모리 DB로 검증한다.
+ */
+export function createSqliteConnection(path: string): { db: SqliteDb; raw: Database.Database } {
+  const raw = new Database(path);
+  raw.pragma('foreign_keys = ON');
+  raw.pragma('busy_timeout = 5000');
+  // WAL: 읽기-쓰기 동시성 향상 (디스크 DB 전용; ':memory:'엔 적용 불가/무의미)
+  if (path !== ':memory:') {
+    raw.pragma('journal_mode = WAL');
+  }
+  // NORMAL: 성능/내구성 균형. 원자성이 중요한 쓰기는 호출부에서 BEGIN IMMEDIATE 트랜잭션으로 보강한다.
+  raw.pragma('synchronous = NORMAL');
+  const db = drizzle(raw, { schema });
+  return { db, raw };
+}
+
+/** DB_PROVIDER=sqlite 환경의 싱글톤 연결. */
+export function getSqliteDb(): SqliteDb {
+  if (_db) return _db;
+  if (process.env.DB_PROVIDER !== 'sqlite') {
+    throw new Error('getSqliteDb()는 DB_PROVIDER=sqlite 환경에서만 사용할 수 있습니다.');
+  }
+  const { db, raw } = createSqliteConnection(getSqlitePath());
+  _db = db;
+  _raw = raw;
+  return _db;
+}
+
+/** 마이그레이션 적용 (부팅 시 또는 테스트 셋업). */
+export function runSqliteMigrations(db: SqliteDb, migrationsFolder = './drizzle/sqlite'): void {
+  migrate(db, { migrationsFolder });
+}
+
+/** 연결을 닫고 싱글톤을 초기화한다 (테스트 정리·재초기화용). */
+export function resetSqliteConnection(): void {
+  if (_raw) {
+    try {
+      _raw.close();
+    } catch {
+      // already closed — ignore
+    }
+    _raw = null;
+  }
+  _db = null;
+}

--- a/src/lib/db/sqlite/schema.ts
+++ b/src/lib/db/sqlite/schema.ts
@@ -1,0 +1,187 @@
+/**
+ * SQLite 스키마 (임베디드 단일 인스턴스·단일 사용자 경로).
+ *
+ * pg 스키마(`src/lib/db/schema.ts`)를 SQLite 방언으로 미러링한다. 단일 사용자/셀프호스트
+ * 결정에 따라 다음 테이블은 제외된다:
+ *  - organizations / memberships (Organizations 기능 제거, D-1)
+ *  - account / session / verificationToken (Auth.js JWT 세션 전략 — DB 어댑터 미사용)
+ *  - event_log (platform_events로 대체된 죽은 테이블)
+ *
+ * 타입 매핑: uuid→text(randomUUID), varchar/text→text, jsonb→text(mode:json),
+ * boolean→integer(mode:boolean), timestamptz→text(ISO8601), date→text(YYYY-MM-DD),
+ * text[]→text(mode:json $type<string[]>). DB 레벨 기본값은 스칼라/boolean에만 두고,
+ * json/배열/타임스탬프는 앱(레포)·$defaultFn에서 채워 drizzle-kit 직렬화 quirk를 피한다.
+ */
+import { sqliteTable, text, integer, primaryKey, unique } from 'drizzle-orm/sqlite-core';
+
+const uuidPk = () =>
+  text('id')
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID());
+
+const createdAt = () => text('created_at').$defaultFn(() => new Date().toISOString());
+const updatedAt = () => text('updated_at').$defaultFn(() => new Date().toISOString());
+
+// ── 1. users (단일 관리자 1행 운용) ───────────────────────────────────────────
+export const users = sqliteTable('users', {
+  id: uuidPk(),
+  email: text('email').notNull().unique(),
+  name: text('name'),
+  avatar_url: text('avatar_url'),
+  emailVerified: text('email_verified'),
+  image: text('image'),
+  preferences: text('preferences', { mode: 'json' }).$type<Record<string, unknown>>(),
+  created_at: createdAt(),
+  updated_at: updatedAt(),
+});
+
+// ── 2. api_catalog ────────────────────────────────────────────────────────────
+export const apiCatalog = sqliteTable('api_catalog', {
+  id: uuidPk(),
+  name: text('name').notNull(),
+  description: text('description'),
+  category: text('category'),
+  base_url: text('base_url'),
+  auth_type: text('auth_type').default('none'),
+  auth_config: text('auth_config', { mode: 'json' }).$type<Record<string, unknown>>(),
+  rate_limit: text('rate_limit'),
+  changelog: text('changelog', { mode: 'json' }).$type<unknown[]>(),
+  is_active: integer('is_active', { mode: 'boolean' }).default(true),
+  icon_url: text('icon_url'),
+  docs_url: text('docs_url'),
+  endpoints: text('endpoints', { mode: 'json' }).$type<unknown[]>(),
+  tags: text('tags', { mode: 'json' }).$type<string[]>(),
+  api_version: text('api_version'),
+  deprecated_at: text('deprecated_at'),
+  // 자기참조(successor_id)는 FK 제약 없이 컬럼만 보존 (단일 인스턴스, 무결성은 앱이 관리)
+  successor_id: text('successor_id'),
+  cors_supported: integer('cors_supported', { mode: 'boolean' }).default(true),
+  requires_proxy: integer('requires_proxy', { mode: 'boolean' }).default(false),
+  credit_required: integer('credit_required'),
+  cache_ttl_seconds: integer('cache_ttl_seconds'),
+  verification_status: text('verification_status').default('unverified'),
+  verified_at: text('verified_at'),
+  last_verification_note: text('last_verification_note'),
+  created_at: createdAt(),
+  updated_at: updatedAt(),
+});
+
+// ── 3. projects ───────────────────────────────────────────────────────────────
+export const projects = sqliteTable('projects', {
+  id: uuidPk(),
+  user_id: text('user_id')
+    .notNull()
+    .references(() => users.id),
+  // organizations 테이블은 제외되었으나 컬럼은 nullable로 보존(레포 매퍼 호환, 항상 null)
+  organization_id: text('organization_id'),
+  name: text('name').notNull(),
+  context: text('context'),
+  status: text('status').default('draft'),
+  deploy_url: text('deploy_url'),
+  deploy_platform: text('deploy_platform'),
+  repo_url: text('repo_url'),
+  preview_url: text('preview_url'),
+  metadata: text('metadata', { mode: 'json' }).$type<Record<string, unknown>>(),
+  current_version: integer('current_version').default(0),
+  slug: text('slug'),
+  suggested_slugs: text('suggested_slugs', { mode: 'json' }).$type<string[]>(),
+  published_at: text('published_at'),
+  created_at: createdAt(),
+  updated_at: updatedAt(),
+});
+
+// ── 4. project_apis ───────────────────────────────────────────────────────────
+export const projectApis = sqliteTable(
+  'project_apis',
+  {
+    id: uuidPk(),
+    project_id: text('project_id')
+      .notNull()
+      .references(() => projects.id),
+    api_id: text('api_id')
+      .notNull()
+      .references(() => apiCatalog.id),
+    config: text('config', { mode: 'json' }).$type<Record<string, unknown>>(),
+    created_at: createdAt(),
+  },
+  (t) => [unique().on(t.project_id, t.api_id)],
+);
+
+// ── 5. generated_codes ────────────────────────────────────────────────────────
+export const generatedCodes = sqliteTable(
+  'generated_codes',
+  {
+    id: uuidPk(),
+    project_id: text('project_id')
+      .notNull()
+      .references(() => projects.id),
+    version: integer('version').notNull(),
+    code_html: text('code_html'),
+    code_css: text('code_css'),
+    code_js: text('code_js'),
+    framework: text('framework').default('vanilla'),
+    ai_provider: text('ai_provider'),
+    ai_model: text('ai_model'),
+    ai_prompt_used: text('ai_prompt_used'),
+    generation_time_ms: integer('generation_time_ms'),
+    token_usage: text('token_usage', { mode: 'json' }).$type<Record<string, unknown>>(),
+    dependencies: text('dependencies', { mode: 'json' }).$type<string[]>(),
+    metadata: text('metadata', { mode: 'json' }).$type<Record<string, unknown>>(),
+    created_at: createdAt(),
+  },
+  (t) => [unique().on(t.project_id, t.version)],
+);
+
+// ── 6. user_api_keys ──────────────────────────────────────────────────────────
+export const userApiKeys = sqliteTable(
+  'user_api_keys',
+  {
+    id: uuidPk(),
+    user_id: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    api_id: text('api_id')
+      .notNull()
+      .references(() => apiCatalog.id),
+    encrypted_key: text('encrypted_key').notNull(),
+    is_verified: integer('is_verified', { mode: 'boolean' }).default(false),
+    verified_at: text('verified_at'),
+    created_at: createdAt(),
+    updated_at: updatedAt(),
+  },
+  (t) => [unique().on(t.user_id, t.api_id)],
+);
+
+// ── 7. user_daily_limits (원자적 레이트리밋 카운터) ───────────────────────────
+export const userDailyLimits = sqliteTable(
+  'user_daily_limits',
+  {
+    user_id: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    usage_date: text('usage_date').notNull(),
+    generation_count: integer('generation_count').default(0),
+    deploy_count: integer('deploy_count').default(0),
+  },
+  (t) => [primaryKey({ columns: [t.user_id, t.usage_date] })],
+);
+
+// ── 8. platform_events (감사 로그) ────────────────────────────────────────────
+export const platformEvents = sqliteTable('platform_events', {
+  id: uuidPk(),
+  type: text('type').notNull(),
+  payload: text('payload', { mode: 'json' }).$type<Record<string, unknown>>(),
+  user_id: text('user_id').references(() => users.id),
+  project_id: text('project_id').references(() => projects.id),
+  created_at: createdAt(),
+});
+
+// ── 9. feature_flags ──────────────────────────────────────────────────────────
+export const featureFlags = sqliteTable('feature_flags', {
+  id: uuidPk(),
+  flag_name: text('flag_name').notNull().unique(),
+  enabled: integer('enabled', { mode: 'boolean' }).default(false),
+  description: text('description'),
+  rules: text('rules', { mode: 'json' }).$type<Record<string, unknown>>(),
+  updated_at: updatedAt(),
+});

--- a/src/lib/db/sqlite/seedAdmin.test.ts
+++ b/src/lib/db/sqlite/seedAdmin.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { eq } from 'drizzle-orm';
+import { createSqliteConnection, runSqliteMigrations, type SqliteDb } from './connection';
+import * as schema from './schema';
+import { seedAdminUser } from './seedAdmin';
+
+const ADMIN_ID = '00000000-0000-0000-0000-000000000001';
+
+/**
+ * seedAdminUser 단위 테스트 — :memory: DB로 격리.
+ * 단일 관리자(AUTH_PROVIDER=local) 부팅 시드의 멱등성·env 게이팅을 검증한다.
+ */
+describe('seedAdminUser', () => {
+  let db: SqliteDb;
+  let raw: Database.Database;
+  const ORIG = { ...process.env };
+
+  beforeEach(() => {
+    const conn = createSqliteConnection(':memory:');
+    db = conn.db;
+    raw = conn.raw;
+    runSqliteMigrations(db);
+    process.env.ADMIN_EMAIL = 'admin@example.com';
+    process.env.ADMIN_USER_ID = ADMIN_ID;
+    delete process.env.ADMIN_NAME;
+  });
+
+  afterEach(() => {
+    raw.close();
+    process.env = { ...ORIG };
+  });
+
+  it('ADMIN_EMAIL이 설정되면 관리자 행을 시드하고 true를 반환한다', () => {
+    const seeded = seedAdminUser(db);
+    expect(seeded).toBe(true);
+
+    const row = db.select().from(schema.users).where(eq(schema.users.id, ADMIN_ID)).get();
+    expect(row?.email).toBe('admin@example.com');
+    expect(row?.name).toBe('Admin'); // ADMIN_NAME 미설정 시 기본값
+  });
+
+  it('ADMIN_NAME을 반영한다', () => {
+    process.env.ADMIN_NAME = '운영자';
+    seedAdminUser(db);
+
+    const row = db.select().from(schema.users).where(eq(schema.users.id, ADMIN_ID)).get();
+    expect(row?.name).toBe('운영자');
+  });
+
+  it('멱등 — 두 번 호출해도 행은 하나이고 두 번째 호출은 false', () => {
+    expect(seedAdminUser(db)).toBe(true);
+    expect(seedAdminUser(db)).toBe(false);
+
+    expect(db.select().from(schema.users).all()).toHaveLength(1);
+  });
+
+  it('ADMIN_EMAIL 미설정 시 no-op(false)이고 행을 만들지 않는다', () => {
+    delete process.env.ADMIN_EMAIL;
+    expect(seedAdminUser(db)).toBe(false);
+    expect(db.select().from(schema.users).all()).toHaveLength(0);
+  });
+
+  it('이미 같은 id의 행이 있으면(이메일이 달라도) 덮어쓰지 않는다', () => {
+    raw
+      .prepare('INSERT INTO users (id, email, created_at, updated_at) VALUES (?, ?, ?, ?)')
+      .run(ADMIN_ID, 'existing@example.com', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z');
+
+    expect(seedAdminUser(db)).toBe(false);
+
+    const row = db.select().from(schema.users).where(eq(schema.users.id, ADMIN_ID)).get();
+    expect(row?.email).toBe('existing@example.com');
+  });
+});

--- a/src/lib/db/sqlite/seedAdmin.ts
+++ b/src/lib/db/sqlite/seedAdmin.ts
@@ -1,0 +1,42 @@
+import { eq } from 'drizzle-orm';
+import type { SqliteDb } from './connection';
+import * as schema from './schema';
+import { getAdminUserId } from '@/lib/auth/adminCredentials';
+
+/**
+ * 단일 관리자 `users` 행을 멱등 시드한다 (AUTH_PROVIDER=local + DB_PROVIDER=sqlite 부팅 경로).
+ *
+ * Credentials authorize가 반환하는 관리자 신원(`getAdminUserId()`)은 `users.id`(FK 앵커)와
+ * 일치해야 한다. 그렇지 않으면 관리자가 프로젝트를 만들 때 `projects.user_id` FK가 깨진다.
+ * 따라서 부팅 시 이 행을 보장한다.
+ *
+ * - `ADMIN_EMAIL` 미설정 시 no-op (로컬 인증 비활성 — 시드할 신원이 없음).
+ * - 이미 동일 id 행이 있으면 덮어쓰지 않는다 (재배포 멱등).
+ *
+ * @returns 새로 시드했으면 `true`, 미설정·이미 존재 시 `false`.
+ */
+export function seedAdminUser(db: SqliteDb): boolean {
+  const email = process.env.ADMIN_EMAIL;
+  if (!email) return false;
+
+  const id = getAdminUserId();
+  const existing = db
+    .select({ id: schema.users.id })
+    .from(schema.users)
+    .where(eq(schema.users.id, id))
+    .get();
+  if (existing) return false;
+
+  const now = new Date().toISOString();
+  db.insert(schema.users)
+    .values({
+      id,
+      email,
+      name: process.env.ADMIN_NAME ?? 'Admin',
+      created_at: now,
+      updated_at: now,
+    })
+    .run();
+
+  return true;
+}

--- a/src/lib/db/sqlite/seedCatalog.test.ts
+++ b/src/lib/db/sqlite/seedCatalog.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { sql, eq } from 'drizzle-orm';
+import { createSqliteConnection, runSqliteMigrations, type SqliteDb } from './connection';
+import * as schema from './schema';
+import { seedCatalog, seedFeatureFlags } from './seedCatalog';
+
+/**
+ * 번들된 시드 데이터(src/data/*.json, 프로덕션 미러)를 :memory: SQLite에 시드하는지 검증.
+ */
+describe('seedCatalog / seedFeatureFlags', () => {
+  let db: SqliteDb;
+  let raw: Database.Database;
+
+  beforeEach(() => {
+    const conn = createSqliteConnection(':memory:');
+    db = conn.db;
+    raw = conn.raw;
+    runSqliteMigrations(db);
+  });
+
+  afterEach(() => {
+    raw.close();
+  });
+
+  function count(table: typeof schema.apiCatalog | typeof schema.featureFlags): number {
+    return db.select({ c: sql<number>`count(*)` }).from(table).get()?.c ?? 0;
+  }
+
+  it('seedCatalog는 프로덕션 미러 49행을 시드한다(활성 23)', () => {
+    const n = seedCatalog(db);
+    expect(n).toBe(49);
+    expect(count(schema.apiCatalog)).toBe(49);
+
+    const active = db
+      .select({ c: sql<number>`count(*)` })
+      .from(schema.apiCatalog)
+      .where(eq(schema.apiCatalog.is_active, true))
+      .get();
+    expect(active?.c).toBe(23);
+  });
+
+  it('seedCatalog는 멱등이다(두 번째 호출 0, 행 유지)', () => {
+    expect(seedCatalog(db)).toBe(49);
+    expect(seedCatalog(db)).toBe(0);
+    expect(count(schema.apiCatalog)).toBe(49);
+  });
+
+  it('json/array/boolean 필드가 올바른 타입으로 역직렬화된다', () => {
+    seedCatalog(db);
+    const row = db
+      .select()
+      .from(schema.apiCatalog)
+      .where(eq(schema.apiCatalog.auth_type, 'api_key'))
+      .limit(1)
+      .get();
+    expect(row).toBeTruthy();
+    expect(typeof row?.auth_config).toBe('object');
+    expect(Array.isArray(row?.endpoints)).toBe(true);
+    expect(Array.isArray(row?.tags)).toBe(true);
+    expect(typeof row?.is_active).toBe('boolean');
+  });
+
+  it('seedFeatureFlags는 7개를 시드하고 멱등이다', () => {
+    expect(seedFeatureFlags(db)).toBe(7);
+    expect(seedFeatureFlags(db)).toBe(0);
+    expect(count(schema.featureFlags)).toBe(7);
+
+    const dark = db
+      .select()
+      .from(schema.featureFlags)
+      .where(eq(schema.featureFlags.flag_name, 'enable_dark_mode'))
+      .get();
+    expect(dark?.enabled).toBe(true);
+    expect(typeof dark?.rules).toBe('object');
+  });
+});

--- a/src/lib/db/sqlite/seedCatalog.ts
+++ b/src/lib/db/sqlite/seedCatalog.ts
@@ -1,0 +1,33 @@
+import { sql } from 'drizzle-orm';
+import type { SqliteDb } from './connection';
+import * as schema from './schema';
+import catalogData from '@/data/apiCatalog.json';
+import featureFlagsData from '@/data/featureFlags.json';
+
+/**
+ * API 카탈로그/피처 플래그를 번들된 시드 데이터(`src/data/*.json`)로 SQLite에 시드한다
+ * (DB_PROVIDER=sqlite 부팅 경로). 데이터는 프로덕션 `api_catalog`/`feature_flags`를
+ * 미러링한 생성 산출물이며 `scripts/generateSqliteSeed.ts`로 재생성한다.
+ *
+ * 멱등: 테이블이 비어 있을 때만 일괄 삽입한다(이미 시드/cron 갱신된 행은 보존).
+ * id·created_at 등은 프로덕션 값을 그대로 유지해 환경 간 일관성(project_apis FK)을 보장한다.
+ */
+export function seedCatalog(db: SqliteDb): number {
+  const existing = db.select({ c: sql<number>`count(*)` }).from(schema.apiCatalog).get();
+  if ((existing?.c ?? 0) > 0) return 0;
+
+  const rows = catalogData as unknown as (typeof schema.apiCatalog.$inferInsert)[];
+  if (rows.length === 0) return 0;
+  db.insert(schema.apiCatalog).values(rows).run();
+  return rows.length;
+}
+
+export function seedFeatureFlags(db: SqliteDb): number {
+  const existing = db.select({ c: sql<number>`count(*)` }).from(schema.featureFlags).get();
+  if ((existing?.c ?? 0) > 0) return 0;
+
+  const rows = featureFlagsData as unknown as (typeof schema.featureFlags.$inferInsert)[];
+  if (rows.length === 0) return 0;
+  db.insert(schema.featureFlags).values(rows).run();
+  return rows.length;
+}

--- a/src/lib/events/eventPersister.test.ts
+++ b/src/lib/events/eventPersister.test.ts
@@ -12,13 +12,19 @@ vi.mock('@/repositories/factory', () => ({
 vi.mock('@/lib/supabase/server', () => ({
   createServiceClient: vi.fn(),
 }));
+vi.mock('@/lib/config/providers', () => ({
+  getDbProvider: vi.fn(() => 'supabase'),
+}));
 vi.mock('@/lib/utils/logger', () => ({
   logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.resetModules();
   vi.clearAllMocks();
+  // 기본 provider를 supabase로 리셋(테스트 간 mockReturnValue 누출 방지).
+  const { getDbProvider } = await import('@/lib/config/providers');
+  (getDbProvider as ReturnType<typeof vi.fn>).mockReturnValue('supabase');
 });
 
 describe('registerEventPersister', () => {
@@ -66,6 +72,30 @@ describe('registerEventPersister', () => {
 
     expect(createServiceClient).toHaveBeenCalledTimes(1);
     expect(createEventRepository).toHaveBeenCalledWith(mockSupabase);
+    expect(mockPersist).toHaveBeenCalledWith(fakeEvent, {});
+  });
+
+  it('sqlite 모드에서는 createServiceClient 없이 createEventRepository(undefined)로 persist한다', async () => {
+    const { registerEventPersister } = await import('./eventPersister');
+    const { eventBus } = await import('./eventBus');
+    const { createServiceClient } = await import('@/lib/supabase/server');
+    const { createEventRepository } = await import('@/repositories/factory');
+    const { getDbProvider } = await import('@/lib/config/providers');
+
+    (getDbProvider as ReturnType<typeof vi.fn>).mockReturnValue('sqlite');
+    const mockPersist = vi.fn().mockResolvedValue(undefined);
+    (createEventRepository as ReturnType<typeof vi.fn>).mockReturnValue({ persist: mockPersist });
+
+    registerEventPersister();
+    const handler = (eventBus.on as ReturnType<typeof vi.fn>).mock.calls[0][0] as (
+      event: unknown,
+    ) => Promise<void>;
+
+    const fakeEvent = { type: 'SQLITE_EVENT', payload: {} };
+    await handler(fakeEvent);
+
+    expect(createServiceClient).not.toHaveBeenCalled();
+    expect(createEventRepository).toHaveBeenCalledWith(undefined);
     expect(mockPersist).toHaveBeenCalledWith(fakeEvent, {});
   });
 

--- a/src/lib/events/eventPersister.ts
+++ b/src/lib/events/eventPersister.ts
@@ -1,6 +1,7 @@
 import { eventBus } from './eventBus';
 import { createEventRepository } from '@/repositories/factory';
 import { createServiceClient } from '@/lib/supabase/server';
+import { getDbProvider } from '@/lib/config/providers';
 import { logger } from '@/lib/utils/logger';
 
 let registered = false;
@@ -15,7 +16,10 @@ export function registerEventPersister(): void {
 
   eventBus.on(async (event) => {
     try {
-      const supabase = await createServiceClient();
+      // provider-무관: supabase 모드에서만 service client를 생성하고, sqlite/postgres는
+      // 인자 없이 레포를 만든다(factory가 DB_PROVIDER로 분기). sqlite 모드에서 createServiceClient를
+      // 호출하면 supabase env 부재로 throw하던 버그를 제거한다.
+      const supabase = getDbProvider() === 'supabase' ? await createServiceClient() : undefined;
       const eventRepo = createEventRepository(supabase);
       await eventRepo.persist(event, {});
     } catch (err) {

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * 미들웨어 — AUTH_PROVIDER=local 세션 게이팅 분기 검증.
+ *
+ * edge-safe 세션 모듈(local-auth-edge)을 mock해 분기 로직만 단위 검증한다(실 Auth.js JWT 검증은
+ * 실서버에서 동작 — Phase 4 서빙 검증 대상). supabase updateSession은 호출되지 않아야 한다.
+ */
+const mocks = vi.hoisted(() => ({ auth: vi.fn(), updateSession: vi.fn() }));
+
+vi.mock('@/lib/auth/local-auth-edge', () => ({ auth: mocks.auth }));
+vi.mock('@/lib/supabase/middleware', () => ({ updateSession: mocks.updateSession }));
+
+import { middleware } from '@/middleware';
+
+function req(path: string): NextRequest {
+  return new NextRequest(new URL(`http://localhost${path}`));
+}
+
+describe('middleware — AUTH_PROVIDER=local', () => {
+  const ORIG = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.updateSession.mockReturnValue(NextResponse.next());
+    process.env.AUTH_PROVIDER = 'local';
+    delete process.env.NEXT_PUBLIC_ROOT_DOMAIN; // 서브도메인 라우팅 비활성
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIG };
+  });
+
+  it('보호 경로 + 세션 없음 → /login으로 리다이렉트(redirect 파라미터 보존)', async () => {
+    mocks.auth.mockResolvedValue(null);
+
+    const res = await middleware(req('/dashboard'));
+
+    expect(res.status).toBe(307);
+    const loc = res.headers.get('location') ?? '';
+    expect(loc).toContain('/login');
+    expect(loc).toContain('redirect=%2Fdashboard');
+    expect(mocks.updateSession).not.toHaveBeenCalled();
+  });
+
+  it('보호 경로 + 세션 있음 → 통과(보안 헤더 포함, 리다이렉트 아님)', async () => {
+    mocks.auth.mockResolvedValue({ user: { id: 'admin-1', email: 'a@b.com' } });
+
+    const res = await middleware(req('/builder'));
+
+    expect(res.headers.get('location')).toBeNull();
+    expect(res.headers.get('X-Frame-Options')).toBe('DENY');
+    expect(mocks.updateSession).not.toHaveBeenCalled();
+  });
+
+  it('비보호 경로(/)는 세션 검증 없이 통과한다', async () => {
+    const res = await middleware(req('/'));
+
+    expect(mocks.auth).not.toHaveBeenCalled();
+    expect(res.headers.get('location')).toBeNull();
+    expect(mocks.updateSession).not.toHaveBeenCalled();
+  });
+
+  it('supabase 모드는 local-auth-edge 대신 updateSession을 사용한다', async () => {
+    process.env.AUTH_PROVIDER = 'supabase';
+
+    await middleware(req('/dashboard'));
+
+    expect(mocks.updateSession).toHaveBeenCalledTimes(1);
+    expect(mocks.auth).not.toHaveBeenCalled();
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,39 @@ import { getCorrelationId, CORRELATION_ID_HEADER } from '@/lib/utils/correlation
 // providers.ts → failover.ts → pg → Node.js 'crypto' — incompatible with Edge runtime.
 // Read AUTH_PROVIDER directly from env in the middleware.
 
+const PROTECTED_ROUTES = ['/builder', '/dashboard', '/preview'];
+
+/**
+ * Auth.js(JWT) 모드(local/authjs)의 보호 경로 게이팅.
+ * 보호 경로가 아니거나 인증된 경우 null, 미인증이면 /login 리다이렉트 응답을 반환한다.
+ *
+ * 세션은 동적 import로 지연 로드한다 — Node 전용 그래프(authjs: pg/Drizzle)가 정적 Edge 번들로
+ * 유입되지 않도록. `local`은 edge-safe 설정(node:crypto 미의존, local-auth-edge.ts)을 사용한다.
+ */
+async function enforceAuthGate(
+  request: NextRequest,
+  authProvider: 'authjs' | 'local',
+): Promise<NextResponse | null> {
+  const authPath = request.nextUrl.pathname;
+  if (!PROTECTED_ROUTES.some((route) => authPath.startsWith(route))) return null;
+
+  let authed: boolean;
+  if (authProvider === 'local') {
+    const { auth } = await import('@/lib/auth/local-auth-edge');
+    const session = await auth();
+    authed = Boolean(session?.user);
+  } else {
+    const { getAuthJsUser } = await import('@/lib/auth/authjs-auth');
+    authed = Boolean(await getAuthJsUser());
+  }
+  if (authed) return null;
+
+  const url = request.nextUrl.clone();
+  url.pathname = '/login';
+  url.searchParams.set('redirect', authPath);
+  return NextResponse.redirect(url);
+}
+
 export async function middleware(request: NextRequest) {
   const correlationId = getCorrelationId(request);
 
@@ -35,27 +68,12 @@ export async function middleware(request: NextRequest) {
   let response: NextResponse;
 
   const authProvider = process.env.AUTH_PROVIDER ?? 'supabase';
-  if (authProvider === 'authjs') {
-    // Auth.js manages sessions via its own route handlers (/api/auth/*)
-    // No session refresh needed in middleware
+  if (authProvider === 'authjs' || authProvider === 'local') {
+    // Auth.js (JWT) manages sessions via its own route handlers (/api/auth/*)
+    // No session refresh needed in middleware.
     response = NextResponse.next({ request });
-
-    // Auth.js mode: protect routes that require authentication
-    const authPath = request.nextUrl.pathname;
-    const PROTECTED_ROUTES = ['/builder', '/dashboard', '/preview'];
-    const isProtected = PROTECTED_ROUTES.some((route) => authPath.startsWith(route));
-
-    if (isProtected) {
-      // Import auth lazily to avoid loading Drizzle in Supabase mode
-      const { getAuthJsUser } = await import('@/lib/auth/authjs-auth');
-      const user = await getAuthJsUser();
-      if (!user) {
-        const url = request.nextUrl.clone();
-        url.pathname = '/login';
-        url.searchParams.set('redirect', authPath);
-        return NextResponse.redirect(url);
-      }
-    }
+    const redirect = await enforceAuthGate(request, authProvider);
+    if (redirect) return redirect;
   } else {
     response = await updateSession(request);
   }

--- a/src/repositories/drizzle/DrizzleCodeRepository.ts
+++ b/src/repositories/drizzle/DrizzleCodeRepository.ts
@@ -1,4 +1,4 @@
-import { eq, desc, sql, count as drizzleCount, and } from 'drizzle-orm';
+import { eq, desc, sql, count as drizzleCount, and, gte } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import * as schema from '@/lib/db/schema';
 import type { GeneratedCode, CodeMetadata } from '@/types/project';
@@ -171,6 +171,24 @@ export class DrizzleCodeRepository implements ICodeRepository {
 
     if (rows.length === 0) return 1;
     return (rows[0].version ?? 0) + 1;
+  }
+
+  async findMetadataByDateRange(
+    from: Date,
+  ): Promise<Array<{ metadata: CodeMetadata; createdAt: string }>> {
+    const rows = await this.db
+      .select({
+        metadata: schema.generatedCodes.metadata,
+        created_at: schema.generatedCodes.created_at,
+      })
+      .from(schema.generatedCodes)
+      .where(gte(schema.generatedCodes.created_at, from))
+      .orderBy(desc(schema.generatedCodes.created_at));
+
+    return rows.map((r) => ({
+      metadata: (r.metadata as CodeMetadata) ?? {},
+      createdAt: String(r.created_at),
+    }));
   }
 
   private toDomain(row: typeof schema.generatedCodes.$inferSelect): GeneratedCode {

--- a/src/repositories/drizzle/DrizzleEventRepository.ts
+++ b/src/repositories/drizzle/DrizzleEventRepository.ts
@@ -1,4 +1,4 @@
-import { eq, desc, sql } from 'drizzle-orm';
+import { eq, desc, sql, and, gte } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import * as schema from '@/lib/db/schema';
 import type { DomainEvent } from '@/types/events';
@@ -76,5 +76,22 @@ export class DrizzleEventRepository implements IEventRepository {
       });
       return [];
     }
+  }
+
+  // 집계 메서드는 DB 오류를 throw한다(qc-stats 의도 — 장애 은폐 방지). created_at은 timestamptz(Date).
+  async countByTypeSince(type: string, since: Date): Promise<number> {
+    const [row] = await this.db
+      .select({ total: sql<number>`count(*)` })
+      .from(schema.platformEvents)
+      .where(and(eq(schema.platformEvents.type, type), gte(schema.platformEvents.created_at, since)));
+    return Number(row?.total ?? 0);
+  }
+
+  async findPayloadsByTypeSince(type: string, since: Date): Promise<unknown[]> {
+    const rows = await this.db
+      .select({ payload: schema.platformEvents.payload })
+      .from(schema.platformEvents)
+      .where(and(eq(schema.platformEvents.type, type), gte(schema.platformEvents.created_at, since)));
+    return rows.map((r) => r.payload);
   }
 }

--- a/src/repositories/eventRepository.ts
+++ b/src/repositories/eventRepository.ts
@@ -88,4 +88,25 @@ export class EventRepository implements IEventRepository {
       createdAt: row.created_at as string,
     }));
   }
+
+  // 집계 메서드는 DB 오류를 throw한다(은폐 시 장애가 0-메트릭으로 보고되는 것을 방지 — qc-stats 의도).
+  async countByTypeSince(type: string, since: Date): Promise<number> {
+    const { count, error } = await this.supabase
+      .from('platform_events')
+      .select('id', { count: 'exact', head: true })
+      .eq('type', type)
+      .gte('created_at', since.toISOString());
+    if (error) throw error;
+    return count ?? 0;
+  }
+
+  async findPayloadsByTypeSince(type: string, since: Date): Promise<unknown[]> {
+    const { data, error } = await this.supabase
+      .from('platform_events')
+      .select('payload')
+      .eq('type', type)
+      .gte('created_at', since.toISOString());
+    if (error) throw error;
+    return (data ?? []).map((row) => row.payload as unknown);
+  }
 }

--- a/src/repositories/factory.ts
+++ b/src/repositories/factory.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { getDbProvider } from '@/lib/config/providers';
 import { getDb } from '@/lib/db/connection';
+import { getSqliteDb } from '@/lib/db/sqlite/connection';
 import type {
   IProjectRepository,
   IUserRepository,
@@ -31,7 +32,21 @@ import {
   DrizzleUserApiKeyRepository,
 } from '@/repositories/drizzle';
 
+// SQLite implementations (DB_PROVIDER=sqlite — 임베디드 단일 인스턴스)
+import {
+  SqliteProjectRepository,
+  SqliteUserRepository,
+  SqliteCodeRepository,
+  SqliteCatalogRepository,
+  SqliteEventRepository,
+  SqliteRateLimitRepository,
+  SqliteUserApiKeyRepository,
+} from '@/repositories/sqlite';
+
 export function createProjectRepository(supabase?: SupabaseClient): IProjectRepository {
+  if (getDbProvider() === 'sqlite') {
+    return new SqliteProjectRepository(getSqliteDb());
+  }
   if (getDbProvider() === 'postgres') {
     return new DrizzleProjectRepository(getDb());
   }
@@ -40,6 +55,9 @@ export function createProjectRepository(supabase?: SupabaseClient): IProjectRepo
 }
 
 export function createUserRepository(supabase?: SupabaseClient): IUserRepository {
+  if (getDbProvider() === 'sqlite') {
+    return new SqliteUserRepository(getSqliteDb());
+  }
   if (getDbProvider() === 'postgres') {
     return new DrizzleUserRepository(getDb());
   }
@@ -48,6 +66,9 @@ export function createUserRepository(supabase?: SupabaseClient): IUserRepository
 }
 
 export function createCodeRepository(supabase?: SupabaseClient): ICodeRepository {
+  if (getDbProvider() === 'sqlite') {
+    return new SqliteCodeRepository(getSqliteDb());
+  }
   if (getDbProvider() === 'postgres') {
     return new DrizzleCodeRepository(getDb());
   }
@@ -56,6 +77,9 @@ export function createCodeRepository(supabase?: SupabaseClient): ICodeRepository
 }
 
 export function createCatalogRepository(supabase?: SupabaseClient): ICatalogRepository {
+  if (getDbProvider() === 'sqlite') {
+    return new SqliteCatalogRepository(getSqliteDb());
+  }
   if (getDbProvider() === 'postgres') {
     return new DrizzleCatalogRepository(getDb());
   }
@@ -64,6 +88,9 @@ export function createCatalogRepository(supabase?: SupabaseClient): ICatalogRepo
 }
 
 export function createEventRepository(supabase?: SupabaseClient): IEventRepository {
+  if (getDbProvider() === 'sqlite') {
+    return new SqliteEventRepository(getSqliteDb());
+  }
   if (getDbProvider() === 'postgres') {
     return new DrizzleEventRepository(getDb());
   }
@@ -72,6 +99,9 @@ export function createEventRepository(supabase?: SupabaseClient): IEventReposito
 }
 
 export function createRateLimitRepository(supabase?: SupabaseClient): IRateLimitRepository {
+  if (getDbProvider() === 'sqlite') {
+    return new SqliteRateLimitRepository(getSqliteDb());
+  }
   if (getDbProvider() === 'postgres') {
     return new DrizzleRateLimitRepository(getDb());
   }
@@ -80,6 +110,9 @@ export function createRateLimitRepository(supabase?: SupabaseClient): IRateLimit
 }
 
 export function createUserApiKeyRepository(supabase?: SupabaseClient): IUserApiKeyRepository {
+  if (getDbProvider() === 'sqlite') {
+    return new SqliteUserApiKeyRepository(getSqliteDb());
+  }
   if (getDbProvider() === 'postgres') {
     return new DrizzleUserApiKeyRepository(getDb());
   }

--- a/src/repositories/interfaces/ICodeRepository.ts
+++ b/src/repositories/interfaces/ICodeRepository.ts
@@ -1,9 +1,11 @@
 import type { IBaseRepository } from './IBaseRepository';
-import type { GeneratedCode } from '@/types/project';
+import type { GeneratedCode, CodeMetadata } from '@/types/project';
 
 export interface ICodeRepository extends IBaseRepository<GeneratedCode> {
   findByProject(projectId: string, version?: number): Promise<GeneratedCode | null>;
   countByProject(projectId: string): Promise<number>;
   pruneOldVersions(projectId: string, keepCount: number): Promise<void>;
   getNextVersion(projectId: string): Promise<number>;
+  /** `from`(포함) 이후 생성 코드의 메타데이터 목록 — QC 통계 집계용. DB 오류 시 throw. */
+  findMetadataByDateRange(from: Date): Promise<Array<{ metadata: CodeMetadata; createdAt: string }>>;
 }

--- a/src/repositories/interfaces/IEventRepository.ts
+++ b/src/repositories/interfaces/IEventRepository.ts
@@ -17,4 +17,8 @@ export interface IEventRepository {
   persist(event: DomainEvent, context: PersistEventContext): Promise<void>;
   persistAsync(event: DomainEvent, context: PersistEventContext): void;
   findByUser(userId: string, limit?: number): Promise<EventRecord[]>;
+  /** 지정 type 이벤트 중 `since`(포함) 이후 개수 — QC 통계 등 집계용. DB 오류 시 throw. */
+  countByTypeSince(type: string, since: Date): Promise<number>;
+  /** 지정 type 이벤트 중 `since`(포함) 이후 payload 배열 — 집계용. DB 오류 시 throw. */
+  findPayloadsByTypeSince(type: string, since: Date): Promise<unknown[]>;
 }

--- a/src/repositories/sqlite/SqliteCatalogRepository.test.ts
+++ b/src/repositories/sqlite/SqliteCatalogRepository.test.ts
@@ -1,0 +1,486 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createSqliteConnection, runSqliteMigrations, type SqliteDb } from '@/lib/db/sqlite/connection';
+import * as schema from '@/lib/db/sqlite/schema';
+import { SqliteCatalogRepository } from './SqliteCatalogRepository';
+import type { ApiCatalogItem } from '@/types/api';
+
+/**
+ * SqliteCatalogRepository 단위 테스트 (:memory: 격리).
+ * 각 테스트마다 새 in-memory DB를 만들고 마이그레이션을 적용한다.
+ * 매핑 기준은 Supabase 레포(catalogRepository.ts)와 일치해야 한다.
+ */
+
+let db: SqliteDb;
+let raw: Database.Database;
+let repo: SqliteCatalogRepository;
+
+/** 카탈로그 1행 시드 헬퍼 — 필요한 필드만 override. */
+function seedCatalog(overrides: Partial<typeof schema.apiCatalog.$inferInsert> = {}): string {
+  const id = (overrides.id as string) ?? crypto.randomUUID();
+  db
+    .insert(schema.apiCatalog)
+    .values({
+      id,
+      name: 'Test API',
+      description: 'A test API',
+      category: 'data',
+      base_url: 'https://api.example.com',
+      auth_type: 'none',
+      auth_config: {},
+      is_active: true,
+      endpoints: [],
+      tags: [],
+      ...overrides,
+    })
+    .run();
+  return id;
+}
+
+function seedUser(email = 'admin@example.com'): string {
+  const id = crypto.randomUUID();
+  db.insert(schema.users).values({ id, email }).run();
+  return id;
+}
+
+function seedProject(userId: string, overrides: Partial<typeof schema.projects.$inferInsert> = {}): string {
+  const id = (overrides.id as string) ?? crypto.randomUUID();
+  db
+    .insert(schema.projects)
+    .values({
+      id,
+      user_id: userId,
+      name: 'Test Project',
+      context: 'a weather dashboard',
+      status: 'draft',
+      ...overrides,
+    })
+    .run();
+  return id;
+}
+
+beforeEach(() => {
+  const conn = createSqliteConnection(':memory:');
+  db = conn.db;
+  raw = conn.raw;
+  runSqliteMigrations(db);
+  repo = new SqliteCatalogRepository(db);
+});
+
+afterEach(() => {
+  raw.close();
+});
+
+describe('SqliteCatalogRepository — findById', () => {
+  it('returns the mapped domain item when present', async () => {
+    const id = seedCatalog({
+      name: 'Weather API',
+      category: 'weather',
+      auth_type: 'api_key',
+      auth_config: { header: 'X-Api-Key' },
+      rate_limit: '60/min',
+      tags: ['weather', 'forecast'],
+      cors_supported: false,
+      requires_proxy: true,
+      credit_required: 5,
+      cache_ttl_seconds: 300,
+      verification_status: 'verified',
+      verified_at: '2026-06-01T00:00:00.000Z',
+      last_verification_note: 'looks good',
+    });
+
+    const item = await repo.findById(id);
+    expect(item).not.toBeNull();
+    expect(item!.id).toBe(id);
+    expect(item!.name).toBe('Weather API');
+    expect(item!.category).toBe('weather');
+    expect(item!.authType).toBe('api_key');
+    expect(item!.authConfig).toEqual({ header: 'X-Api-Key' });
+    expect(item!.rateLimit).toBe('60/min');
+    expect(item!.tags).toEqual(['weather', 'forecast']);
+    expect(item!.corsSupported).toBe(false);
+    expect(item!.requiresProxy).toBe(true);
+    expect(item!.creditRequired).toBe(5);
+    expect(item!.cacheTtlSeconds).toBe(300);
+    expect(item!.verificationStatus).toBe('verified');
+    expect(item!.verifiedAt).toBe('2026-06-01T00:00:00.000Z');
+    expect(item!.lastVerificationNote).toBe('looks good');
+    expect(typeof item!.createdAt).toBe('string');
+    expect(typeof item!.updatedAt).toBe('string');
+  });
+
+  it('returns null when not found', async () => {
+    const item = await repo.findById(crypto.randomUUID());
+    expect(item).toBeNull();
+  });
+
+  it('defaults verificationStatus to "unverified" when column is at default', async () => {
+    const id = seedCatalog();
+    const item = await repo.findById(id);
+    expect(item!.verificationStatus).toBe('unverified');
+    expect(item!.verifiedAt).toBeNull();
+    expect(item!.lastVerificationNote).toBeNull();
+  });
+
+  it('parses endpoints with snake_case JSONB field names (example_call/response_example)', async () => {
+    const id = seedCatalog({
+      endpoints: [
+        {
+          path: '/forecast',
+          method: 'GET',
+          description: 'get forecast',
+          parameters: { city: 'string' },
+          response_example: { temp: 20 },
+          example_call: "fetch('/forecast')",
+          response_data_path: 'data.items',
+          request_headers: { 'X-Foo': 'bar' },
+        },
+      ],
+    });
+
+    const item = await repo.findById(id);
+    const ep = item!.endpoints[0];
+    expect(ep.path).toBe('/forecast');
+    expect(ep.exampleCall).toBe("fetch('/forecast')");
+    expect(ep.responseDataPath).toBe('data.items');
+    expect(ep.requestHeaders).toEqual({ 'X-Foo': 'bar' });
+    expect(ep.responseExample).toEqual({ temp: 20 });
+    // parameters object → params array
+    expect(ep.params).toEqual([{ name: 'city', type: 'string', required: false, description: '' }]);
+  });
+
+  it('parses endpoints with camelCase field names (exampleCall/responseExample)', async () => {
+    const id = seedCatalog({
+      endpoints: [
+        {
+          path: '/x',
+          method: 'POST',
+          description: 'd',
+          params: [{ name: 'q', type: 'string', required: true, description: 'query' }],
+          responseExample: { ok: true },
+          exampleCall: 'call()',
+          responseDataPath: 'items',
+          requestHeaders: { A: 'B' },
+        },
+      ],
+    });
+
+    const item = await repo.findById(id);
+    const ep = item!.endpoints[0];
+    expect(ep.method).toBe('POST');
+    expect(ep.exampleCall).toBe('call()');
+    expect(ep.responseDataPath).toBe('items');
+    expect(ep.requestHeaders).toEqual({ A: 'B' });
+    expect(ep.params).toEqual([{ name: 'q', type: 'string', required: true, description: 'query' }]);
+  });
+});
+
+describe('SqliteCatalogRepository — create / update / delete', () => {
+  it('creates an item and returns the mapped domain shape', async () => {
+    const input: Omit<ApiCatalogItem, 'id' | 'createdAt' | 'updatedAt'> = {
+      name: 'New API',
+      description: 'desc',
+      category: 'news',
+      baseUrl: 'https://news.example.com',
+      authType: 'none',
+      authConfig: { k: 'v' },
+      rateLimit: null,
+      isActive: true,
+      iconUrl: null,
+      docsUrl: null,
+      endpoints: [],
+      tags: ['n'],
+      apiVersion: null,
+      deprecatedAt: null,
+      successorId: null,
+      corsSupported: true,
+      requiresProxy: false,
+      creditRequired: null,
+      cacheTtlSeconds: null,
+      verificationStatus: 'unverified',
+      verifiedAt: null,
+      lastVerificationNote: null,
+    };
+
+    const created = await repo.create(input);
+    expect(created.id).toBeTruthy();
+    expect(created.name).toBe('New API');
+    expect(created.category).toBe('news');
+    expect(created.authConfig).toEqual({ k: 'v' });
+    expect(created.tags).toEqual(['n']);
+    expect(typeof created.createdAt).toBe('string');
+
+    const fetched = await repo.findById(created.id);
+    expect(fetched!.name).toBe('New API');
+  });
+
+  it('updates an existing item and bumps updated_at', async () => {
+    const id = seedCatalog({ name: 'Old', updated_at: '2020-01-01T00:00:00.000Z' });
+    const updated = await repo.update(id, { name: 'Updated', category: 'finance' });
+    expect(updated.name).toBe('Updated');
+    expect(updated.category).toBe('finance');
+    expect(updated.updatedAt).not.toBe('2020-01-01T00:00:00.000Z');
+  });
+
+  it('deletes an item', async () => {
+    const id = seedCatalog();
+    await repo.delete(id);
+    expect(await repo.findById(id)).toBeNull();
+  });
+});
+
+describe('SqliteCatalogRepository — findMany / count', () => {
+  it('returns items and total with default ordering', async () => {
+    seedCatalog({ name: 'A' });
+    seedCatalog({ name: 'B' });
+    seedCatalog({ name: 'C' });
+
+    const result = await repo.findMany();
+    expect(result.total).toBe(3);
+    expect(result.items.length).toBe(3);
+  });
+
+  it('applies camelCase filter keys mapped to snake_case columns', async () => {
+    seedCatalog({ name: 'active1', is_active: true });
+    seedCatalog({ name: 'inactive1', is_active: false });
+
+    const result = await repo.findMany({ isActive: true });
+    expect(result.total).toBe(1);
+    expect(result.items[0].name).toBe('active1');
+  });
+
+  it('paginates via page/limit', async () => {
+    for (let i = 0; i < 5; i++) seedCatalog({ name: `n${i}` });
+    const page1 = await repo.findMany(undefined, { page: 1, limit: 2 });
+    expect(page1.items.length).toBe(2);
+    expect(page1.total).toBe(5);
+    const page3 = await repo.findMany(undefined, { page: 3, limit: 2 });
+    expect(page3.items.length).toBe(1);
+  });
+
+  it('count respects filter', async () => {
+    seedCatalog({ category: 'weather' });
+    seedCatalog({ category: 'weather' });
+    seedCatalog({ category: 'news' });
+
+    expect(await repo.count()).toBe(3);
+    expect(await repo.count({ category: 'weather' })).toBe(2);
+  });
+
+  it('count returns 0 on empty table', async () => {
+    expect(await repo.count()).toBe(0);
+  });
+});
+
+describe('SqliteCatalogRepository — search', () => {
+  beforeEach(() => {
+    seedCatalog({ name: 'Weather Forecast', description: 'predicts weather', category: 'weather', is_active: true });
+    seedCatalog({ name: 'News Reader', description: 'reads news', category: 'news', is_active: true });
+    seedCatalog({ name: 'Hidden API', description: 'inactive', category: 'data', is_active: false });
+    seedCatalog({
+      name: 'Deprecated API',
+      description: 'old',
+      category: 'data',
+      is_active: true,
+      deprecated_at: '2025-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('returns only active, non-deprecated items by default', async () => {
+    const { items, total } = await repo.search({});
+    const names = items.map((i) => i.name).sort();
+    expect(total).toBe(2);
+    expect(names).toEqual(['News Reader', 'Weather Forecast']);
+  });
+
+  it('orders results by name ascending', async () => {
+    const { items } = await repo.search({});
+    expect(items.map((i) => i.name)).toEqual(['News Reader', 'Weather Forecast']);
+  });
+
+  it('filters by category', async () => {
+    const { items, total } = await repo.search({ category: 'weather' });
+    expect(total).toBe(1);
+    expect(items[0].name).toBe('Weather Forecast');
+  });
+
+  it('treats category "all" as no category filter', async () => {
+    const { total } = await repo.search({ category: 'all' });
+    expect(total).toBe(2);
+  });
+
+  it('searches name and description case-insensitively (mirrors ilike)', async () => {
+    const byName = await repo.search({ search: 'weather' });
+    expect(byName.total).toBe(1);
+    expect(byName.items[0].name).toBe('Weather Forecast');
+
+    const byDesc = await repo.search({ search: 'NEWS' });
+    expect(byDesc.total).toBe(1);
+    expect(byDesc.items[0].name).toBe('News Reader');
+  });
+
+  it('returns empty when search matches nothing', async () => {
+    const { items, total } = await repo.search({ search: 'zzznomatch' });
+    expect(total).toBe(0);
+    expect(items).toEqual([]);
+  });
+
+  it('escapes LIKE wildcards so they match literally', async () => {
+    seedCatalog({ name: '100% Coverage', description: 'literal percent', is_active: true });
+    // '%' is escaped → matches the literal "100%" token, not a wildcard
+    const { total, items } = await repo.search({ search: '100%' });
+    expect(total).toBe(1);
+    expect(items[0].name).toBe('100% Coverage');
+  });
+
+  it('paginates with bounded page/limit', async () => {
+    // 2 active items, limit 1 → 2 pages
+    const page1 = await repo.search({ page: 1, limit: 1 });
+    expect(page1.items.length).toBe(1);
+    expect(page1.total).toBe(2);
+    const page2 = await repo.search({ page: 2, limit: 1 });
+    expect(page2.items.length).toBe(1);
+    expect(page2.items[0].name).not.toBe(page1.items[0].name);
+  });
+});
+
+describe('SqliteCatalogRepository — getCategories', () => {
+  it('aggregates active non-deprecated categories with labels and icons', async () => {
+    seedCatalog({ category: 'weather', is_active: true });
+    seedCatalog({ category: 'weather', is_active: true });
+    seedCatalog({ category: 'news', is_active: true });
+    seedCatalog({ category: 'data', is_active: false }); // excluded (inactive)
+    seedCatalog({ category: 'finance', is_active: true, deprecated_at: '2025-01-01T00:00:00.000Z' }); // excluded
+
+    const cats = await repo.getCategories();
+    const byKey = new Map(cats.map((c) => [c.key, c]));
+
+    expect(byKey.get('weather')).toEqual({ key: 'weather', label: '날씨/환경', icon: 'Cloud', count: 2 });
+    expect(byKey.get('news')).toEqual({ key: 'news', label: '뉴스', icon: 'Newspaper', count: 1 });
+    expect(byKey.has('data')).toBe(false);
+    expect(byKey.has('finance')).toBe(false);
+  });
+
+  it('falls back to key + "Box" for unknown categories', async () => {
+    seedCatalog({ category: 'quantum', is_active: true });
+    const cats = await repo.getCategories();
+    const c = cats.find((x) => x.key === 'quantum');
+    expect(c).toEqual({ key: 'quantum', label: 'quantum', icon: 'Box', count: 1 });
+  });
+
+  it('returns empty array when no active catalog rows', async () => {
+    expect(await repo.getCategories()).toEqual([]);
+  });
+});
+
+describe('SqliteCatalogRepository — findByIds', () => {
+  it('returns matching items', async () => {
+    const id1 = seedCatalog({ name: 'One' });
+    const id2 = seedCatalog({ name: 'Two' });
+    seedCatalog({ name: 'Three' });
+
+    const items = await repo.findByIds([id1, id2]);
+    expect(items.map((i) => i.name).sort()).toEqual(['One', 'Two']);
+  });
+
+  it('returns empty array for empty input', async () => {
+    expect(await repo.findByIds([])).toEqual([]);
+  });
+
+  it('returns empty array when no ids match', async () => {
+    seedCatalog();
+    expect(await repo.findByIds([crypto.randomUUID()])).toEqual([]);
+  });
+});
+
+describe('SqliteCatalogRepository — getApiUsageFromProjects', () => {
+  it('returns api_id + project context for matching project statuses', async () => {
+    const userId = seedUser();
+    const apiId = seedCatalog();
+    const projectId = seedProject(userId, { status: 'published', context: 'weather dashboard' });
+
+    db.insert(schema.projectApis).values({ project_id: projectId, api_id: apiId, config: {} }).run();
+
+    const usage = await repo.getApiUsageFromProjects(['published']);
+    expect(usage).toEqual([{ apiId, context: 'weather dashboard' }]);
+  });
+
+  it('excludes projects whose status is not requested', async () => {
+    const userId = seedUser();
+    const apiId = seedCatalog();
+    const draftProject = seedProject(userId, { status: 'draft', context: 'x' });
+    db.insert(schema.projectApis).values({ project_id: draftProject, api_id: apiId, config: {} }).run();
+
+    const usage = await repo.getApiUsageFromProjects(['published']);
+    expect(usage).toEqual([]);
+  });
+
+  it('defaults missing context to empty string', async () => {
+    const userId = seedUser();
+    const apiId = seedCatalog();
+    const projectId = seedProject(userId, { status: 'generated', context: null });
+    db.insert(schema.projectApis).values({ project_id: projectId, api_id: apiId, config: {} }).run();
+
+    const usage = await repo.getApiUsageFromProjects(['generated']);
+    expect(usage).toEqual([{ apiId, context: '' }]);
+  });
+
+  it('returns empty array for empty status list', async () => {
+    expect(await repo.getApiUsageFromProjects([])).toEqual([]);
+  });
+});
+
+describe('SqliteCatalogRepository — getActiveNameToIdMap', () => {
+  it('maps lowercased name → id for active catalog only', async () => {
+    const id1 = seedCatalog({ name: 'OpenWeather', is_active: true });
+    seedCatalog({ name: 'InactiveOne', is_active: false });
+
+    const map = await repo.getActiveNameToIdMap();
+    expect(map.get('openweather')).toBe(id1);
+    expect(map.has('inactiveone')).toBe(false);
+    expect(map.size).toBe(1);
+  });
+
+  it('returns empty map when nothing active', async () => {
+    seedCatalog({ is_active: false });
+    const map = await repo.getActiveNameToIdMap();
+    expect(map.size).toBe(0);
+  });
+});
+
+describe('SqliteCatalogRepository — ping', () => {
+  it('returns true when the table is queryable', async () => {
+    expect(await repo.ping()).toBe(true);
+  });
+});
+
+describe('SqliteCatalogRepository — getUsageCounts', () => {
+  it('counts today generations (>= sinceDate), total projects and users', async () => {
+    const userId = seedUser('a@example.com');
+    seedUser('b@example.com');
+    const apiId = seedCatalog();
+    const projectId = seedProject(userId);
+
+    // one generation today, one before sinceDate
+    db
+      .insert(schema.generatedCodes)
+      .values({ project_id: projectId, version: 1, created_at: '2026-06-22T12:00:00.000Z' })
+      .run();
+    db
+      .insert(schema.generatedCodes)
+      .values({ project_id: projectId, version: 2, created_at: '2020-01-01T00:00:00.000Z' })
+      .run();
+
+    const since = new Date('2026-06-22T00:00:00.000Z');
+    const counts = await repo.getUsageCounts(since);
+
+    expect(counts.todayGenerations).toBe(1);
+    expect(counts.totalProjects).toBe(1);
+    expect(counts.totalUsers).toBe(2);
+  });
+
+  it('returns zeros on empty DB', async () => {
+    const counts = await repo.getUsageCounts(new Date('2026-01-01T00:00:00.000Z'));
+    expect(counts).toEqual({ todayGenerations: 0, totalProjects: 0, totalUsers: 0 });
+  });
+});

--- a/src/repositories/sqlite/SqliteCatalogRepository.ts
+++ b/src/repositories/sqlite/SqliteCatalogRepository.ts
@@ -1,0 +1,339 @@
+import { eq, and, or, isNull, inArray, asc, desc, gte, sql } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+import type { SQLiteColumn } from 'drizzle-orm/sqlite-core';
+import type { SqliteDb } from '@/lib/db/sqlite/connection';
+import * as schema from '@/lib/db/sqlite/schema';
+import type { ApiCatalogItem, ApiVerificationStatus, CatalogSearchParams, Category } from '@/types/api';
+import type { ICatalogRepository, ProjectStatus } from '@/repositories/interfaces';
+import type { QueryOptions } from '@/repositories/interfaces/IBaseRepository';
+import {
+  toDatabaseRow,
+  normalizePagination,
+  parseEndpoints,
+  toSnake,
+  CATEGORY_LABELS,
+  CATEGORY_ICONS,
+} from '@/repositories/utils';
+
+/**
+ * SQLite(better-sqlite3 + drizzle) 구현 (임베디드 단일 인스턴스·단일 사용자 경로).
+ *
+ * 매핑 기준은 Supabase 레포(`catalogRepository.ts`)와 동일하다 — 가장 정확한 toDomain.
+ * Drizzle pg 레포(`DrizzleCatalogRepository.ts`)는 쿼리 구조 참고용이며, 그 레포가 누락한
+ * verification_status / verified_at / last_verification_note 매핑을 여기서는 반드시 포함한다.
+ *
+ * SQLite 방언 주의:
+ * - 타임스탬프(created_at/updated_at/deprecated_at/verified_at)는 ISO8601 문자열로 저장되며
+ *   도메인이 `string`을 기대하므로 그대로 반환한다.
+ * - JSON 컬럼(auth_config/endpoints/tags, mode:'json')은 drizzle가 객체/배열로 역직렬화해 돌려준다
+ *   (JSON.parse 불필요). endpoints는 snake_case/camelCase 이중성을 `parseEndpoints`가 흡수한다.
+ * - boolean 컬럼(is_active/cors_supported/requires_proxy, mode:'boolean')은 drizzle가 true/false로 돌려준다.
+ * - 검색은 SQLite `LIKE`(ASCII 대소문자 무시)로 Supabase `ilike` 동작을 미러링한다.
+ *   기본 필터: is_active=true AND deprecated_at IS NULL.
+ */
+export class SqliteCatalogRepository implements ICatalogRepository {
+  constructor(private db: SqliteDb) {}
+
+  async findById(id: string): Promise<ApiCatalogItem | null> {
+    const row = this.db
+      .select()
+      .from(schema.apiCatalog)
+      .where(eq(schema.apiCatalog.id, id))
+      .limit(1)
+      .get();
+
+    return row ? this.toDomain(row) : null;
+  }
+
+  async findMany(
+    filter?: Record<string, unknown>,
+    options: QueryOptions = {},
+  ): Promise<{ items: ApiCatalogItem[]; total: number }> {
+    const { orderDirection = 'desc' } = options;
+    const { offset, limit } = normalizePagination(options);
+
+    const conditions = this.buildEqConditions(filter);
+
+    const countRow = this.db
+      .select({ total: sql<number>`count(*)` })
+      .from(schema.apiCatalog)
+      .where(conditions)
+      .get();
+
+    const rows = this.db
+      .select()
+      .from(schema.apiCatalog)
+      .where(conditions)
+      .orderBy(orderDirection === 'asc' ? asc(schema.apiCatalog.created_at) : desc(schema.apiCatalog.created_at))
+      .offset(offset)
+      .limit(limit)
+      .all();
+
+    return {
+      items: rows.map((row) => this.toDomain(row)),
+      total: Number(countRow?.total ?? 0),
+    };
+  }
+
+  async create(input: Omit<ApiCatalogItem, 'id' | 'createdAt' | 'updatedAt'>): Promise<ApiCatalogItem> {
+    const dbData = toDatabaseRow(input as Partial<Record<string, unknown>>);
+
+    const [row] = this.db
+      .insert(schema.apiCatalog)
+      .values(dbData as typeof schema.apiCatalog.$inferInsert)
+      .returning()
+      .all();
+
+    return this.toDomain(row);
+  }
+
+  async update(id: string, input: Partial<ApiCatalogItem>): Promise<ApiCatalogItem> {
+    const dbData = toDatabaseRow(input as Partial<Record<string, unknown>>);
+
+    const [row] = this.db
+      .update(schema.apiCatalog)
+      .set({ ...dbData, updated_at: new Date().toISOString() } as Partial<typeof schema.apiCatalog.$inferInsert>)
+      .where(eq(schema.apiCatalog.id, id))
+      .returning()
+      .all();
+
+    return this.toDomain(row);
+  }
+
+  async delete(id: string): Promise<void> {
+    this.db.delete(schema.apiCatalog).where(eq(schema.apiCatalog.id, id)).run();
+  }
+
+  async count(filter?: Record<string, unknown>): Promise<number> {
+    const conditions = this.buildEqConditions(filter);
+
+    const row = this.db
+      .select({ total: sql<number>`count(*)` })
+      .from(schema.apiCatalog)
+      .where(conditions)
+      .get();
+
+    return Number(row?.total ?? 0);
+  }
+
+  async search(params: CatalogSearchParams): Promise<{ items: ApiCatalogItem[]; total: number }> {
+    const { category, search, page = 1, limit = 20 } = params;
+
+    // Bounds checking (Supabase 레포와 동일)
+    const safePage = Math.max(1, page);
+    const safeLimit = Math.min(Math.max(1, limit), 100);
+    const offset = (safePage - 1) * safeLimit;
+
+    // Base conditions: active and not deprecated
+    const baseConditions = and(
+      eq(schema.apiCatalog.is_active, true),
+      isNull(schema.apiCatalog.deprecated_at),
+    );
+
+    // Category filter
+    const categoryCondition =
+      category && category !== 'all' ? eq(schema.apiCatalog.category, category) : undefined;
+
+    // Search filter — escape LIKE special chars, then mirror ilike via SQLite LIKE
+    let searchCondition;
+    if (search) {
+      const sanitized = search
+        .trim()
+        .slice(0, 100)
+        .replace(/\\/g, '\\\\')
+        .replace(/%/g, '\\%')
+        .replace(/_/g, '\\_');
+
+      if (sanitized) {
+        // SQLite LIKE는 ASCII 대소문자를 무시(ilike 미러링)하지만, 기본적으로 escape 문자를
+        // 지원하지 않는다. 위 sanitizer가 \%, \_, \\ 로 이스케이프하므로 ESCAPE '\' 절을
+        // 명시해 와일드카드를 리터럴로 매칭한다. (drizzle `like`는 ESCAPE를 붙이지 않음)
+        const pattern = `%${sanitized}%`;
+        searchCondition = or(
+          sql`${schema.apiCatalog.name} LIKE ${pattern} ESCAPE '\\'`,
+          sql`${schema.apiCatalog.description} LIKE ${pattern} ESCAPE '\\'`,
+        );
+      }
+    }
+
+    const allConditions = and(baseConditions, ...[categoryCondition, searchCondition].filter(Boolean));
+
+    const countRow = this.db
+      .select({ total: sql<number>`count(*)` })
+      .from(schema.apiCatalog)
+      .where(allConditions)
+      .get();
+
+    const rows = this.db
+      .select()
+      .from(schema.apiCatalog)
+      .where(allConditions)
+      .orderBy(asc(schema.apiCatalog.name))
+      .offset(offset)
+      .limit(safeLimit)
+      .all();
+
+    return {
+      items: rows.map((row) => this.toDomain(row)),
+      total: Number(countRow?.total ?? 0),
+    };
+  }
+
+  async getCategories(): Promise<Category[]> {
+    const rows = this.db
+      .select({ category: schema.apiCatalog.category })
+      .from(schema.apiCatalog)
+      .where(and(eq(schema.apiCatalog.is_active, true), isNull(schema.apiCatalog.deprecated_at)))
+      .all();
+
+    const counts = new Map<string, number>();
+    for (const row of rows) {
+      const cat = row.category ?? 'unknown';
+      counts.set(cat, (counts.get(cat) ?? 0) + 1);
+    }
+
+    return Array.from(counts.entries()).map(([key, count]) => ({
+      key,
+      label: CATEGORY_LABELS[key] ?? key,
+      icon: CATEGORY_ICONS[key] ?? 'Box',
+      count,
+    }));
+  }
+
+  async findByIds(ids: string[]): Promise<ApiCatalogItem[]> {
+    if (ids.length === 0) return [];
+
+    const rows = this.db
+      .select()
+      .from(schema.apiCatalog)
+      .where(inArray(schema.apiCatalog.id, ids))
+      .all();
+
+    return rows.map((row) => this.toDomain(row));
+  }
+
+  async getApiUsageFromProjects(statuses: ProjectStatus[]): Promise<Array<{ apiId: string; context: string }>> {
+    if (statuses.length === 0) return [];
+
+    const rows = this.db
+      .select({
+        api_id: schema.projectApis.api_id,
+        context: schema.projects.context,
+      })
+      .from(schema.projectApis)
+      .innerJoin(schema.projects, eq(schema.projectApis.project_id, schema.projects.id))
+      .where(inArray(schema.projects.status, statuses))
+      .all();
+
+    return rows.map((row) => ({
+      apiId: row.api_id,
+      context: row.context ?? '',
+    }));
+  }
+
+  async getActiveNameToIdMap(): Promise<Map<string, string>> {
+    const rows = this.db
+      .select({ id: schema.apiCatalog.id, name: schema.apiCatalog.name })
+      .from(schema.apiCatalog)
+      .where(eq(schema.apiCatalog.is_active, true))
+      .all();
+
+    const map = new Map<string, string>();
+    for (const row of rows) {
+      map.set(row.name.toLowerCase(), row.id);
+    }
+    return map;
+  }
+
+  async ping(): Promise<boolean> {
+    try {
+      this.db
+        .select({ n: sql<number>`count(*)` })
+        .from(schema.apiCatalog)
+        .limit(1)
+        .get();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getUsageCounts(
+    sinceDate: Date,
+  ): Promise<{ todayGenerations: number; totalProjects: number; totalUsers: number }> {
+    const since = sinceDate.toISOString();
+
+    const genRow = this.db
+      .select({ n: sql<number>`count(*)` })
+      .from(schema.generatedCodes)
+      .where(gte(schema.generatedCodes.created_at, since))
+      .get();
+
+    const projectRow = this.db
+      .select({ n: sql<number>`count(*)` })
+      .from(schema.projects)
+      .get();
+
+    const userRow = this.db
+      .select({ n: sql<number>`count(*)` })
+      .from(schema.users)
+      .get();
+
+    return {
+      todayGenerations: Number(genRow?.n ?? 0),
+      totalProjects: Number(projectRow?.n ?? 0),
+      totalUsers: Number(userRow?.n ?? 0),
+    };
+  }
+
+  /**
+   * filter(camelCase 또는 snake_case 키)를 snake_case 컬럼 eq 조건으로 변환한다.
+   * Supabase BaseRepository.findMany/count와 동일하게 undefined/null 값은 무시한다.
+   */
+  private buildEqConditions(filter?: Record<string, unknown>) {
+    if (!filter) return undefined;
+
+    const columns = schema.apiCatalog as unknown as Record<string, SQLiteColumn | undefined>;
+    const conditions: SQL[] = [];
+    for (const [key, value] of Object.entries(filter)) {
+      if (value === undefined || value === null) continue;
+      const column = columns[toSnake(key)];
+      if (column) {
+        conditions.push(eq(column, value as string | number | boolean));
+      }
+    }
+
+    if (conditions.length === 0) return undefined;
+    return conditions.length === 1 ? conditions[0] : and(...conditions);
+  }
+
+  private toDomain(row: typeof schema.apiCatalog.$inferSelect): ApiCatalogItem {
+    return {
+      id: row.id,
+      name: row.name,
+      description: (row.description as string) ?? '',
+      category: (row.category as string) ?? '',
+      baseUrl: (row.base_url as string) ?? '',
+      authType: (row.auth_type as ApiCatalogItem['authType']) ?? 'none',
+      authConfig: (row.auth_config as Record<string, unknown>) ?? {},
+      rateLimit: row.rate_limit ?? null,
+      isActive: row.is_active ?? true,
+      iconUrl: row.icon_url ?? null,
+      docsUrl: row.docs_url ?? null,
+      endpoints: parseEndpoints(row.endpoints),
+      tags: row.tags ?? [],
+      apiVersion: row.api_version ?? null,
+      deprecatedAt: row.deprecated_at ?? null,
+      successorId: row.successor_id ?? null,
+      corsSupported: row.cors_supported ?? true,
+      requiresProxy: row.requires_proxy ?? false,
+      creditRequired: row.credit_required != null ? Number(row.credit_required) : null,
+      cacheTtlSeconds: row.cache_ttl_seconds != null ? Number(row.cache_ttl_seconds) : null,
+      createdAt: row.created_at as string,
+      updatedAt: row.updated_at as string,
+      verificationStatus: (row.verification_status ?? 'unverified') as ApiVerificationStatus,
+      verifiedAt: row.verified_at != null ? (row.verified_at as string) : null,
+      lastVerificationNote: (row.last_verification_note as string) ?? null,
+    };
+  }
+}

--- a/src/repositories/sqlite/SqliteCodeRepository.test.ts
+++ b/src/repositories/sqlite/SqliteCodeRepository.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createSqliteConnection, runSqliteMigrations, type SqliteDb } from '@/lib/db/sqlite/connection';
+import * as schema from '@/lib/db/sqlite/schema';
+import { SqliteCodeRepository } from './SqliteCodeRepository';
+import type { GeneratedCode } from '@/types/project';
+
+type CreateInput = Omit<GeneratedCode, 'id' | 'createdAt' | 'updatedAt'>;
+
+describe('SqliteCodeRepository', () => {
+  let db: SqliteDb;
+  let raw: Database.Database;
+  let repo: SqliteCodeRepository;
+  let projectId: string;
+
+  /** FK 선행 행(users 1행, projects 1행)을 시드하고 project id를 반환한다. */
+  function seedProject(): { userId: string; projectId: string } {
+    const [user] = db
+      .insert(schema.users)
+      .values({ email: `user-${crypto.randomUUID()}@example.com`, name: 'Tester' })
+      .returning()
+      .all();
+
+    const [project] = db
+      .insert(schema.projects)
+      .values({ user_id: user.id, name: 'Test Project' })
+      .returning()
+      .all();
+
+    return { userId: user.id, projectId: project.id };
+  }
+
+  function baseInput(overrides: Partial<CreateInput> = {}): CreateInput {
+    return {
+      projectId,
+      version: 1,
+      codeHtml: '<h1>hi</h1>',
+      codeCss: 'body{}',
+      codeJs: 'console.log(1)',
+      framework: 'vanilla',
+      aiProvider: 'anthropic',
+      aiModel: 'claude-opus-4-7',
+      aiPromptUsed: 'prompt',
+      generationTimeMs: 1234,
+      tokenUsage: { input: 100, output: 200 },
+      dependencies: ['tailwind'],
+      metadata: { qualityScore: 88, hasResponsive: true },
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    const conn = createSqliteConnection(':memory:');
+    db = conn.db;
+    raw = conn.raw;
+    runSqliteMigrations(db);
+    repo = new SqliteCodeRepository(db);
+    const seeded = seedProject();
+    projectId = seeded.projectId;
+  });
+
+  afterEach(() => {
+    raw.close();
+  });
+
+  describe('create', () => {
+    it('새 생성 코드를 만들고 도메인 shape로 반환한다 (JSON/타임스탬프 매핑)', async () => {
+      const created = await repo.create(baseInput());
+
+      expect(created.id).toBeTruthy();
+      expect(created.projectId).toBe(projectId);
+      expect(created.version).toBe(1);
+      expect(created.codeHtml).toBe('<h1>hi</h1>');
+      expect(created.codeCss).toBe('body{}');
+      expect(created.codeJs).toBe('console.log(1)');
+      expect(created.framework).toBe('vanilla');
+      expect(created.aiProvider).toBe('anthropic');
+      expect(created.aiModel).toBe('claude-opus-4-7');
+      expect(created.aiPromptUsed).toBe('prompt');
+      expect(created.generationTimeMs).toBe(1234);
+      // JSON 컬럼은 객체/배열로 역직렬화되어야 한다 (JSON.parse 불필요)
+      expect(created.tokenUsage).toEqual({ input: 100, output: 200 });
+      expect(created.dependencies).toEqual(['tailwind']);
+      expect(created.metadata).toEqual({ qualityScore: 88, hasResponsive: true });
+      // 타임스탬프는 ISO 문자열
+      expect(typeof created.createdAt).toBe('string');
+      expect(new Date(created.createdAt).toISOString()).toBe(created.createdAt);
+    });
+
+    it('null/빈 필드를 기본값으로 매핑한다', async () => {
+      const created = await repo.create(
+        baseInput({
+          codeCss: '',
+          codeJs: '',
+          aiProvider: null,
+          aiModel: null,
+          aiPromptUsed: null,
+          generationTimeMs: null,
+          tokenUsage: null,
+          dependencies: [],
+          metadata: {},
+        }),
+      );
+
+      expect(created.aiProvider).toBeNull();
+      expect(created.aiModel).toBeNull();
+      expect(created.aiPromptUsed).toBeNull();
+      expect(created.generationTimeMs).toBeNull();
+      expect(created.tokenUsage).toBeNull();
+      expect(created.dependencies).toEqual([]);
+      expect(created.metadata).toEqual({});
+    });
+
+    it('(project_id, version) UNIQUE 제약을 강제한다', async () => {
+      await repo.create(baseInput({ version: 1 }));
+      await expect(repo.create(baseInput({ version: 1 }))).rejects.toThrow();
+    });
+  });
+
+  describe('findById', () => {
+    it('존재하는 행을 조회한다', async () => {
+      const created = await repo.create(baseInput());
+      const found = await repo.findById(created.id);
+      expect(found).not.toBeNull();
+      expect(found?.id).toBe(created.id);
+    });
+
+    it('없으면 null을 반환한다', async () => {
+      const found = await repo.findById(crypto.randomUUID());
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('findMany', () => {
+    it('필터·페이지네이션·정렬(created_at desc 기본)을 적용한다', async () => {
+      await repo.create(baseInput({ version: 1 }));
+      await repo.create(baseInput({ version: 2 }));
+      await repo.create(baseInput({ version: 3 }));
+
+      const result = await repo.findMany({ projectId });
+      expect(result.total).toBe(3);
+      expect(result.items).toHaveLength(3);
+      expect(result.items.every((i) => i.projectId === projectId)).toBe(true);
+    });
+
+    it('limit/page로 페이지를 자른다', async () => {
+      for (let v = 1; v <= 5; v++) {
+        await repo.create(baseInput({ version: v }));
+      }
+      const page1 = await repo.findMany({ projectId }, { page: 1, limit: 2 });
+      expect(page1.total).toBe(5);
+      expect(page1.items).toHaveLength(2);
+
+      const page3 = await repo.findMany({ projectId }, { page: 3, limit: 2 });
+      expect(page3.items).toHaveLength(1);
+    });
+
+    it('필터 없으면 빈 결과', async () => {
+      const result = await repo.findMany({ projectId });
+      expect(result.total).toBe(0);
+      expect(result.items).toEqual([]);
+    });
+  });
+
+  describe('update', () => {
+    it('필드를 갱신하고 갱신된 도메인을 반환한다', async () => {
+      const created = await repo.create(baseInput());
+      const updated = await repo.update(created.id, {
+        codeHtml: '<h2>updated</h2>',
+        metadata: { qualityScore: 99 },
+      });
+      expect(updated.id).toBe(created.id);
+      expect(updated.codeHtml).toBe('<h2>updated</h2>');
+      expect(updated.metadata).toEqual({ qualityScore: 99 });
+      // 변경하지 않은 필드는 유지
+      expect(updated.version).toBe(1);
+    });
+  });
+
+  describe('delete', () => {
+    it('행을 삭제한다', async () => {
+      const created = await repo.create(baseInput());
+      await repo.delete(created.id);
+      expect(await repo.findById(created.id)).toBeNull();
+    });
+
+    it('없는 id 삭제는 조용히 통과한다', async () => {
+      await expect(repo.delete(crypto.randomUUID())).resolves.toBeUndefined();
+    });
+  });
+
+  describe('count', () => {
+    it('필터에 맞는 행 수를 센다', async () => {
+      await repo.create(baseInput({ version: 1 }));
+      await repo.create(baseInput({ version: 2 }));
+      expect(await repo.count({ projectId })).toBe(2);
+      expect(await repo.count()).toBe(2);
+      expect(await repo.count({ projectId: crypto.randomUUID() })).toBe(0);
+    });
+  });
+
+  describe('findByProject', () => {
+    it('version 미지정 시 최신 버전을 반환한다', async () => {
+      await repo.create(baseInput({ version: 1 }));
+      await repo.create(baseInput({ version: 3 }));
+      await repo.create(baseInput({ version: 2 }));
+
+      const latest = await repo.findByProject(projectId);
+      expect(latest?.version).toBe(3);
+    });
+
+    it('version 지정 시 해당 버전을 반환한다', async () => {
+      await repo.create(baseInput({ version: 1 }));
+      await repo.create(baseInput({ version: 2 }));
+
+      const v1 = await repo.findByProject(projectId, 1);
+      expect(v1?.version).toBe(1);
+    });
+
+    it('없으면 null', async () => {
+      expect(await repo.findByProject(projectId)).toBeNull();
+      expect(await repo.findByProject(projectId, 99)).toBeNull();
+      expect(await repo.findByProject(crypto.randomUUID())).toBeNull();
+    });
+  });
+
+  describe('countByProject', () => {
+    it('프로젝트별 행 수를 센다', async () => {
+      await repo.create(baseInput({ version: 1 }));
+      await repo.create(baseInput({ version: 2 }));
+      expect(await repo.countByProject(projectId)).toBe(2);
+    });
+
+    it('행이 없으면 0', async () => {
+      expect(await repo.countByProject(projectId)).toBe(0);
+      expect(await repo.countByProject(crypto.randomUUID())).toBe(0);
+    });
+  });
+
+  describe('getNextVersion', () => {
+    it('행이 없으면 1을 반환한다', async () => {
+      expect(await repo.getNextVersion(projectId)).toBe(1);
+    });
+
+    it('MAX(version)+1을 반환한다', async () => {
+      await repo.create(baseInput({ version: 1 }));
+      await repo.create(baseInput({ version: 5 }));
+      await repo.create(baseInput({ version: 3 }));
+      expect(await repo.getNextVersion(projectId)).toBe(6);
+    });
+
+    it('다른 프로젝트의 버전에 영향받지 않는다', async () => {
+      await repo.create(baseInput({ version: 7 }));
+      const other = seedProject();
+      expect(await repo.getNextVersion(other.projectId)).toBe(1);
+    });
+  });
+
+  describe('pruneOldVersions', () => {
+    it('최신 keepCount개만 남기고 오래된 버전을 삭제한다', async () => {
+      for (let v = 1; v <= 5; v++) {
+        await repo.create(baseInput({ version: v }));
+      }
+
+      await repo.pruneOldVersions(projectId, 2);
+
+      const remaining = await repo.findMany({ projectId }, { limit: 100 });
+      const versions = remaining.items.map((i) => i.version).sort((a, b) => a - b);
+      // 최신 2개(4,5)만 유지
+      expect(versions).toEqual([4, 5]);
+    });
+
+    it('keepCount 이하면 아무것도 삭제하지 않는다', async () => {
+      await repo.create(baseInput({ version: 1 }));
+      await repo.create(baseInput({ version: 2 }));
+
+      await repo.pruneOldVersions(projectId, 5);
+
+      expect(await repo.countByProject(projectId)).toBe(2);
+    });
+
+    it('행이 없으면 조용히 통과한다', async () => {
+      await expect(repo.pruneOldVersions(projectId, 3)).resolves.toBeUndefined();
+    });
+
+    it('다른 프로젝트 버전은 건드리지 않는다', async () => {
+      for (let v = 1; v <= 3; v++) {
+        await repo.create(baseInput({ version: v }));
+      }
+      const other = seedProject();
+      const otherRepo = new SqliteCodeRepository(db);
+      const prevProject = projectId;
+      projectId = other.projectId;
+      await otherRepo.create(baseInput({ version: 1 }));
+      await otherRepo.create(baseInput({ version: 2 }));
+      projectId = prevProject;
+
+      await repo.pruneOldVersions(prevProject, 1);
+
+      expect(await repo.countByProject(prevProject)).toBe(1);
+      expect(await repo.countByProject(other.projectId)).toBe(2);
+    });
+  });
+});

--- a/src/repositories/sqlite/SqliteCodeRepository.test.ts
+++ b/src/repositories/sqlite/SqliteCodeRepository.test.ts
@@ -63,6 +63,30 @@ describe('SqliteCodeRepository', () => {
     raw.close();
   });
 
+  describe('findMetadataByDateRange', () => {
+    function insertCode(version: number, createdAt: string, metadata: Record<string, unknown>): void {
+      raw
+        .prepare(
+          'INSERT INTO generated_codes (id, project_id, version, metadata, created_at) VALUES (?, ?, ?, ?, ?)',
+        )
+        .run(crypto.randomUUID(), projectId, version, JSON.stringify(metadata), createdAt);
+    }
+
+    it('from(포함) 이후 코드의 metadata를 created_at desc로 반환한다', async () => {
+      insertCode(1, '2026-06-10T00:00:00.000Z', { structuralScore: 80 });
+      insertCode(2, '2026-06-20T00:00:00.000Z', { structuralScore: 90 });
+      insertCode(3, '2026-05-01T00:00:00.000Z', { structuralScore: 50 }); // 윈도우 이전
+
+      const result = await repo.findMetadataByDateRange(new Date('2026-06-01T00:00:00.000Z'));
+
+      expect(result).toHaveLength(2);
+      // desc 정렬 → 최신(06-20)이 먼저
+      expect((result[0].metadata as { structuralScore?: number }).structuralScore).toBe(90);
+      expect(result[0].createdAt).toBe('2026-06-20T00:00:00.000Z');
+      expect((result[1].metadata as { structuralScore?: number }).structuralScore).toBe(80);
+    });
+  });
+
   describe('create', () => {
     it('새 생성 코드를 만들고 도메인 shape로 반환한다 (JSON/타임스탬프 매핑)', async () => {
       const created = await repo.create(baseInput());

--- a/src/repositories/sqlite/SqliteCodeRepository.ts
+++ b/src/repositories/sqlite/SqliteCodeRepository.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, sql, count as drizzleCount, inArray } from 'drizzle-orm';
+import { eq, and, desc, sql, count as drizzleCount, inArray, gte } from 'drizzle-orm';
 import type { SqliteDb } from '@/lib/db/sqlite/connection';
 import * as schema from '@/lib/db/sqlite/schema';
 import type { GeneratedCode, CodeMetadata } from '@/types/project';
@@ -178,6 +178,26 @@ export class SqliteCodeRepository implements ICodeRepository {
 
     if (!row) return 1;
     return (row.version ?? 0) + 1;
+  }
+
+  // created_at은 ISO8601 텍스트라 사전식 비교(>=)가 곧 시간순 비교. metadata(mode:json)는 객체로 역직렬화됨.
+  async findMetadataByDateRange(
+    from: Date,
+  ): Promise<Array<{ metadata: CodeMetadata; createdAt: string }>> {
+    const rows = this.db
+      .select({
+        metadata: schema.generatedCodes.metadata,
+        created_at: schema.generatedCodes.created_at,
+      })
+      .from(schema.generatedCodes)
+      .where(gte(schema.generatedCodes.created_at, from.toISOString()))
+      .orderBy(desc(schema.generatedCodes.created_at))
+      .all();
+
+    return rows.map((r) => ({
+      metadata: (r.metadata as CodeMetadata) ?? {},
+      createdAt: String(r.created_at),
+    }));
   }
 
   private toDomain(row: typeof schema.generatedCodes.$inferSelect): GeneratedCode {

--- a/src/repositories/sqlite/SqliteCodeRepository.ts
+++ b/src/repositories/sqlite/SqliteCodeRepository.ts
@@ -1,0 +1,202 @@
+import { eq, and, desc, sql, count as drizzleCount, inArray } from 'drizzle-orm';
+import type { SqliteDb } from '@/lib/db/sqlite/connection';
+import * as schema from '@/lib/db/sqlite/schema';
+import type { GeneratedCode, CodeMetadata } from '@/types/project';
+import type { ICodeRepository } from '@/repositories/interfaces';
+import type { QueryOptions } from '@/repositories/interfaces/IBaseRepository';
+import { toDatabaseRow, normalizePagination, buildConditions } from '@/repositories/utils';
+
+/**
+ * SQLite 구현 (임베디드 단일 인스턴스·단일 사용자 경로).
+ *
+ * 매핑 기준은 Supabase 레포(`codeRepository.ts`)와 동일하다:
+ * - 타임스탬프(created_at)는 SQLite에 ISO 문자열로 저장되며, 도메인은 `string`을 기대하므로 그대로 반환.
+ * - JSON 컬럼(token_usage / dependencies / metadata)은 drizzle(mode:json)가 이미
+ *   객체/배열로 역직렬화해 돌려주므로 JSON.parse 불필요.
+ * - generated_codes에는 updated_at 컬럼이 없다(BaseRepository.update의 updated_at 주입 패턴 미적용).
+ * - (project_id, version) UNIQUE 제약. getNextVersion은 MAX(version)+1(없으면 1).
+ */
+export class SqliteCodeRepository implements ICodeRepository {
+  constructor(private db: SqliteDb) {}
+
+  async findById(id: string): Promise<GeneratedCode | null> {
+    const row = this.db
+      .select()
+      .from(schema.generatedCodes)
+      .where(eq(schema.generatedCodes.id, id))
+      .limit(1)
+      .get();
+
+    return row ? this.toDomain(row) : null;
+  }
+
+  async findMany(
+    filter?: Record<string, unknown>,
+    options: QueryOptions = {},
+  ): Promise<{ items: GeneratedCode[]; total: number }> {
+    const { orderDirection = 'desc' } = options;
+    const { offset, limit } = normalizePagination(options);
+
+    const conditions = buildConditions(filter);
+
+    const countResult = this.db
+      .select({ total: drizzleCount() })
+      .from(schema.generatedCodes)
+      .where(conditions)
+      .get();
+
+    const rows = this.db
+      .select()
+      .from(schema.generatedCodes)
+      .where(conditions)
+      .orderBy(
+        orderDirection === 'asc'
+          ? schema.generatedCodes.created_at
+          : desc(schema.generatedCodes.created_at),
+      )
+      .offset(offset)
+      .limit(limit)
+      .all();
+
+    return {
+      items: rows.map((row) => this.toDomain(row)),
+      total: countResult?.total ?? 0,
+    };
+  }
+
+  async create(input: Omit<GeneratedCode, 'id' | 'createdAt' | 'updatedAt'>): Promise<GeneratedCode> {
+    const dbData = toDatabaseRow(input);
+
+    const [row] = this.db
+      .insert(schema.generatedCodes)
+      .values(dbData as typeof schema.generatedCodes.$inferInsert)
+      .returning()
+      .all();
+
+    return this.toDomain(row);
+  }
+
+  async update(id: string, input: Partial<GeneratedCode>): Promise<GeneratedCode> {
+    const dbData = toDatabaseRow(input);
+
+    // generated_codes에는 updated_at 컬럼이 없으므로 추가하지 않는다.
+    const [row] = this.db
+      .update(schema.generatedCodes)
+      .set(dbData as Partial<typeof schema.generatedCodes.$inferInsert>)
+      .where(eq(schema.generatedCodes.id, id))
+      .returning()
+      .all();
+
+    return this.toDomain(row);
+  }
+
+  async delete(id: string): Promise<void> {
+    this.db.delete(schema.generatedCodes).where(eq(schema.generatedCodes.id, id)).run();
+  }
+
+  async count(filter?: Record<string, unknown>): Promise<number> {
+    const conditions = buildConditions(filter);
+
+    const result = this.db
+      .select({ total: drizzleCount() })
+      .from(schema.generatedCodes)
+      .where(conditions)
+      .get();
+
+    return result?.total ?? 0;
+  }
+
+  async findByProject(projectId: string, version?: number): Promise<GeneratedCode | null> {
+    if (version !== undefined) {
+      const row = this.db
+        .select()
+        .from(schema.generatedCodes)
+        .where(
+          and(
+            eq(schema.generatedCodes.project_id, projectId),
+            eq(schema.generatedCodes.version, version),
+          ),
+        )
+        .limit(1)
+        .get();
+
+      return row ? this.toDomain(row) : null;
+    }
+
+    // version 미지정: 최신 버전 1건
+    const row = this.db
+      .select()
+      .from(schema.generatedCodes)
+      .where(eq(schema.generatedCodes.project_id, projectId))
+      .orderBy(desc(schema.generatedCodes.version))
+      .limit(1)
+      .get();
+
+    return row ? this.toDomain(row) : null;
+  }
+
+  async countByProject(projectId: string): Promise<number> {
+    const result = this.db
+      .select({ total: drizzleCount() })
+      .from(schema.generatedCodes)
+      .where(eq(schema.generatedCodes.project_id, projectId))
+      .get();
+
+    return result?.total ?? 0;
+  }
+
+  async pruneOldVersions(projectId: string, keepCount: number): Promise<void> {
+    // 최신 keepCount개를 제외한 나머지(오래된) 버전들의 id를 조회 후 삭제.
+    // SQLite는 OFFSET 단독 사용을 허용하지 않으므로 대형 sentinel LIMIT으로 전 행을 대상으로 한다.
+    // (drizzle은 limit(-1)을 LIMIT 절로 직렬화하지 않아 bare OFFSET이 되어 syntax error 발생)
+    const toDelete = this.db
+      .select({ id: schema.generatedCodes.id })
+      .from(schema.generatedCodes)
+      .where(eq(schema.generatedCodes.project_id, projectId))
+      .orderBy(desc(schema.generatedCodes.version))
+      .limit(Number.MAX_SAFE_INTEGER)
+      .offset(keepCount)
+      .all();
+
+    if (toDelete.length === 0) return;
+
+    const idsToDelete = toDelete.map((row) => row.id);
+    this.db
+      .delete(schema.generatedCodes)
+      .where(inArray(schema.generatedCodes.id, idsToDelete))
+      .run();
+  }
+
+  async getNextVersion(projectId: string): Promise<number> {
+    const row = this.db
+      .select({ version: schema.generatedCodes.version })
+      .from(schema.generatedCodes)
+      .where(eq(schema.generatedCodes.project_id, projectId))
+      .orderBy(desc(schema.generatedCodes.version))
+      .limit(1)
+      .get();
+
+    if (!row) return 1;
+    return (row.version ?? 0) + 1;
+  }
+
+  private toDomain(row: typeof schema.generatedCodes.$inferSelect): GeneratedCode {
+    return {
+      id: row.id,
+      projectId: row.project_id,
+      version: row.version,
+      codeHtml: row.code_html ?? '',
+      codeCss: row.code_css ?? '',
+      codeJs: row.code_js ?? '',
+      framework: (row.framework as GeneratedCode['framework']) ?? 'vanilla',
+      aiProvider: row.ai_provider ?? null,
+      aiModel: row.ai_model ?? null,
+      aiPromptUsed: row.ai_prompt_used ?? null,
+      generationTimeMs: row.generation_time_ms ?? null,
+      tokenUsage: (row.token_usage as GeneratedCode['tokenUsage']) ?? null,
+      dependencies: (row.dependencies as string[]) ?? [],
+      metadata: (row.metadata as CodeMetadata) ?? {},
+      createdAt: row.created_at as string,
+    };
+  }
+}

--- a/src/repositories/sqlite/SqliteEventRepository.test.ts
+++ b/src/repositories/sqlite/SqliteEventRepository.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createSqliteConnection, runSqliteMigrations, type SqliteDb } from '@/lib/db/sqlite/connection';
+import * as schema from '@/lib/db/sqlite/schema';
+import type { DomainEvent } from '@/types/events';
+import { SqliteEventRepository } from './SqliteEventRepository';
+
+// Silence + observe best-effort logging.
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { logger } from '@/lib/utils/logger';
+
+const USER_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_USER_ID = '22222222-2222-2222-2222-222222222222';
+const PROJECT_ID = '33333333-3333-3333-3333-333333333333';
+
+function seedUser(db: SqliteDb, id: string, email: string): void {
+  db.insert(schema.users).values({ id, email }).run();
+}
+
+function seedProject(db: SqliteDb, id: string, userId: string): void {
+  db.insert(schema.projects).values({ id, user_id: userId, name: 'Test Project' }).run();
+}
+
+/** Direct row read helper (bypasses the repo) for white-box assertions. */
+function allEvents(db: SqliteDb) {
+  return db.select().from(schema.platformEvents).all();
+}
+
+describe('SqliteEventRepository', () => {
+  let db: SqliteDb;
+  let raw: Database.Database;
+  let repo: SqliteEventRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const conn = createSqliteConnection(':memory:');
+    db = conn.db;
+    raw = conn.raw;
+    runSqliteMigrations(db);
+    // FK prerequisites: a user (and one project) so user_id/project_id FKs resolve.
+    seedUser(db, USER_ID, 'owner@example.com');
+    seedUser(db, OTHER_USER_ID, 'other@example.com');
+    seedProject(db, PROJECT_ID, USER_ID);
+    repo = new SqliteEventRepository(db);
+  });
+
+  afterEach(() => {
+    raw.close();
+  });
+
+  describe('persist', () => {
+    it('persists an event with type and payload', async () => {
+      const event: DomainEvent = {
+        type: 'PROJECT_CREATED',
+        payload: { projectId: PROJECT_ID, userId: USER_ID, apiCount: 3 },
+      };
+
+      await repo.persist(event, { userId: USER_ID, projectId: PROJECT_ID });
+
+      const rows = allEvents(db);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].type).toBe('PROJECT_CREATED');
+      // payload (mode:'json') is round-tripped as an object, no JSON.parse needed.
+      expect(rows[0].payload).toEqual({
+        projectId: PROJECT_ID,
+        userId: USER_ID,
+        apiCount: 3,
+      });
+      expect(rows[0].user_id).toBe(USER_ID);
+      expect(rows[0].project_id).toBe(PROJECT_ID);
+      expect(typeof rows[0].id).toBe('string');
+      expect(rows[0].id.length).toBeGreaterThan(0);
+      // created_at is auto-filled by the schema $defaultFn as an ISO string.
+      expect(typeof rows[0].created_at).toBe('string');
+      expect(() => new Date(rows[0].created_at as string).toISOString()).not.toThrow();
+    });
+
+    it('extracts user_id and project_id from the payload when not given in context', async () => {
+      const event: DomainEvent = {
+        type: 'PROJECT_CREATED',
+        payload: { projectId: PROJECT_ID, userId: USER_ID, apiCount: 1 },
+      };
+
+      // No context fields supplied -> falls back to payload.userId / payload.projectId.
+      await repo.persist(event, {});
+
+      const rows = allEvents(db);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].user_id).toBe(USER_ID);
+      expect(rows[0].project_id).toBe(PROJECT_ID);
+    });
+
+    it('prefers context over payload-derived ids', async () => {
+      const event: DomainEvent = {
+        type: 'PROJECT_CREATED',
+        payload: { projectId: PROJECT_ID, userId: OTHER_USER_ID, apiCount: 0 },
+      };
+
+      await repo.persist(event, { userId: USER_ID, projectId: PROJECT_ID });
+
+      const rows = allEvents(db);
+      expect(rows[0].user_id).toBe(USER_ID); // context wins over payload OTHER_USER_ID
+      expect(rows[0].project_id).toBe(PROJECT_ID);
+    });
+
+    it('stores null user_id / project_id when neither context nor payload provide them', async () => {
+      const event: DomainEvent = {
+        type: 'API_QUOTA_WARNING',
+        payload: { service: 'unsplash', usage: 90, limit: 100 },
+      };
+
+      await repo.persist(event, {});
+
+      const rows = allEvents(db);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].user_id).toBeNull();
+      expect(rows[0].project_id).toBeNull();
+      expect(rows[0].payload).toEqual({ service: 'unsplash', usage: 90, limit: 100 });
+    });
+
+    it('defaults context to {} when omitted', async () => {
+      const event: DomainEvent = {
+        type: 'USER_SIGNED_UP',
+        payload: { userId: USER_ID },
+      };
+
+      // Called with only the event argument — context defaults to {}.
+      await repo.persist(event);
+
+      const rows = allEvents(db);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].user_id).toBe(USER_ID);
+      expect(rows[0].project_id).toBeNull();
+    });
+
+    it('is best-effort: logs a warning and does not throw on DB error (FK violation)', async () => {
+      const event: DomainEvent = {
+        type: 'USER_SIGNED_UP',
+        // userId references a non-existent user -> FK constraint failure.
+        payload: { userId: '99999999-9999-9999-9999-999999999999' },
+      };
+
+      await expect(repo.persist(event, {})).resolves.toBeUndefined();
+
+      expect(allEvents(db)).toHaveLength(0);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Failed to persist domain event',
+        expect.objectContaining({ eventType: 'USER_SIGNED_UP' }),
+      );
+    });
+
+    it('forwards correlationId into the warning context on failure', async () => {
+      const event: DomainEvent = {
+        type: 'USER_SIGNED_UP',
+        payload: { userId: '99999999-9999-9999-9999-999999999999' },
+      };
+
+      await repo.persist(event, { correlationId: 'corr-123' });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Failed to persist domain event',
+        expect.objectContaining({ correlationId: 'corr-123' }),
+      );
+    });
+  });
+
+  describe('persistAsync', () => {
+    it('writes the event without requiring await (fire-and-forget)', async () => {
+      const event: DomainEvent = {
+        type: 'DEPLOYMENT_COMPLETED',
+        payload: { projectId: PROJECT_ID, url: 'https://x.xzawed.xyz', platform: 'railway' },
+      };
+
+      repo.persistAsync(event, { userId: USER_ID, projectId: PROJECT_ID });
+
+      // Allow the internal promise microtask to settle.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const rows = allEvents(db);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].type).toBe('DEPLOYMENT_COMPLETED');
+      expect(rows[0].project_id).toBe(PROJECT_ID);
+    });
+
+    it('returns void synchronously', () => {
+      const event: DomainEvent = {
+        type: 'USER_SIGNED_UP',
+        payload: { userId: USER_ID },
+      };
+      const result = repo.persistAsync(event, {});
+      expect(result).toBeUndefined();
+    });
+
+    it('does not throw even when persistence fails', async () => {
+      const event: DomainEvent = {
+        type: 'USER_SIGNED_UP',
+        payload: { userId: '99999999-9999-9999-9999-999999999999' },
+      };
+
+      expect(() => repo.persistAsync(event, {})).not.toThrow();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(allEvents(db)).toHaveLength(0);
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('findByUser', () => {
+    it('returns recent events for a user, newest first, with the EventRecord shape', async () => {
+      // Insert with explicit, ordered created_at so ordering is deterministic.
+      const base = Date.parse('2026-06-01T00:00:00.000Z');
+      const mk = (i: number) => new Date(base + i * 1000).toISOString();
+
+      db.insert(schema.platformEvents)
+        .values([
+          { type: 'EVENT_A', payload: { n: 1 }, user_id: USER_ID, created_at: mk(0) },
+          { type: 'EVENT_B', payload: { n: 2 }, user_id: USER_ID, created_at: mk(1) },
+          { type: 'EVENT_C', payload: { n: 3 }, user_id: USER_ID, created_at: mk(2) },
+        ])
+        .run();
+
+      const result = await repo.findByUser(USER_ID);
+
+      expect(result).toHaveLength(3);
+      // newest first
+      expect(result.map((r) => r.type)).toEqual(['EVENT_C', 'EVENT_B', 'EVENT_A']);
+      const first = result[0];
+      expect(first).toEqual({
+        id: expect.any(String),
+        type: 'EVENT_C',
+        payload: { n: 3 },
+        createdAt: mk(2),
+      });
+      // createdAt mapped as a string
+      expect(typeof first.createdAt).toBe('string');
+    });
+
+    it('only returns events for the requested user', async () => {
+      db.insert(schema.platformEvents)
+        .values([
+          { type: 'MINE', payload: {}, user_id: USER_ID },
+          { type: 'THEIRS', payload: {}, user_id: OTHER_USER_ID },
+        ])
+        .run();
+
+      const result = await repo.findByUser(USER_ID);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('MINE');
+    });
+
+    it('returns an empty array when the user has no events', async () => {
+      const result = await repo.findByUser(USER_ID);
+      expect(result).toEqual([]);
+    });
+
+    it('respects the limit argument', async () => {
+      const rows = Array.from({ length: 5 }, (_, i) => ({
+        type: `E_${i}`,
+        payload: { i },
+        user_id: USER_ID,
+        created_at: new Date(Date.parse('2026-06-01T00:00:00.000Z') + i * 1000).toISOString(),
+      }));
+      db.insert(schema.platformEvents).values(rows).run();
+
+      const result = await repo.findByUser(USER_ID, 2);
+      expect(result).toHaveLength(2);
+      // Most recent two (E_4, E_3)
+      expect(result.map((r) => r.type)).toEqual(['E_4', 'E_3']);
+    });
+
+    it('caps the limit at 100', async () => {
+      // 3 rows but limit 1000 -> capped at 100, returns all 3.
+      db.insert(schema.platformEvents)
+        .values([
+          { type: 'A', payload: {}, user_id: USER_ID },
+          { type: 'B', payload: {}, user_id: USER_ID },
+          { type: 'C', payload: {}, user_id: USER_ID },
+        ])
+        .run();
+
+      const result = await repo.findByUser(USER_ID, 1000);
+      expect(result).toHaveLength(3);
+    });
+
+    it('defaults to a limit of 50 when not provided', async () => {
+      // 51 events; default limit 50 -> only 50 returned.
+      const baseTs = Date.parse('2026-06-01T00:00:00.000Z');
+      const rows = Array.from({ length: 51 }, (_, i) => ({
+        type: `E_${i}`,
+        payload: { i },
+        user_id: USER_ID,
+        created_at: new Date(baseTs + i * 1000).toISOString(),
+      }));
+      db.insert(schema.platformEvents).values(rows).run();
+
+      const result = await repo.findByUser(USER_ID);
+      expect(result).toHaveLength(50);
+    });
+
+    it('returns an empty array (not a throw) when the query fails', async () => {
+      // Close the underlying DB to force the select to throw, then assert graceful handling.
+      raw.close();
+
+      const result = await repo.findByUser(USER_ID);
+      expect(result).toEqual([]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Failed to fetch user events',
+        expect.objectContaining({ userId: USER_ID }),
+      );
+
+      // Re-open a connection so afterEach's close() does not throw on an already-closed handle.
+      const conn = createSqliteConnection(':memory:');
+      raw = conn.raw;
+    });
+  });
+});

--- a/src/repositories/sqlite/SqliteEventRepository.test.ts
+++ b/src/repositories/sqlite/SqliteEventRepository.test.ts
@@ -56,6 +56,48 @@ describe('SqliteEventRepository', () => {
     raw.close();
   });
 
+  describe('countByTypeSince / findPayloadsByTypeSince', () => {
+    function insertEvent(type: string, createdAt: string, payload: Record<string, unknown> = {}): void {
+      raw
+        .prepare('INSERT INTO platform_events (id, type, payload, created_at) VALUES (?, ?, ?, ?)')
+        .run(crypto.randomUUID(), type, JSON.stringify(payload), createdAt);
+    }
+
+    beforeEach(() => {
+      insertEvent('CODE_GENERATION_FAILED', '2026-06-10T00:00:00.000Z');
+      insertEvent('CODE_GENERATION_FAILED', '2026-06-20T00:00:00.000Z');
+      insertEvent('CODE_GENERATION_FAILED', '2026-05-01T00:00:00.000Z'); // 윈도우 이전
+      insertEvent('STAGE_SKIPPED', '2026-06-20T00:00:00.000Z', { stage: 'stage2' });
+      insertEvent('STAGE_SKIPPED', '2026-06-21T00:00:00.000Z', { stage: 'stage3' });
+    });
+
+    it('countByTypeSince는 type + since(포함) 이후만 센다', async () => {
+      const since = new Date('2026-06-01T00:00:00.000Z');
+      expect(await repo.countByTypeSince('CODE_GENERATION_FAILED', since)).toBe(2);
+      expect(await repo.countByTypeSince('STAGE_SKIPPED', since)).toBe(2);
+      expect(await repo.countByTypeSince('NONEXISTENT', since)).toBe(0);
+    });
+
+    it('since 경계는 포함(>=)이다', async () => {
+      expect(
+        await repo.countByTypeSince('CODE_GENERATION_FAILED', new Date('2026-06-10T00:00:00.000Z')),
+      ).toBe(2);
+      expect(
+        await repo.countByTypeSince('CODE_GENERATION_FAILED', new Date('2026-06-11T00:00:00.000Z')),
+      ).toBe(1);
+    });
+
+    it('findPayloadsByTypeSince는 type + since 이후 payload 배열을 돌려준다', async () => {
+      const payloads = await repo.findPayloadsByTypeSince(
+        'STAGE_SKIPPED',
+        new Date('2026-06-01T00:00:00.000Z'),
+      );
+      expect(payloads).toHaveLength(2);
+      const stages = payloads.map((p) => (p as { stage?: string }).stage).sort();
+      expect(stages).toEqual(['stage2', 'stage3']);
+    });
+  });
+
   describe('persist', () => {
     it('persists an event with type and payload', async () => {
       const event: DomainEvent = {

--- a/src/repositories/sqlite/SqliteEventRepository.ts
+++ b/src/repositories/sqlite/SqliteEventRepository.ts
@@ -1,4 +1,4 @@
-import { eq, desc } from 'drizzle-orm';
+import { eq, desc, and, gte, sql } from 'drizzle-orm';
 import type { SqliteDb } from '@/lib/db/sqlite/connection';
 import * as schema from '@/lib/db/sqlite/schema';
 import type { DomainEvent } from '@/types/events';
@@ -96,5 +96,34 @@ export class SqliteEventRepository implements IEventRepository {
       });
       return [];
     }
+  }
+
+  // created_at은 ISO8601 텍스트라 사전식 비교가 곧 시간순 비교(>=).
+  async countByTypeSince(type: string, since: Date): Promise<number> {
+    const row = this.db
+      .select({ total: sql<number>`count(*)` })
+      .from(schema.platformEvents)
+      .where(
+        and(
+          eq(schema.platformEvents.type, type),
+          gte(schema.platformEvents.created_at, since.toISOString()),
+        ),
+      )
+      .get();
+    return row?.total ?? 0;
+  }
+
+  async findPayloadsByTypeSince(type: string, since: Date): Promise<unknown[]> {
+    const rows = this.db
+      .select({ payload: schema.platformEvents.payload })
+      .from(schema.platformEvents)
+      .where(
+        and(
+          eq(schema.platformEvents.type, type),
+          gte(schema.platformEvents.created_at, since.toISOString()),
+        ),
+      )
+      .all();
+    return rows.map((r) => r.payload);
   }
 }

--- a/src/repositories/sqlite/SqliteEventRepository.ts
+++ b/src/repositories/sqlite/SqliteEventRepository.ts
@@ -1,0 +1,100 @@
+import { eq, desc } from 'drizzle-orm';
+import type { SqliteDb } from '@/lib/db/sqlite/connection';
+import * as schema from '@/lib/db/sqlite/schema';
+import type { DomainEvent } from '@/types/events';
+import { logger } from '@/lib/utils/logger';
+import type { IEventRepository, PersistEventContext, EventRecord } from '@/repositories/interfaces';
+
+/**
+ * SQLite(better-sqlite3 + drizzle)-based EventRepository for persisting domain events.
+ *
+ * Same semantics as the Supabase version (the source of truth for mapping):
+ * - persist() logs but doesn't throw on error (best-effort audit logging — the
+ *   main business operation must not fail because of event persistence).
+ * - persistAsync() is fire-and-forget; it never throws.
+ * - findByUser() returns the most recent events for a user (max 100), with
+ *   `payload` already deserialized by drizzle (mode:'json') and `createdAt`
+ *   as an ISO string (SQLite stores timestamps as ISO8601 text).
+ *
+ * Single-user / self-hosted path: ownership is enforced by the supplied user_id
+ * filter (no RLS layer).
+ */
+export class SqliteEventRepository implements IEventRepository {
+  constructor(private readonly db: SqliteDb) {}
+
+  /**
+   * Persists a domain event to the platform_events table.
+   * Extracts user_id / project_id from the event payload when not provided
+   * in context, so callers only need to pass context for cross-cutting fields.
+   */
+  async persist(event: DomainEvent, context: PersistEventContext = {}): Promise<void> {
+    const payload = event.payload as Record<string, unknown>;
+
+    const row = {
+      type: event.type,
+      payload,
+      user_id: context.userId ?? (payload.userId as string | undefined) ?? null,
+      project_id: context.projectId ?? (payload.projectId as string | undefined) ?? null,
+    };
+
+    try {
+      this.db.insert(schema.platformEvents).values(row).run();
+    } catch (err: unknown) {
+      // Log but don't throw — event persistence is best-effort.
+      logger.warn('Failed to persist domain event', {
+        eventType: event.type,
+        error: err instanceof Error ? err.message : String(err),
+        correlationId: context.correlationId,
+      });
+    }
+  }
+
+  /**
+   * Fire-and-forget wrapper — safe to call without await.
+   * Errors are swallowed after logging; the caller's execution continues.
+   */
+  persistAsync(event: DomainEvent, context: PersistEventContext = {}): void {
+    this.persist(event, context).catch((err: unknown) => {
+      logger.warn('EventRepository.persistAsync unhandled error', {
+        eventType: event.type,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
+
+  /**
+   * Retrieves recent events for a user (for audit log UI, max 100),
+   * newest first.
+   */
+  async findByUser(userId: string, limit = 50): Promise<EventRecord[]> {
+    const safeLimit = Math.min(limit, 100);
+
+    try {
+      const rows = this.db
+        .select({
+          id: schema.platformEvents.id,
+          type: schema.platformEvents.type,
+          payload: schema.platformEvents.payload,
+          created_at: schema.platformEvents.created_at,
+        })
+        .from(schema.platformEvents)
+        .where(eq(schema.platformEvents.user_id, userId))
+        .orderBy(desc(schema.platformEvents.created_at))
+        .limit(safeLimit)
+        .all();
+
+      return rows.map((row) => ({
+        id: row.id,
+        type: row.type,
+        payload: row.payload,
+        createdAt: String(row.created_at),
+      }));
+    } catch (err: unknown) {
+      logger.warn('Failed to fetch user events', {
+        userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return [];
+    }
+  }
+}

--- a/src/repositories/sqlite/SqliteProjectRepository.test.ts
+++ b/src/repositories/sqlite/SqliteProjectRepository.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createSqliteConnection, runSqliteMigrations, type SqliteDb } from '@/lib/db/sqlite/connection';
+import * as schema from '@/lib/db/sqlite/schema';
+import { SqliteProjectRepository } from './SqliteProjectRepository';
+import type { Project } from '@/types/project';
+
+const USER_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_USER_ID = '22222222-2222-2222-2222-222222222222';
+const API_ID = '33333333-3333-3333-3333-333333333333';
+const API_ID_2 = '44444444-4444-4444-4444-444444444444';
+
+function seedUser(db: SqliteDb, id: string, email: string): void {
+  db.insert(schema.users).values({ id, email }).run();
+}
+
+function seedApi(db: SqliteDb, id: string, name: string): void {
+  db.insert(schema.apiCatalog).values({ id, name }).run();
+}
+
+/** 직접 projects 행을 삽입하고 도메인 식별용 id를 반환한다. */
+function seedProject(
+  db: SqliteDb,
+  overrides: Partial<typeof schema.projects.$inferInsert> = {}
+): string {
+  const [row] = db
+    .insert(schema.projects)
+    .values({
+      user_id: USER_ID,
+      name: 'Test Project',
+      context: 'a context',
+      ...overrides,
+    } as typeof schema.projects.$inferInsert)
+    .returning()
+    .all();
+  return row.id;
+}
+
+function baseCreateInput(
+  overrides: Partial<Omit<Project, 'id' | 'createdAt' | 'updatedAt'>> = {}
+): Omit<Project, 'id' | 'createdAt' | 'updatedAt'> {
+  return {
+    userId: USER_ID,
+    organizationId: null,
+    name: 'My Project',
+    context: 'build something',
+    status: 'draft',
+    deployUrl: null,
+    deployPlatform: null,
+    repoUrl: null,
+    previewUrl: null,
+    metadata: {},
+    currentVersion: 0,
+    apis: [],
+    slug: null,
+    suggestedSlugs: undefined,
+    publishedAt: null,
+    ...overrides,
+  };
+}
+
+describe('SqliteProjectRepository', () => {
+  let db: SqliteDb;
+  let raw: Database.Database;
+  let repo: SqliteProjectRepository;
+
+  beforeEach(() => {
+    const conn = createSqliteConnection(':memory:');
+    db = conn.db;
+    raw = conn.raw;
+    runSqliteMigrations(db);
+
+    seedUser(db, USER_ID, 'owner@example.com');
+    seedUser(db, OTHER_USER_ID, 'other@example.com');
+    seedApi(db, API_ID, 'API One');
+    seedApi(db, API_ID_2, 'API Two');
+
+    repo = new SqliteProjectRepository(db);
+  });
+
+  afterEach(() => {
+    raw.close();
+  });
+
+  describe('create', () => {
+    it('creates a project and maps to domain shape', async () => {
+      const created = await repo.create(baseCreateInput({ name: 'Hello', context: 'ctx' }));
+
+      expect(created.id).toBeTruthy();
+      expect(created.name).toBe('Hello');
+      expect(created.context).toBe('ctx');
+      expect(created.userId).toBe(USER_ID);
+      expect(created.status).toBe('draft');
+      // organization_id는 항상 null 보존
+      expect(created.organizationId).toBeNull();
+      expect(created.apis).toEqual([]);
+      expect(created.metadata).toEqual({});
+      expect(created.currentVersion).toBe(0);
+      expect(created.slug).toBeNull();
+      expect(created.publishedAt).toBeNull();
+      // 타임스탬프는 ISO 문자열
+      expect(typeof created.createdAt).toBe('string');
+      expect(typeof created.updatedAt).toBe('string');
+      expect(() => new Date(created.createdAt).toISOString()).not.toThrow();
+    });
+
+    it('strips apis and persists json metadata + suggestedSlugs round-trip', async () => {
+      const created = await repo.create(
+        baseCreateInput({
+          metadata: { tags: ['x', 'y'], isPublic: true },
+          suggestedSlugs: ['a', 'b'],
+        })
+      );
+
+      const reloaded = await repo.findById(created.id);
+      expect(reloaded).not.toBeNull();
+      // JSON 컬럼은 객체/배열로 역직렬화되어 돌아옴(JSON.parse 불필요)
+      expect(reloaded?.metadata).toEqual({ tags: ['x', 'y'], isPublic: true });
+      expect(reloaded?.suggestedSlugs).toEqual(['a', 'b']);
+      // apis는 매핑에서 항상 빈 배열
+      expect(reloaded?.apis).toEqual([]);
+    });
+  });
+
+  describe('findById', () => {
+    it('returns the project when found', async () => {
+      const id = seedProject(db, { name: 'FindMe' });
+      const found = await repo.findById(id);
+      expect(found?.id).toBe(id);
+      expect(found?.name).toBe('FindMe');
+    });
+
+    it('returns null when not found', async () => {
+      const found = await repo.findById('00000000-0000-0000-0000-000000000000');
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('findByUserId', () => {
+    it('returns only the given user projects, newest first', async () => {
+      const first = seedProject(db, {
+        name: 'First',
+        created_at: '2026-01-01T00:00:00.000Z',
+      });
+      const second = seedProject(db, {
+        name: 'Second',
+        created_at: '2026-02-01T00:00:00.000Z',
+      });
+      // 다른 사용자 프로젝트는 제외되어야 함
+      seedProject(db, { user_id: OTHER_USER_ID, name: 'Foreign' });
+
+      const list = await repo.findByUserId(USER_ID);
+      expect(list).toHaveLength(2);
+      // created_at desc → Second 먼저
+      expect(list[0].id).toBe(second);
+      expect(list[1].id).toBe(first);
+      expect(list.every((p) => p.userId === USER_ID)).toBe(true);
+    });
+
+    it('returns empty array when user has no projects', async () => {
+      const list = await repo.findByUserId(OTHER_USER_ID);
+      expect(list).toEqual([]);
+    });
+  });
+
+  describe('findMany', () => {
+    beforeEach(() => {
+      seedProject(db, { name: 'P1', status: 'draft', created_at: '2026-01-01T00:00:00.000Z' });
+      seedProject(db, { name: 'P2', status: 'published', created_at: '2026-02-01T00:00:00.000Z' });
+      seedProject(db, {
+        user_id: OTHER_USER_ID,
+        name: 'P3',
+        status: 'draft',
+        created_at: '2026-03-01T00:00:00.000Z',
+      });
+    });
+
+    it('returns all with total when no filter (desc by created_at)', async () => {
+      const { items, total } = await repo.findMany();
+      expect(total).toBe(3);
+      expect(items).toHaveLength(3);
+      expect(items[0].name).toBe('P3'); // newest
+    });
+
+    it('applies camelCase filter converted to snake_case column', async () => {
+      const { items, total } = await repo.findMany({ userId: USER_ID });
+      expect(total).toBe(2);
+      expect(items.every((p) => p.userId === USER_ID)).toBe(true);
+    });
+
+    it('supports multiple filter conditions', async () => {
+      const { items, total } = await repo.findMany({ userId: USER_ID, status: 'published' });
+      expect(total).toBe(1);
+      expect(items[0].name).toBe('P2');
+    });
+
+    it('honors pagination (limit/page)', async () => {
+      const pageOne = await repo.findMany(undefined, { page: 1, limit: 2 });
+      expect(pageOne.total).toBe(3);
+      expect(pageOne.items).toHaveLength(2);
+
+      const pageTwo = await repo.findMany(undefined, { page: 2, limit: 2 });
+      expect(pageTwo.total).toBe(3);
+      expect(pageTwo.items).toHaveLength(1);
+    });
+
+    it('honors ascending order direction', async () => {
+      const { items } = await repo.findMany(undefined, { orderDirection: 'asc' });
+      expect(items[0].name).toBe('P1'); // oldest first
+    });
+  });
+
+  describe('update', () => {
+    it('updates fields and refreshes updated_at, stripping apis', async () => {
+      const id = seedProject(db, { name: 'Before', updated_at: '2020-01-01T00:00:00.000Z' });
+
+      const updated = await repo.update(id, {
+        name: 'After',
+        status: 'generated',
+        apis: [{ id: 'should-be-stripped' } as never],
+      });
+
+      expect(updated.name).toBe('After');
+      expect(updated.status).toBe('generated');
+      expect(updated.apis).toEqual([]);
+      // updated_at이 갱신됨
+      expect(updated.updatedAt).not.toBe('2020-01-01T00:00:00.000Z');
+      expect(new Date(updated.updatedAt).getTime()).toBeGreaterThan(
+        new Date('2020-01-01T00:00:00.000Z').getTime()
+      );
+    });
+
+    it('throws NotFoundError when project does not exist', async () => {
+      await expect(
+        repo.update('00000000-0000-0000-0000-000000000000', { name: 'x' })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes the project', async () => {
+      const id = seedProject(db);
+      await repo.delete(id);
+      const found = await repo.findById(id);
+      expect(found).toBeNull();
+    });
+
+    it('is a no-op when id does not exist', async () => {
+      await expect(
+        repo.delete('00000000-0000-0000-0000-000000000000')
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('count', () => {
+    beforeEach(() => {
+      seedProject(db, { status: 'draft' });
+      seedProject(db, { status: 'published' });
+      seedProject(db, { user_id: OTHER_USER_ID, status: 'draft' });
+    });
+
+    it('counts all when no filter', async () => {
+      expect(await repo.count()).toBe(3);
+    });
+
+    it('counts with snake_case-converted filter', async () => {
+      expect(await repo.count({ userId: USER_ID })).toBe(2);
+      expect(await repo.count({ status: 'published' })).toBe(1);
+    });
+  });
+
+  describe('findBySlug', () => {
+    it('returns the project with the matching slug', async () => {
+      const id = seedProject(db, { slug: 'my-slug' });
+      const found = await repo.findBySlug('my-slug');
+      expect(found?.id).toBe(id);
+      expect(found?.slug).toBe('my-slug');
+    });
+
+    it('returns null when slug not found', async () => {
+      const found = await repo.findBySlug('nonexistent');
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('updateSlug', () => {
+    it('sets slug, published_at, status=published and refreshes updated_at', async () => {
+      const id = seedProject(db, { status: 'draft' });
+      const publishedAt = new Date('2026-06-22T12:00:00.000Z');
+
+      const result = await repo.updateSlug(id, 'live-slug', publishedAt);
+
+      expect(result.slug).toBe('live-slug');
+      expect(result.status).toBe('published');
+      expect(result.publishedAt).toBe('2026-06-22T12:00:00.000Z');
+      expect(typeof result.updatedAt).toBe('string');
+
+      // 영속성 확인
+      const reloaded = await repo.findBySlug('live-slug');
+      expect(reloaded?.id).toBe(id);
+      expect(reloaded?.status).toBe('published');
+    });
+
+    it('throws NotFoundError when project does not exist', async () => {
+      await expect(
+        repo.updateSlug('00000000-0000-0000-0000-000000000000', 's', new Date())
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('updateSuggestedSlugs', () => {
+    it('persists the suggested slugs json array', async () => {
+      const id = seedProject(db);
+      await repo.updateSuggestedSlugs(id, ['alpha', 'beta', 'gamma']);
+
+      const reloaded = await repo.findById(id);
+      expect(reloaded?.suggestedSlugs).toEqual(['alpha', 'beta', 'gamma']);
+    });
+  });
+
+  describe('insertProjectApis / getProjectApiIds', () => {
+    it('inserts mappings and reads them back', async () => {
+      const projectId = seedProject(db);
+      await repo.insertProjectApis(projectId, [API_ID, API_ID_2]);
+
+      const ids = await repo.getProjectApiIds(projectId);
+      expect(ids.sort()).toEqual([API_ID, API_ID_2].sort());
+    });
+
+    it('insert is a no-op for empty array', async () => {
+      const projectId = seedProject(db);
+      await repo.insertProjectApis(projectId, []);
+      const ids = await repo.getProjectApiIds(projectId);
+      expect(ids).toEqual([]);
+    });
+
+    it('getProjectApiIds returns empty array when none', async () => {
+      const projectId = seedProject(db);
+      const ids = await repo.getProjectApiIds(projectId);
+      expect(ids).toEqual([]);
+    });
+  });
+
+  describe('countTodayGenerations', () => {
+    function seedGeneratedCode(
+      projectId: string,
+      version: number,
+      createdAt: string
+    ): void {
+      db.insert(schema.generatedCodes)
+        .values({
+          project_id: projectId,
+          version,
+          created_at: createdAt,
+        } as typeof schema.generatedCodes.$inferInsert)
+        .run();
+    }
+
+    it('counts only generated_codes created today (UTC) for the user', async () => {
+      const projectId = seedProject(db, { name: 'GenProj' });
+
+      const now = new Date();
+      const todayUtc = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 10, 0, 0)
+      ).toISOString();
+      const alsoToday = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 23, 59, 0)
+      ).toISOString();
+      const yesterday = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()) - 1
+      ).toISOString();
+
+      seedGeneratedCode(projectId, 1, todayUtc);
+      seedGeneratedCode(projectId, 2, alsoToday);
+      seedGeneratedCode(projectId, 3, yesterday); // 어제 → 제외
+
+      const count = await repo.countTodayGenerations(USER_ID);
+      expect(count).toBe(2);
+    });
+
+    it('does not count other users generations', async () => {
+      const ownProject = seedProject(db, { name: 'Own' });
+      const foreignProject = seedProject(db, { user_id: OTHER_USER_ID, name: 'Foreign' });
+
+      const now = new Date();
+      const todayUtc = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 8, 0, 0)
+      ).toISOString();
+
+      seedGeneratedCode(ownProject, 1, todayUtc);
+      seedGeneratedCode(foreignProject, 1, todayUtc);
+
+      expect(await repo.countTodayGenerations(USER_ID)).toBe(1);
+      expect(await repo.countTodayGenerations(OTHER_USER_ID)).toBe(1);
+    });
+
+    it('returns 0 when user has no generations', async () => {
+      expect(await repo.countTodayGenerations(USER_ID)).toBe(0);
+    });
+  });
+});

--- a/src/repositories/sqlite/SqliteProjectRepository.ts
+++ b/src/repositories/sqlite/SqliteProjectRepository.ts
@@ -1,0 +1,253 @@
+import { eq, and, desc, asc, sql } from 'drizzle-orm';
+import type { SQLiteColumn } from 'drizzle-orm/sqlite-core';
+import type { SqliteDb } from '@/lib/db/sqlite/connection';
+import * as schema from '@/lib/db/sqlite/schema';
+import type { Project, ProjectMetadata } from '@/types/project';
+import type { IProjectRepository } from '@/repositories/interfaces';
+import type { QueryOptions } from '@/repositories/interfaces/IBaseRepository';
+import { toDatabaseRow, normalizePagination, toSnake } from '@/repositories/utils';
+import { NotFoundError } from '@/lib/utils/errors';
+
+type ProjectRow = typeof schema.projects.$inferSelect;
+
+/**
+ * SQLite 구현 — IProjectRepository.
+ *
+ * 매핑 기준은 Supabase 레포(projectRepository.ts)의 toDomain이다:
+ *  - organization_id는 항상 null 보존(테이블에 컬럼은 있으나 Organizations 기능 제거)
+ *  - metadata는 객체(없으면 {}), suggested_slugs는 배열(없으면 undefined)
+ *  - 타임스탬프(created_at/updated_at/published_at)는 ISO 문자열 그대로 (도메인이 string ISO 기대)
+ *  - apis는 항상 빈 배열(별도 join으로 채움)
+ *
+ * SQLite quirk:
+ *  - JSON 컬럼(mode:json)은 drizzle가 이미 객체/배열로 역직렬화해 돌려준다(JSON.parse 불필요)
+ *  - created_at은 ISO8601 UTC 문자열로 저장되므로 사전식 문자열 비교로 날짜 필터가 가능하다
+ */
+export class SqliteProjectRepository implements IProjectRepository {
+  constructor(private db: SqliteDb) {}
+
+  async findById(id: string): Promise<Project | null> {
+    const rows = this.db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, id))
+      .limit(1)
+      .all();
+
+    return rows.length > 0 ? this.toDomain(rows[0]) : null;
+  }
+
+  async findMany(
+    filter?: Record<string, unknown>,
+    options: QueryOptions = {}
+  ): Promise<{ items: Project[]; total: number }> {
+    const { orderBy = 'created_at', orderDirection = 'desc' } = options;
+    const { offset, limit } = normalizePagination(options);
+
+    const conditions = this.buildConditions(filter);
+
+    const countRow = this.db
+      .select({ total: sql<number>`count(*)` })
+      .from(schema.projects)
+      .where(conditions)
+      .get();
+
+    const columns = schema.projects as unknown as Record<string, SQLiteColumn | undefined>;
+    const orderColumn: SQLiteColumn = columns[orderBy] ?? schema.projects.created_at;
+    const orderExpr = orderDirection === 'asc' ? asc(orderColumn) : desc(orderColumn);
+
+    const rows = this.db
+      .select()
+      .from(schema.projects)
+      .where(conditions)
+      .orderBy(orderExpr)
+      .limit(limit)
+      .offset(offset)
+      .all();
+
+    return {
+      items: rows.map((row) => this.toDomain(row)),
+      total: countRow?.total ?? 0,
+    };
+  }
+
+  async create(input: Omit<Project, 'id' | 'createdAt' | 'updatedAt'>): Promise<Project> {
+    const { apis: _apis, ...rest } = input;
+    const dbData = toDatabaseRow(rest);
+
+    const [row] = this.db
+      .insert(schema.projects)
+      .values(dbData as typeof schema.projects.$inferInsert)
+      .returning()
+      .all();
+
+    return this.toDomain(row);
+  }
+
+  async update(id: string, input: Partial<Project>): Promise<Project> {
+    const { apis: _apis, ...rest } = input;
+    const dbData = toDatabaseRow(rest);
+
+    const [row] = this.db
+      .update(schema.projects)
+      .set({ ...dbData, updated_at: new Date().toISOString() } as Partial<
+        typeof schema.projects.$inferInsert
+      >)
+      .where(eq(schema.projects.id, id))
+      .returning()
+      .all();
+
+    if (!row) throw new NotFoundError('프로젝트', id);
+    return this.toDomain(row);
+  }
+
+  async delete(id: string): Promise<void> {
+    this.db.delete(schema.projects).where(eq(schema.projects.id, id)).run();
+  }
+
+  async count(filter?: Record<string, unknown>): Promise<number> {
+    const conditions = this.buildConditions(filter);
+
+    const row = this.db
+      .select({ total: sql<number>`count(*)` })
+      .from(schema.projects)
+      .where(conditions)
+      .get();
+
+    return row?.total ?? 0;
+  }
+
+  async findByUserId(userId: string): Promise<Project[]> {
+    const rows = this.db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.user_id, userId))
+      .orderBy(desc(schema.projects.created_at))
+      .all();
+
+    return rows.map((row) => this.toDomain(row));
+  }
+
+  async countTodayGenerations(userId: string): Promise<number> {
+    // Supabase RPC(count_today_generations)와 동일 의미:
+    //   gc.created_at >= date_trunc('day', NOW() AT TIME ZONE 'UTC')
+    // created_at은 ISO8601 UTC 문자열이므로 UTC 자정 ISO 문자열과의 사전식 >= 비교로 재현한다.
+    const now = new Date();
+    const utcMidnight = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+    ).toISOString();
+
+    const row = this.db
+      .select({ cnt: sql<number>`count(*)` })
+      .from(schema.generatedCodes)
+      .innerJoin(schema.projects, eq(schema.projects.id, schema.generatedCodes.project_id))
+      .where(
+        and(
+          eq(schema.projects.user_id, userId),
+          sql`${schema.generatedCodes.created_at} >= ${utcMidnight}`
+        )
+      )
+      .get();
+
+    return row?.cnt ?? 0;
+  }
+
+  async insertProjectApis(projectId: string, apiIds: string[]): Promise<void> {
+    if (apiIds.length === 0) return;
+
+    const mappings = apiIds.map((apiId) => ({
+      project_id: projectId,
+      api_id: apiId,
+    }));
+
+    this.db.insert(schema.projectApis).values(mappings).run();
+  }
+
+  async getProjectApiIds(projectId: string): Promise<string[]> {
+    const rows = this.db
+      .select({ api_id: schema.projectApis.api_id })
+      .from(schema.projectApis)
+      .where(eq(schema.projectApis.project_id, projectId))
+      .all();
+
+    return rows.map((row) => row.api_id);
+  }
+
+  async findBySlug(slug: string): Promise<Project | null> {
+    const rows = this.db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.slug, slug))
+      .limit(1)
+      .all();
+
+    return rows.length > 0 ? this.toDomain(rows[0]) : null;
+  }
+
+  async updateSuggestedSlugs(id: string, slugs: string[]): Promise<void> {
+    this.db
+      .update(schema.projects)
+      .set({ suggested_slugs: slugs })
+      .where(eq(schema.projects.id, id))
+      .run();
+  }
+
+  async updateSlug(id: string, slug: string, publishedAt: Date): Promise<Project> {
+    const [row] = this.db
+      .update(schema.projects)
+      .set({
+        slug,
+        published_at: publishedAt.toISOString(),
+        status: 'published',
+        updated_at: new Date().toISOString(),
+      })
+      .where(eq(schema.projects.id, id))
+      .returning()
+      .all();
+
+    if (!row) throw new NotFoundError('프로젝트', id);
+    return this.toDomain(row);
+  }
+
+  /**
+   * 평면 객체 필터를 drizzle WHERE 조건으로 변환한다(camelCase → snake_case 컬럼).
+   * Supabase 레포의 findMany/count 필터 처리와 동일 의미.
+   */
+  private buildConditions(filter?: Record<string, unknown>) {
+    if (!filter) return undefined;
+
+    const conditions = Object.entries(filter)
+      .filter(([, value]) => value !== undefined && value !== null)
+      .map(([key, value]) => {
+        const col = toSnake(key);
+        return sql`${sql.identifier(col)} = ${value}`;
+      });
+
+    if (conditions.length === 0) return undefined;
+    if (conditions.length === 1) return conditions[0];
+    return and(...conditions);
+  }
+
+  private toDomain(row: ProjectRow): Project {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      organizationId: row.organization_id ?? null,
+      name: row.name,
+      context: row.context ?? '',
+      status: row.status as Project['status'],
+      deployUrl: row.deploy_url ?? null,
+      deployPlatform: row.deploy_platform ?? null,
+      repoUrl: row.repo_url ?? null,
+      previewUrl: row.preview_url ?? null,
+      metadata: (row.metadata as ProjectMetadata) ?? {},
+      currentVersion: row.current_version ?? 0,
+      apis: [],
+      slug: row.slug ?? null,
+      suggestedSlugs: row.suggested_slugs ?? undefined,
+      publishedAt: row.published_at ?? null,
+      createdAt: row.created_at ?? '',
+      updatedAt: row.updated_at ?? '',
+    };
+  }
+}

--- a/src/repositories/sqlite/SqliteRateLimitRepository.test.ts
+++ b/src/repositories/sqlite/SqliteRateLimitRepository.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createSqliteConnection, runSqliteMigrations, type SqliteDb } from '@/lib/db/sqlite/connection';
+import * as schema from '@/lib/db/sqlite/schema';
+import { SqliteRateLimitRepository } from './SqliteRateLimitRepository';
+
+/** PG CURRENT_DATE에 대응하는 로컬 오늘 날짜 YYYY-MM-DD (레포 구현과 동일 규칙). */
+function today(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+describe('SqliteRateLimitRepository', () => {
+  let db: SqliteDb;
+  let raw: Database.Database;
+  let repo: SqliteRateLimitRepository;
+  const USER_ID = '11111111-1111-1111-1111-111111111111';
+
+  beforeEach(() => {
+    const conn = createSqliteConnection(':memory:');
+    db = conn.db;
+    raw = conn.raw;
+    runSqliteMigrations(db);
+    // FK 선행 행: users 1행
+    db.insert(schema.users).values({ id: USER_ID, email: 'user@example.com' }).run();
+    repo = new SqliteRateLimitRepository(db);
+  });
+
+  afterEach(() => {
+    raw.close();
+  });
+
+  /** user_daily_limits 오늘 행을 직접 조회 (검증 헬퍼). */
+  function readRow(): { generation_count: number | null; deploy_count: number | null } | undefined {
+    return raw
+      .prepare(
+        'SELECT generation_count, deploy_count FROM user_daily_limits WHERE user_id = ? AND usage_date = ?',
+      )
+      .get(USER_ID, today()) as
+      | { generation_count: number | null; deploy_count: number | null }
+      | undefined;
+  }
+
+  describe('checkAndIncrementDailyLimit', () => {
+    it('첫 호출 시 행을 생성하고 카운트를 1로 올리며 true를 반환한다', async () => {
+      const ok = await repo.checkAndIncrementDailyLimit(USER_ID, 5);
+      expect(ok).toBe(true);
+      expect(readRow()?.generation_count).toBe(1);
+    });
+
+    it('한도 미만이면 호출마다 증가하고 true를 반환한다', async () => {
+      expect(await repo.checkAndIncrementDailyLimit(USER_ID, 3)).toBe(true);
+      expect(await repo.checkAndIncrementDailyLimit(USER_ID, 3)).toBe(true);
+      expect(await repo.checkAndIncrementDailyLimit(USER_ID, 3)).toBe(true);
+      expect(readRow()?.generation_count).toBe(3);
+    });
+
+    it('한도 도달 시 더 이상 증가하지 않고 false를 반환한다', async () => {
+      await repo.checkAndIncrementDailyLimit(USER_ID, 2);
+      await repo.checkAndIncrementDailyLimit(USER_ID, 2);
+      const blocked = await repo.checkAndIncrementDailyLimit(USER_ID, 2);
+      expect(blocked).toBe(false);
+      // 카운트는 한도(2)에서 멈춘다 — 증가하지 않음
+      expect(readRow()?.generation_count).toBe(2);
+    });
+
+    it('한도가 0이면 즉시 false를 반환하고 증가하지 않는다', async () => {
+      const ok = await repo.checkAndIncrementDailyLimit(USER_ID, 0);
+      expect(ok).toBe(false);
+      // 행은 생성되되 카운트는 0
+      expect(readRow()?.generation_count).toBe(0);
+    });
+
+    it('deploy_count에는 영향을 주지 않는다', async () => {
+      await repo.checkAndIncrementDailyLimit(USER_ID, 5);
+      expect(readRow()?.deploy_count).toBe(0);
+    });
+  });
+
+  describe('decrementDailyLimit', () => {
+    it('카운트를 1 감소시킨다', async () => {
+      await repo.checkAndIncrementDailyLimit(USER_ID, 5);
+      await repo.checkAndIncrementDailyLimit(USER_ID, 5);
+      await repo.decrementDailyLimit(USER_ID);
+      expect(readRow()?.generation_count).toBe(1);
+    });
+
+    it('0 미만으로 내려가지 않는다 (GREATEST(0, ...))', async () => {
+      await repo.checkAndIncrementDailyLimit(USER_ID, 5); // count=1
+      await repo.decrementDailyLimit(USER_ID); // count=0
+      await repo.decrementDailyLimit(USER_ID); // count=0 (floor)
+      expect(readRow()?.generation_count).toBe(0);
+    });
+
+    it('오늘 행이 없으면 아무 일도 일어나지 않는다 (no-op)', async () => {
+      await repo.decrementDailyLimit(USER_ID);
+      expect(readRow()).toBeUndefined();
+    });
+  });
+
+  describe('getCurrentUsage', () => {
+    it('행이 없으면 0을 반환한다', async () => {
+      expect(await repo.getCurrentUsage(USER_ID)).toBe(0);
+    });
+
+    it('현재 generation_count를 반환한다', async () => {
+      await repo.checkAndIncrementDailyLimit(USER_ID, 5);
+      await repo.checkAndIncrementDailyLimit(USER_ID, 5);
+      expect(await repo.getCurrentUsage(USER_ID)).toBe(2);
+    });
+
+    it('다른 사용자의 카운트와 격리된다', async () => {
+      const other = '22222222-2222-2222-2222-222222222222';
+      db.insert(schema.users).values({ id: other, email: 'other@example.com' }).run();
+      await repo.checkAndIncrementDailyLimit(USER_ID, 5);
+      expect(await repo.getCurrentUsage(other)).toBe(0);
+      expect(await repo.getCurrentUsage(USER_ID)).toBe(1);
+    });
+  });
+
+  describe('checkAndIncrementDailyDeployLimit', () => {
+    it('첫 호출 시 deploy_count를 1로 올리며 true를 반환한다', async () => {
+      const ok = await repo.checkAndIncrementDailyDeployLimit(USER_ID, 5);
+      expect(ok).toBe(true);
+      expect(readRow()?.deploy_count).toBe(1);
+    });
+
+    it('한도 도달 시 false를 반환하고 증가하지 않는다', async () => {
+      await repo.checkAndIncrementDailyDeployLimit(USER_ID, 1);
+      const blocked = await repo.checkAndIncrementDailyDeployLimit(USER_ID, 1);
+      expect(blocked).toBe(false);
+      expect(readRow()?.deploy_count).toBe(1);
+    });
+
+    it('generation_count에는 영향을 주지 않는다', async () => {
+      await repo.checkAndIncrementDailyDeployLimit(USER_ID, 5);
+      expect(readRow()?.generation_count).toBe(0);
+    });
+
+    it('generation과 deploy 카운터는 같은 행에서 독립적으로 증가한다', async () => {
+      await repo.checkAndIncrementDailyLimit(USER_ID, 5);
+      await repo.checkAndIncrementDailyDeployLimit(USER_ID, 5);
+      await repo.checkAndIncrementDailyDeployLimit(USER_ID, 5);
+      const row = readRow();
+      expect(row?.generation_count).toBe(1);
+      expect(row?.deploy_count).toBe(2);
+    });
+  });
+
+  describe('decrementDailyDeployLimit', () => {
+    it('deploy_count를 1 감소시킨다', async () => {
+      await repo.checkAndIncrementDailyDeployLimit(USER_ID, 5);
+      await repo.checkAndIncrementDailyDeployLimit(USER_ID, 5);
+      await repo.decrementDailyDeployLimit(USER_ID);
+      expect(readRow()?.deploy_count).toBe(1);
+    });
+
+    it('0 미만으로 내려가지 않는다', async () => {
+      await repo.checkAndIncrementDailyDeployLimit(USER_ID, 5); // 1
+      await repo.decrementDailyDeployLimit(USER_ID); // 0
+      await repo.decrementDailyDeployLimit(USER_ID); // 0 (floor)
+      expect(readRow()?.deploy_count).toBe(0);
+    });
+
+    it('오늘 행이 없으면 no-op', async () => {
+      await repo.decrementDailyDeployLimit(USER_ID);
+      expect(readRow()).toBeUndefined();
+    });
+  });
+
+  describe('원자성/시퀀스', () => {
+    it('한도를 정확히 한도 횟수만큼만 허용한다 (test-and-set)', async () => {
+      const limit = 4;
+      let allowed = 0;
+      for (let i = 0; i < 10; i += 1) {
+         
+        if (await repo.checkAndIncrementDailyLimit(USER_ID, limit)) allowed += 1;
+      }
+      expect(allowed).toBe(limit);
+      expect(readRow()?.generation_count).toBe(limit);
+    });
+  });
+});

--- a/src/repositories/sqlite/SqliteRateLimitRepository.ts
+++ b/src/repositories/sqlite/SqliteRateLimitRepository.ts
@@ -1,0 +1,133 @@
+import { and, eq, sql } from 'drizzle-orm';
+import type { SqliteDb } from '@/lib/db/sqlite/connection';
+import * as schema from '@/lib/db/sqlite/schema';
+import type { IRateLimitRepository } from '@/repositories/interfaces';
+
+/**
+ * SQLite 기반 레이트리밋 레포지토리 (임베디드 단일 인스턴스·단일 사용자 경로).
+ *
+ * Supabase/PG의 원자적 함수들(`try_increment_daily_generation`,
+ * `decrement_daily_generation`, `get_daily_generation_count`,
+ * `try_increment_daily_deploy`, `decrement_daily_deploy`)을 SQLite로 재현한다.
+ *
+ * 원자성: better-sqlite3는 동기 API이며 `db.transaction(fn)`은 `BEGIN`(IMMEDIATE에
+ * 준하는 단일 writer)로 감싼다. SQLite는 한 시점에 writer가 1개뿐이므로
+ * "INSERT OR IGNORE(오늘 행 보장) → UPDATE ... WHERE count < limit RETURNING"
+ * 시퀀스가 단일 트랜잭션 안에서 원자적으로 test-and-set 된다. 한도 초과 시
+ * UPDATE가 0행 → RETURNING 결과 없음 → false.
+ *
+ * usage_date는 PG의 CURRENT_DATE(서버 로컬 날짜)에 대응하는 로컬 YYYY-MM-DD 문자열.
+ */
+export class SqliteRateLimitRepository implements IRateLimitRepository {
+  constructor(private db: SqliteDb) {}
+
+  /** PG CURRENT_DATE 대응: 로컬 타임존 기준 오늘 날짜 YYYY-MM-DD. */
+  private today(): string {
+    const now = new Date();
+    const y = now.getFullYear();
+    const m = String(now.getMonth() + 1).padStart(2, '0');
+    const d = String(now.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
+  async checkAndIncrementDailyLimit(userId: string, limit: number): Promise<boolean> {
+    const usageDate = this.today();
+    return this.db.transaction((tx) => {
+      // 오늘 행 보장 (없으면 0으로 생성). 이미 있으면 무시.
+      tx.insert(schema.userDailyLimits)
+        .values({ user_id: userId, usage_date: usageDate, generation_count: 0 })
+        .onConflictDoNothing()
+        .run();
+
+      // 원자적 test-and-set: 한도 미만일 때만 +1
+      const rows = tx
+        .update(schema.userDailyLimits)
+        .set({ generation_count: sql`${schema.userDailyLimits.generation_count} + 1` })
+        .where(
+          and(
+            eq(schema.userDailyLimits.user_id, userId),
+            eq(schema.userDailyLimits.usage_date, usageDate),
+            sql`${schema.userDailyLimits.generation_count} < ${limit}`,
+          ),
+        )
+        .returning({ count: schema.userDailyLimits.generation_count })
+        .all();
+
+      // 0행이면 한도 도달 → false
+      return rows.length > 0;
+    });
+  }
+
+  async decrementDailyLimit(userId: string): Promise<void> {
+    const usageDate = this.today();
+    this.db
+      .update(schema.userDailyLimits)
+      .set({
+        // GREATEST(0, count - 1)
+        generation_count: sql`MAX(0, ${schema.userDailyLimits.generation_count} - 1)`,
+      })
+      .where(
+        and(
+          eq(schema.userDailyLimits.user_id, userId),
+          eq(schema.userDailyLimits.usage_date, usageDate),
+        ),
+      )
+      .run();
+  }
+
+  async getCurrentUsage(userId: string): Promise<number> {
+    const usageDate = this.today();
+    const row = this.db
+      .select({ count: schema.userDailyLimits.generation_count })
+      .from(schema.userDailyLimits)
+      .where(
+        and(
+          eq(schema.userDailyLimits.user_id, userId),
+          eq(schema.userDailyLimits.usage_date, usageDate),
+        ),
+      )
+      .get();
+    return row?.count ?? 0;
+  }
+
+  async checkAndIncrementDailyDeployLimit(userId: string, limit: number): Promise<boolean> {
+    const usageDate = this.today();
+    return this.db.transaction((tx) => {
+      tx.insert(schema.userDailyLimits)
+        .values({ user_id: userId, usage_date: usageDate, deploy_count: 0 })
+        .onConflictDoNothing()
+        .run();
+
+      const rows = tx
+        .update(schema.userDailyLimits)
+        .set({ deploy_count: sql`${schema.userDailyLimits.deploy_count} + 1` })
+        .where(
+          and(
+            eq(schema.userDailyLimits.user_id, userId),
+            eq(schema.userDailyLimits.usage_date, usageDate),
+            sql`${schema.userDailyLimits.deploy_count} < ${limit}`,
+          ),
+        )
+        .returning({ count: schema.userDailyLimits.deploy_count })
+        .all();
+
+      return rows.length > 0;
+    });
+  }
+
+  async decrementDailyDeployLimit(userId: string): Promise<void> {
+    const usageDate = this.today();
+    this.db
+      .update(schema.userDailyLimits)
+      .set({
+        deploy_count: sql`MAX(0, ${schema.userDailyLimits.deploy_count} - 1)`,
+      })
+      .where(
+        and(
+          eq(schema.userDailyLimits.user_id, userId),
+          eq(schema.userDailyLimits.usage_date, usageDate),
+        ),
+      )
+      .run();
+  }
+}

--- a/src/repositories/sqlite/SqliteUserApiKeyRepository.test.ts
+++ b/src/repositories/sqlite/SqliteUserApiKeyRepository.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createSqliteConnection, runSqliteMigrations } from '@/lib/db/sqlite/connection';
+import type { SqliteDb } from '@/lib/db/sqlite/connection';
+import * as schema from '@/lib/db/sqlite/schema';
+import { SqliteUserApiKeyRepository } from './SqliteUserApiKeyRepository';
+
+const USER_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_USER_ID = '22222222-2222-2222-2222-222222222222';
+const API_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const API_ID_2 = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+describe('SqliteUserApiKeyRepository', () => {
+  let db: SqliteDb;
+  let raw: Database.Database;
+  let repo: SqliteUserApiKeyRepository;
+
+  beforeEach(() => {
+    ({ db, raw } = createSqliteConnection(':memory:'));
+    runSqliteMigrations(db);
+
+    // FK 선행 행 시드: users(2) + api_catalog(2)
+    db.insert(schema.users)
+      .values([
+        { id: USER_ID, email: 'owner@example.com' },
+        { id: OTHER_USER_ID, email: 'other@example.com' },
+      ])
+      .run();
+    db.insert(schema.apiCatalog)
+      .values([
+        { id: API_ID, name: 'API One' },
+        { id: API_ID_2, name: 'API Two' },
+      ])
+      .run();
+
+    repo = new SqliteUserApiKeyRepository(db);
+  });
+
+  afterEach(() => {
+    raw.close();
+  });
+
+  describe('upsert', () => {
+    it('새 키를 삽입하고 도메인 shape를 반환한다', async () => {
+      const result = await repo.upsert(USER_ID, API_ID, 'enc-key-1');
+
+      expect(result.id).toBeTruthy();
+      expect(result.userId).toBe(USER_ID);
+      expect(result.apiId).toBe(API_ID);
+      expect(result.encryptedKey).toBe('enc-key-1');
+      expect(result.isVerified).toBe(false);
+      expect(result.verifiedAt).toBeNull();
+      expect(typeof result.createdAt).toBe('string');
+      expect(typeof result.updatedAt).toBe('string');
+      // ISO 문자열인지 확인
+      expect(Number.isNaN(Date.parse(result.createdAt))).toBe(false);
+    });
+
+    it('동일 (user_id, api_id)에 대해 encrypted_key를 갱신한다 (중복 행 미생성)', async () => {
+      const first = await repo.upsert(USER_ID, API_ID, 'enc-key-1');
+      const second = await repo.upsert(USER_ID, API_ID, 'enc-key-2');
+
+      // 같은 행이 갱신됨 (동일 PK)
+      expect(second.id).toBe(first.id);
+      expect(second.encryptedKey).toBe('enc-key-2');
+
+      const all = await repo.findAllByUser(USER_ID);
+      expect(all).toHaveLength(1);
+      expect(all[0].encryptedKey).toBe('enc-key-2');
+    });
+
+    it('서로 다른 (user, api) 조합은 별도 행으로 저장한다', async () => {
+      await repo.upsert(USER_ID, API_ID, 'k1');
+      await repo.upsert(USER_ID, API_ID_2, 'k2');
+      await repo.upsert(OTHER_USER_ID, API_ID, 'k3');
+
+      expect(await repo.findAllByUser(USER_ID)).toHaveLength(2);
+      expect(await repo.findAllByUser(OTHER_USER_ID)).toHaveLength(1);
+    });
+  });
+
+  describe('findByUserAndApi', () => {
+    it('존재하는 키를 반환한다', async () => {
+      await repo.upsert(USER_ID, API_ID, 'enc-key-1');
+
+      const found = await repo.findByUserAndApi(USER_ID, API_ID);
+      expect(found).not.toBeNull();
+      expect(found?.encryptedKey).toBe('enc-key-1');
+      expect(found?.userId).toBe(USER_ID);
+      expect(found?.apiId).toBe(API_ID);
+    });
+
+    it('존재하지 않으면 null을 반환한다', async () => {
+      const found = await repo.findByUserAndApi(USER_ID, API_ID);
+      expect(found).toBeNull();
+    });
+
+    it('다른 사용자의 키는 조회하지 않는다 (소유권 필터)', async () => {
+      await repo.upsert(OTHER_USER_ID, API_ID, 'k3');
+
+      const found = await repo.findByUserAndApi(USER_ID, API_ID);
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('findAllByUser', () => {
+    it('사용자의 모든 키를 반환한다', async () => {
+      await repo.upsert(USER_ID, API_ID, 'k1');
+      await repo.upsert(USER_ID, API_ID_2, 'k2');
+
+      const all = await repo.findAllByUser(USER_ID);
+      expect(all).toHaveLength(2);
+      const apiIds = all.map((k) => k.apiId).sort();
+      expect(apiIds).toEqual([API_ID, API_ID_2].sort());
+    });
+
+    it('키가 없으면 빈 배열을 반환한다', async () => {
+      const all = await repo.findAllByUser(USER_ID);
+      expect(all).toEqual([]);
+    });
+
+    it('다른 사용자의 키는 포함하지 않는다', async () => {
+      await repo.upsert(USER_ID, API_ID, 'k1');
+      await repo.upsert(OTHER_USER_ID, API_ID_2, 'k2');
+
+      const all = await repo.findAllByUser(USER_ID);
+      expect(all).toHaveLength(1);
+      expect(all[0].apiId).toBe(API_ID);
+    });
+  });
+
+  describe('updateVerificationStatus', () => {
+    it('isVerified=true 설정 시 verified_at을 채운다', async () => {
+      await repo.upsert(USER_ID, API_ID, 'k1');
+
+      await repo.updateVerificationStatus(USER_ID, API_ID, true);
+
+      const found = await repo.findByUserAndApi(USER_ID, API_ID);
+      expect(found?.isVerified).toBe(true);
+      expect(found?.verifiedAt).not.toBeNull();
+      expect(Number.isNaN(Date.parse(found!.verifiedAt as string))).toBe(false);
+    });
+
+    it('isVerified=false 설정 시 verified_at을 null로 비운다', async () => {
+      await repo.upsert(USER_ID, API_ID, 'k1');
+      await repo.updateVerificationStatus(USER_ID, API_ID, true);
+
+      await repo.updateVerificationStatus(USER_ID, API_ID, false);
+
+      const found = await repo.findByUserAndApi(USER_ID, API_ID);
+      expect(found?.isVerified).toBe(false);
+      expect(found?.verifiedAt).toBeNull();
+    });
+
+    it('존재하지 않는 (user, api)에 대해 에러 없이 no-op 처리한다', async () => {
+      await expect(
+        repo.updateVerificationStatus(USER_ID, API_ID, true),
+      ).resolves.toBeUndefined();
+      expect(await repo.findByUserAndApi(USER_ID, API_ID)).toBeNull();
+    });
+  });
+
+  describe('delete', () => {
+    it('존재하는 키를 삭제한다', async () => {
+      await repo.upsert(USER_ID, API_ID, 'k1');
+
+      await repo.delete(USER_ID, API_ID);
+
+      expect(await repo.findByUserAndApi(USER_ID, API_ID)).toBeNull();
+      expect(await repo.findAllByUser(USER_ID)).toEqual([]);
+    });
+
+    it('해당 (user, api)만 삭제하고 다른 행은 보존한다', async () => {
+      await repo.upsert(USER_ID, API_ID, 'k1');
+      await repo.upsert(USER_ID, API_ID_2, 'k2');
+
+      await repo.delete(USER_ID, API_ID);
+
+      const all = await repo.findAllByUser(USER_ID);
+      expect(all).toHaveLength(1);
+      expect(all[0].apiId).toBe(API_ID_2);
+    });
+
+    it('존재하지 않는 키 삭제는 에러 없이 처리한다', async () => {
+      await expect(repo.delete(USER_ID, API_ID)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/repositories/sqlite/SqliteUserApiKeyRepository.ts
+++ b/src/repositories/sqlite/SqliteUserApiKeyRepository.ts
@@ -1,0 +1,95 @@
+import { eq, and, sql } from 'drizzle-orm';
+import type { SqliteDb } from '@/lib/db/sqlite/connection';
+import * as schema from '@/lib/db/sqlite/schema';
+import type { IUserApiKeyRepository, UserApiKey } from '@/repositories/interfaces';
+
+/**
+ * SQLite 구현 (임베디드 단일 인스턴스·단일 사용자 경로).
+ *
+ * 매핑 기준은 Supabase 레포(`supabaseUserApiKeyRepository.ts`)와 동일하다:
+ * - 타임스탬프(created_at/updated_at/verified_at)는 SQLite에 ISO 문자열로 저장되며,
+ *   도메인은 `string`(verified_at은 `string | null`)을 기대하므로 그대로 반환한다.
+ * - is_verified는 drizzle(mode:boolean)가 true/false로 역직렬화해 돌려주므로 그대로 사용한다.
+ * - encrypted_key는 상위 계층에서 암호화된 값을 그대로 저장/반환한다.
+ */
+export class SqliteUserApiKeyRepository implements IUserApiKeyRepository {
+  constructor(private db: SqliteDb) {}
+
+  async upsert(userId: string, apiId: string, encryptedKey: string): Promise<UserApiKey> {
+    const [row] = this.db
+      .insert(schema.userApiKeys)
+      .values({
+        user_id: userId,
+        api_id: apiId,
+        encrypted_key: encryptedKey,
+      })
+      .onConflictDoUpdate({
+        target: [schema.userApiKeys.user_id, schema.userApiKeys.api_id],
+        set: {
+          encrypted_key: sql`excluded.encrypted_key`,
+          updated_at: new Date().toISOString(),
+        },
+      })
+      .returning()
+      .all();
+
+    return this.toDomain(row);
+  }
+
+  async delete(userId: string, apiId: string): Promise<void> {
+    this.db
+      .delete(schema.userApiKeys)
+      .where(and(eq(schema.userApiKeys.user_id, userId), eq(schema.userApiKeys.api_id, apiId)))
+      .run();
+  }
+
+  async findByUserAndApi(userId: string, apiId: string): Promise<UserApiKey | null> {
+    const row = this.db
+      .select()
+      .from(schema.userApiKeys)
+      .where(and(eq(schema.userApiKeys.user_id, userId), eq(schema.userApiKeys.api_id, apiId)))
+      .limit(1)
+      .get();
+
+    return row ? this.toDomain(row) : null;
+  }
+
+  async findAllByUser(userId: string): Promise<UserApiKey[]> {
+    const rows = this.db
+      .select()
+      .from(schema.userApiKeys)
+      .where(eq(schema.userApiKeys.user_id, userId))
+      .all();
+
+    return rows.map((row) => this.toDomain(row));
+  }
+
+  async updateVerificationStatus(
+    userId: string,
+    apiId: string,
+    isVerified: boolean,
+  ): Promise<void> {
+    this.db
+      .update(schema.userApiKeys)
+      .set({
+        is_verified: isVerified,
+        verified_at: isVerified ? new Date().toISOString() : null,
+        updated_at: new Date().toISOString(),
+      })
+      .where(and(eq(schema.userApiKeys.user_id, userId), eq(schema.userApiKeys.api_id, apiId)))
+      .run();
+  }
+
+  private toDomain(row: typeof schema.userApiKeys.$inferSelect): UserApiKey {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      apiId: row.api_id,
+      encryptedKey: row.encrypted_key,
+      isVerified: row.is_verified ?? false,
+      verifiedAt: row.verified_at ?? null,
+      createdAt: row.created_at as string,
+      updatedAt: row.updated_at as string,
+    };
+  }
+}

--- a/src/repositories/sqlite/SqliteUserRepository.test.ts
+++ b/src/repositories/sqlite/SqliteUserRepository.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createSqliteConnection, runSqliteMigrations, type SqliteDb } from '@/lib/db/sqlite/connection';
+import { SqliteUserRepository } from './SqliteUserRepository';
+import type { User } from '@/types/user';
+
+/**
+ * SqliteUserRepository 단위 테스트 — :memory: DB로 격리.
+ * 각 테스트마다 새 연결 + 마이그레이션 적용, afterEach에서 raw.close().
+ */
+describe('SqliteUserRepository', () => {
+  let db: SqliteDb;
+  let raw: Database.Database;
+  let repo: SqliteUserRepository;
+
+  beforeEach(() => {
+    const conn = createSqliteConnection(':memory:');
+    db = conn.db;
+    raw = conn.raw;
+    runSqliteMigrations(db);
+    repo = new SqliteUserRepository(db);
+  });
+
+  afterEach(() => {
+    raw.close();
+  });
+
+  const baseInput: Omit<User, 'id' | 'createdAt' | 'updatedAt'> = {
+    email: 'admin@example.com',
+    name: 'Admin',
+    avatarUrl: 'https://example.com/a.png',
+    preferences: { language: 'ko', theme: 'dark' },
+  };
+
+  describe('create', () => {
+    it('새 유저를 생성하고 도메인 shape으로 반환한다', () => {
+      return repo.create(baseInput).then((user) => {
+        expect(user.id).toBeTruthy();
+        expect(user.email).toBe('admin@example.com');
+        expect(user.name).toBe('Admin');
+        expect(user.avatarUrl).toBe('https://example.com/a.png');
+        expect(user.preferences).toEqual({ language: 'ko', theme: 'dark' });
+        // 타임스탬프는 ISO 문자열로 채워진다
+        expect(typeof user.createdAt).toBe('string');
+        expect(typeof user.updatedAt).toBe('string');
+        expect(() => new Date(user.createdAt).toISOString()).not.toThrow();
+      });
+    });
+
+    it('nullable 필드(name/avatarUrl 없음)와 빈 preferences를 처리한다', async () => {
+      const user = await repo.create({
+        email: 'minimal@example.com',
+        name: null,
+        avatarUrl: null,
+        preferences: {},
+      });
+      expect(user.name).toBeNull();
+      expect(user.avatarUrl).toBeNull();
+      expect(user.preferences).toEqual({});
+    });
+
+    it('preferences가 null로 저장돼도 도메인에서는 {}로 폴백한다', async () => {
+      // drizzle은 json 컬럼이 비어 있으면 null을 돌려주므로 매퍼 폴백을 검증
+      const raw2 = raw;
+      raw2
+        .prepare(
+          'INSERT INTO users (id, email, preferences, created_at, updated_at) VALUES (?, ?, NULL, ?, ?)',
+        )
+        .run('fixed-id-1', 'nullpref@example.com', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z');
+
+      const user = await repo.findById('fixed-id-1');
+      expect(user).not.toBeNull();
+      expect(user?.preferences).toEqual({});
+      expect(user?.name).toBeNull();
+      expect(user?.avatarUrl).toBeNull();
+    });
+  });
+
+  describe('createWithAuthId', () => {
+    it('지정한 authId를 PK로 사용해 생성한다', async () => {
+      const user = await repo.createWithAuthId('auth-uuid-123', baseInput);
+      expect(user.id).toBe('auth-uuid-123');
+      expect(user.email).toBe('admin@example.com');
+
+      const fetched = await repo.findById('auth-uuid-123');
+      expect(fetched?.id).toBe('auth-uuid-123');
+    });
+  });
+
+  describe('findById', () => {
+    it('존재하는 유저를 반환한다', async () => {
+      const created = await repo.create(baseInput);
+      const found = await repo.findById(created.id);
+      expect(found).not.toBeNull();
+      expect(found?.id).toBe(created.id);
+      expect(found?.email).toBe('admin@example.com');
+    });
+
+    it('없는 id면 null을 반환한다', async () => {
+      const found = await repo.findById('does-not-exist');
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('findByEmail', () => {
+    it('이메일로 유저를 조회한다', async () => {
+      await repo.create(baseInput);
+      const found = await repo.findByEmail('admin@example.com');
+      expect(found).not.toBeNull();
+      expect(found?.email).toBe('admin@example.com');
+    });
+
+    it('없는 이메일이면 null을 반환한다', async () => {
+      const found = await repo.findByEmail('missing@example.com');
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('update', () => {
+    it('필드를 갱신하고 updated_at을 새로 채운다', async () => {
+      const created = await repo.create(baseInput);
+
+      const updated = await repo.update(created.id, {
+        name: 'New Name',
+        avatarUrl: 'https://example.com/b.png',
+        preferences: { language: 'en', emailNotifications: true },
+      });
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.name).toBe('New Name');
+      expect(updated.avatarUrl).toBe('https://example.com/b.png');
+      expect(updated.preferences).toEqual({ language: 'en', emailNotifications: true });
+      expect(updated.email).toBe('admin@example.com'); // 변경 안 한 필드 보존
+
+      const refetched = await repo.findById(created.id);
+      expect(refetched?.name).toBe('New Name');
+    });
+
+    it('email만 부분 갱신할 수 있다', async () => {
+      const created = await repo.create(baseInput);
+      const updated = await repo.update(created.id, { email: 'changed@example.com' });
+      expect(updated.email).toBe('changed@example.com');
+      expect(updated.name).toBe('Admin');
+    });
+  });
+
+  describe('delete', () => {
+    it('유저를 삭제한다', async () => {
+      const created = await repo.create(baseInput);
+      await repo.delete(created.id);
+      const found = await repo.findById(created.id);
+      expect(found).toBeNull();
+    });
+
+    it('없는 id 삭제는 에러 없이 통과한다', async () => {
+      await expect(repo.delete('nope')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('findMany', () => {
+    beforeEach(async () => {
+      // 3명 생성 (created_at 순서를 분리하기 위해 명시적 ISO 주입은 raw 사용)
+      raw
+        .prepare('INSERT INTO users (id, email, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)')
+        .run('u1', 'a@example.com', 'Alpha', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z');
+      raw
+        .prepare('INSERT INTO users (id, email, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)')
+        .run('u2', 'b@example.com', 'Bravo', '2026-01-02T00:00:00.000Z', '2026-01-02T00:00:00.000Z');
+      raw
+        .prepare('INSERT INTO users (id, email, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)')
+        .run('u3', 'c@example.com', 'Charlie', '2026-01-03T00:00:00.000Z', '2026-01-03T00:00:00.000Z');
+    });
+
+    it('전체를 created_at desc(기본)로 반환하고 total을 채운다', async () => {
+      const { items, total } = await repo.findMany();
+      expect(total).toBe(3);
+      expect(items).toHaveLength(3);
+      // 기본 desc → 가장 최신(u3)이 먼저
+      expect(items[0].id).toBe('u3');
+      expect(items[2].id).toBe('u1');
+    });
+
+    it('orderDirection asc로 정렬한다', async () => {
+      const { items } = await repo.findMany(undefined, { orderDirection: 'asc' });
+      expect(items[0].id).toBe('u1');
+      expect(items[2].id).toBe('u3');
+    });
+
+    it('페이지네이션(limit/page)을 적용한다', async () => {
+      const page1 = await repo.findMany(undefined, { page: 1, limit: 2 });
+      expect(page1.items).toHaveLength(2);
+      expect(page1.total).toBe(3);
+
+      const page2 = await repo.findMany(undefined, { page: 2, limit: 2 });
+      expect(page2.items).toHaveLength(1);
+      expect(page2.total).toBe(3);
+    });
+
+    it('filter(email)로 좁힌다', async () => {
+      const { items, total } = await repo.findMany({ email: 'b@example.com' });
+      expect(total).toBe(1);
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('u2');
+    });
+
+    it('매칭이 없으면 빈 배열과 total 0을 반환한다', async () => {
+      const { items, total } = await repo.findMany({ email: 'none@example.com' });
+      expect(items).toEqual([]);
+      expect(total).toBe(0);
+    });
+  });
+
+  describe('count', () => {
+    beforeEach(async () => {
+      await repo.create({ email: 'x@example.com', name: null, avatarUrl: null, preferences: {} });
+      await repo.create({ email: 'y@example.com', name: null, avatarUrl: null, preferences: {} });
+    });
+
+    it('필터 없이 전체 수를 센다', async () => {
+      expect(await repo.count()).toBe(2);
+    });
+
+    it('filter에 맞는 수를 센다', async () => {
+      expect(await repo.count({ email: 'x@example.com' })).toBe(1);
+      expect(await repo.count({ email: 'nope@example.com' })).toBe(0);
+    });
+
+    it('빈 테이블이면 0을 반환한다', async () => {
+      const conn = createSqliteConnection(':memory:');
+      runSqliteMigrations(conn.db);
+      const emptyRepo = new SqliteUserRepository(conn.db);
+      expect(await emptyRepo.count()).toBe(0);
+      conn.raw.close();
+    });
+  });
+});

--- a/src/repositories/sqlite/SqliteUserRepository.ts
+++ b/src/repositories/sqlite/SqliteUserRepository.ts
@@ -1,0 +1,147 @@
+import { eq, desc, sql } from 'drizzle-orm';
+import type { SqliteDb } from '@/lib/db/sqlite/connection';
+import * as schema from '@/lib/db/sqlite/schema';
+import type { User, UserPreferences } from '@/types/user';
+import type { IUserRepository } from '@/repositories/interfaces';
+import type { QueryOptions } from '@/repositories/interfaces/IBaseRepository';
+import { toDatabaseRow, normalizePagination, buildConditions } from '@/repositories/utils';
+
+/**
+ * SQLite 구현 (임베디드 단일 인스턴스·단일 사용자 경로).
+ *
+ * 매핑 기준은 Supabase 레포(`userRepository.ts`)와 동일하다:
+ * - created_at/updated_at는 SQLite에 ISO8601 문자열로 저장되며, 도메인 `User`가
+ *   `string`(ISO)을 기대하므로 그대로 반환한다 (Drizzle pg 레포는 `String(...)`로 강제하지만
+ *   SQLite는 이미 string이라 의미상 동일).
+ * - preferences는 drizzle(mode:json)가 객체로 역직렬화해 돌려주므로 그대로 사용한다
+ *   (JSON.parse 불필요). null이면 `{}`로 폴백한다 (Supabase 레포 동작 보존).
+ * - name/avatar_url은 nullable이며 `?? null`로 정규화한다.
+ *
+ * 단일 사용자/셀프호스트라 RLS 대신 인자로 받은 id/email로 직접 필터한다.
+ * 모든 쿼리는 better-sqlite3 동기 API(.all()/.get()/.run()/.returning())를 사용한다.
+ */
+export class SqliteUserRepository implements IUserRepository {
+  constructor(private readonly db: SqliteDb) {}
+
+  async findById(id: string): Promise<User | null> {
+    const row = this.db
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, id))
+      .limit(1)
+      .get();
+
+    return row ? this.toDomain(row) : null;
+  }
+
+  async findMany(
+    filter?: Record<string, unknown>,
+    options: QueryOptions = {},
+  ): Promise<{ items: User[]; total: number }> {
+    const { orderDirection = 'desc' } = options;
+    const { offset, limit } = normalizePagination(options);
+
+    const conditions = buildConditions(filter);
+
+    const countRow = this.db
+      .select({ total: sql<number>`count(*)` })
+      .from(schema.users)
+      .where(conditions)
+      .get();
+
+    const rows = this.db
+      .select()
+      .from(schema.users)
+      .where(conditions)
+      .orderBy(orderDirection === 'asc' ? schema.users.created_at : desc(schema.users.created_at))
+      .limit(limit)
+      .offset(offset)
+      .all();
+
+    return {
+      items: rows.map((row) => this.toDomain(row)),
+      total: countRow?.total ?? 0,
+    };
+  }
+
+  async create(input: Omit<User, 'id' | 'createdAt' | 'updatedAt'>): Promise<User> {
+    const dbData = toDatabaseRow(input);
+
+    const [row] = this.db
+      .insert(schema.users)
+      .values(dbData as typeof schema.users.$inferInsert)
+      .returning()
+      .all();
+
+    return this.toDomain(row);
+  }
+
+  async update(id: string, input: Partial<User>): Promise<User> {
+    const dbData = toDatabaseRow(input);
+
+    const [row] = this.db
+      .update(schema.users)
+      .set({ ...dbData, updated_at: new Date().toISOString() } as Partial<
+        typeof schema.users.$inferInsert
+      >)
+      .where(eq(schema.users.id, id))
+      .returning()
+      .all();
+
+    return this.toDomain(row);
+  }
+
+  async delete(id: string): Promise<void> {
+    this.db.delete(schema.users).where(eq(schema.users.id, id)).run();
+  }
+
+  async count(filter?: Record<string, unknown>): Promise<number> {
+    const conditions = buildConditions(filter);
+
+    const countRow = this.db
+      .select({ total: sql<number>`count(*)` })
+      .from(schema.users)
+      .where(conditions)
+      .get();
+
+    return countRow?.total ?? 0;
+  }
+
+  async createWithAuthId(
+    authId: string,
+    input: Omit<User, 'id' | 'createdAt' | 'updatedAt'>,
+  ): Promise<User> {
+    const dbData = toDatabaseRow(input);
+
+    const [row] = this.db
+      .insert(schema.users)
+      .values({ ...dbData, id: authId } as typeof schema.users.$inferInsert)
+      .returning()
+      .all();
+
+    return this.toDomain(row);
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    const row = this.db
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.email, email))
+      .limit(1)
+      .get();
+
+    return row ? this.toDomain(row) : null;
+  }
+
+  private toDomain(row: typeof schema.users.$inferSelect): User {
+    return {
+      id: row.id,
+      email: row.email,
+      name: row.name ?? null,
+      avatarUrl: row.avatar_url ?? null,
+      preferences: (row.preferences as UserPreferences) ?? {},
+      createdAt: row.created_at as string,
+      updatedAt: row.updated_at as string,
+    };
+  }
+}

--- a/src/repositories/sqlite/index.ts
+++ b/src/repositories/sqlite/index.ts
@@ -1,0 +1,7 @@
+export { SqliteProjectRepository } from './SqliteProjectRepository';
+export { SqliteUserRepository } from './SqliteUserRepository';
+export { SqliteCodeRepository } from './SqliteCodeRepository';
+export { SqliteCatalogRepository } from './SqliteCatalogRepository';
+export { SqliteEventRepository } from './SqliteEventRepository';
+export { SqliteRateLimitRepository } from './SqliteRateLimitRepository';
+export { SqliteUserApiKeyRepository } from './SqliteUserApiKeyRepository';


### PR DESCRIPTION
## 개요
관리형 DB(Supabase) 의존을 제거하고 **임베디드 SQLite(Railway 볼륨) + Auth.js Credentials 단일 관리자(JWT)** 로 전환하는 마이그레이션. **셀프호스트·단일 사용자** 모델.

## ⚠️ 머지 안전성 (중요)
**머지해도 프로덕션 동작은 변하지 않습니다.** 모든 sqlite/local 경로는 `DB_PROVIDER`/`AUTH_PROVIDER` env에 의한 **opt-in**이며, 기본값은 기존 `supabase`입니다. 실제 전환은 머지 후 **Railway env 스위치 + 볼륨 + 재배포**로 일어납니다(컷오버 런북 참조).

## 포함 (Phase 1~7, 14 커밋)
- **P1** SQLite 데이터 계층(스키마 9테이블·WAL·레포 7종·원자적 레이트리밋·factory 배선)
- **P2** `AUTH_PROVIDER=local` (Credentials 단일 관리자 + JWT, edge-safe 분할 설정, 미들웨어 게이팅, NextAuth 라우트, 로그인 폼, 관리자 시드·부팅 부트스트랩)
- **P3** 직접-DB/service-role 정리(provider 가드 + factory 레포 경유, qc-stats용 집계 메서드 3구현체)
- **P5** 카탈로그(49)·플래그(7) 부팅 시드(번들 JSON)
- **P6** Dockerfile sqlite 빌드(better-sqlite3 네이티브·`/data` 볼륨·drizzle 복사) + next.config external
- **P7** 인증·라우트 테스트 정리

## 검증
- 단위 2130 통과 · type-check · lint clean
- 인증 dev 스모크 7/7 · 서빙 6/6 · 카탈로그 시드 5/5
- **Docker build + run**: 컨테이너(sqlite/local, supabase env 0) 부팅→마이그레이션→시드→서빙→게이팅
- 프로덕션 supabase 경로 회귀 없음

## 컷오버 (머지 후, 별도)
[docs/guides/sqlite-cutover-runbook.md](docs/guides/sqlite-cutover-runbook.md) — Railway 볼륨·env·빌드인자·검증·롤백. P8.2(supabase 코드 제거)·P8.3(문서)는 컷오버 안정화 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)