### PR TITLE
fix(auth): 이메일 링크 base URL 수정 (Railway 0.0.0.0:8080 문제)

### DIFF
--- a/src/app/api/v1/auth/forgot-password/route.ts
+++ b/src/app/api/v1/auth/forgot-password/route.ts
@@ -1,6 +1,6 @@
 import { createAuthService } from '@/services/factory';
 import { forgotPasswordSchema } from '@/types/schemas';
-import { parseJsonBody, enforceRateLimit } from '@/lib/auth/routeHelpers';
+import { parseJsonBody, enforceRateLimit, getBaseUrl } from '@/lib/auth/routeHelpers';
 import { handleApiError, jsonResponse } from '@/lib/utils/errors';
 
 export async function POST(request: Request): Promise<Response> {
@@ -8,7 +8,7 @@ export async function POST(request: Request): Promise<Response> {
     enforceRateLimit(request, 'forgot', 5, 60 * 60 * 1000);
     const data = await parseJsonBody(request, forgotPasswordSchema, '이메일 형식이 올바르지 않습니다.');
 
-    const baseUrl = new URL(request.url).origin;
+    const baseUrl = getBaseUrl(request);
     await createAuthService().requestPasswordReset(data.email, baseUrl);
 
     // enumeration 방지: 존재 여부와 무관하게 동일 응답

--- a/src/app/api/v1/auth/resend-verification/route.ts
+++ b/src/app/api/v1/auth/resend-verification/route.ts
@@ -1,6 +1,6 @@
 import { getAuthUser } from '@/lib/auth/index';
 import { createAuthService } from '@/services/factory';
-import { enforceRateLimit } from '@/lib/auth/routeHelpers';
+import { enforceRateLimit, getBaseUrl } from '@/lib/auth/routeHelpers';
 import { AuthRequiredError, handleApiError, jsonResponse } from '@/lib/utils/errors';
 
 export async function POST(request: Request): Promise<Response> {
@@ -10,7 +10,7 @@ export async function POST(request: Request): Promise<Response> {
 
     enforceRateLimit(request, `resend:${user.id}`, 3, 60 * 60 * 1000);
 
-    const baseUrl = new URL(request.url).origin;
+    const baseUrl = getBaseUrl(request);
     await createAuthService().resendVerification(user.id, baseUrl);
     return jsonResponse({ success: true, data: { message: '인증 메일을 다시 보냈습니다.' } });
   } catch (error) {

--- a/src/app/api/v1/auth/signup/route.ts
+++ b/src/app/api/v1/auth/signup/route.ts
@@ -1,6 +1,6 @@
 import { createAuthService } from '@/services/factory';
 import { signupSchema } from '@/types/schemas';
-import { parseJsonBody, enforceRateLimit } from '@/lib/auth/routeHelpers';
+import { parseJsonBody, enforceRateLimit, getBaseUrl } from '@/lib/auth/routeHelpers';
 import { handleApiError, jsonResponse } from '@/lib/utils/errors';
 
 export async function POST(request: Request): Promise<Response> {
@@ -8,7 +8,7 @@ export async function POST(request: Request): Promise<Response> {
     enforceRateLimit(request, 'signup', 5, 60 * 60 * 1000);
     const data = await parseJsonBody(request, signupSchema);
 
-    const baseUrl = new URL(request.url).origin;
+    const baseUrl = getBaseUrl(request);
     await createAuthService().signup(data.email, data.password, baseUrl);
 
     return jsonResponse(

--- a/src/lib/auth/routeHelpers.test.ts
+++ b/src/lib/auth/routeHelpers.test.ts
@@ -85,37 +85,43 @@ describe('enforceRateLimit', () => {
 });
 
 describe('getBaseUrl', () => {
-  const originalAppUrl = process.env.APP_URL;
+  const origAppUrl = process.env.APP_URL;
+  const origRoot = process.env.NEXT_PUBLIC_ROOT_DOMAIN;
   afterEach(() => {
-    if (originalAppUrl === undefined) delete process.env.APP_URL;
-    else process.env.APP_URL = originalAppUrl;
+    if (origAppUrl === undefined) delete process.env.APP_URL;
+    else process.env.APP_URL = origAppUrl;
+    if (origRoot === undefined) delete process.env.NEXT_PUBLIC_ROOT_DOMAIN;
+    else process.env.NEXT_PUBLIC_ROOT_DOMAIN = origRoot;
   });
 
-  function reqWith(headers: Record<string, string>): Request {
-    // 내부 바인드 주소를 흉내내 — 프록시 헤더가 우선되는지 검증
-    return new Request('http://0.0.0.0:8080/api/v1/auth/forgot-password', { method: 'POST', headers });
+  // 내부 바인드 주소 + 위조된 호스트 헤더를 함께 흉내 — 헤더가 무시되는지 검증
+  function hostileReq(): Request {
+    return new Request('http://0.0.0.0:8080/api/v1/auth/forgot-password', {
+      method: 'POST',
+      headers: {
+        'x-forwarded-host': 'attacker.example.com',
+        host: 'attacker.example.com',
+        'x-forwarded-proto': 'http',
+      },
+    });
   }
 
-  it('APP_URL 환경변수가 있으면 우선하고 후행 슬래시를 제거한다', () => {
+  it('APP_URL이 있으면 우선하고 후행 슬래시를 제거한다 (위조 host 무시)', () => {
     process.env.APP_URL = 'https://xzawed.xyz/';
-    expect(getBaseUrl(reqWith({ 'x-forwarded-host': 'evil.example.com' }))).toBe('https://xzawed.xyz');
+    expect(getBaseUrl(hostileReq())).toBe('https://xzawed.xyz');
   });
 
-  it('APP_URL이 없으면 x-forwarded-host/proto로 공개 origin을 만든다 (내부 0.0.0.0 아님)', () => {
+  it('APP_URL이 없으면 NEXT_PUBLIC_ROOT_DOMAIN을 쓰고 위조 host 헤더를 무시한다 (host-header 인젝션 방지)', () => {
     delete process.env.APP_URL;
-    const url = getBaseUrl(reqWith({ 'x-forwarded-host': 'xzawed.xyz', 'x-forwarded-proto': 'https' }));
-    expect(url).toBe('https://xzawed.xyz');
+    process.env.NEXT_PUBLIC_ROOT_DOMAIN = 'xzawed.xyz';
+    expect(getBaseUrl(hostileReq())).toBe('https://xzawed.xyz');
   });
 
-  it('x-forwarded-proto 미설정 시 https를 기본 사용한다', () => {
+  it('신뢰 가능한 설정이 모두 없을 때만 요청 origin으로 폴백한다 (로컬/개발)', () => {
     delete process.env.APP_URL;
-    expect(getBaseUrl(reqWith({ 'x-forwarded-host': 'xzawed.xyz' }))).toBe('https://xzawed.xyz');
-  });
-
-  it('포워드 헤더가 없으면 요청 origin으로 폴백한다', () => {
-    delete process.env.APP_URL;
-    expect(getBaseUrl(new Request('https://fallback.example.com/api', { method: 'POST' }))).toBe(
-      'https://fallback.example.com',
+    delete process.env.NEXT_PUBLIC_ROOT_DOMAIN;
+    expect(getBaseUrl(new Request('https://localhost:3000/api', { method: 'POST' }))).toBe(
+      'https://localhost:3000',
     );
   });
 });

--- a/src/lib/auth/routeHelpers.test.ts
+++ b/src/lib/auth/routeHelpers.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { z } from 'zod/v4';
-import { parseJsonBody, enforceRateLimit } from './routeHelpers';
+import { parseJsonBody, enforceRateLimit, getBaseUrl } from './routeHelpers';
 import { ValidationError, RateLimitError } from '@/lib/utils/errors';
 
 const testSchema = z.object({ name: z.string(), age: z.number() });
@@ -81,5 +81,41 @@ describe('enforceRateLimit', () => {
     expect(() => enforceRateLimit(req1, uniquePrefix, 2, 60 * 1000)).not.toThrow();
     expect(() => enforceRateLimit(req2, uniquePrefix, 2, 60 * 1000)).not.toThrow();
     expect(() => enforceRateLimit(req3, uniquePrefix, 2, 60 * 1000)).toThrow(RateLimitError);
+  });
+});
+
+describe('getBaseUrl', () => {
+  const originalAppUrl = process.env.APP_URL;
+  afterEach(() => {
+    if (originalAppUrl === undefined) delete process.env.APP_URL;
+    else process.env.APP_URL = originalAppUrl;
+  });
+
+  function reqWith(headers: Record<string, string>): Request {
+    // 내부 바인드 주소를 흉내내 — 프록시 헤더가 우선되는지 검증
+    return new Request('http://0.0.0.0:8080/api/v1/auth/forgot-password', { method: 'POST', headers });
+  }
+
+  it('APP_URL 환경변수가 있으면 우선하고 후행 슬래시를 제거한다', () => {
+    process.env.APP_URL = 'https://xzawed.xyz/';
+    expect(getBaseUrl(reqWith({ 'x-forwarded-host': 'evil.example.com' }))).toBe('https://xzawed.xyz');
+  });
+
+  it('APP_URL이 없으면 x-forwarded-host/proto로 공개 origin을 만든다 (내부 0.0.0.0 아님)', () => {
+    delete process.env.APP_URL;
+    const url = getBaseUrl(reqWith({ 'x-forwarded-host': 'xzawed.xyz', 'x-forwarded-proto': 'https' }));
+    expect(url).toBe('https://xzawed.xyz');
+  });
+
+  it('x-forwarded-proto 미설정 시 https를 기본 사용한다', () => {
+    delete process.env.APP_URL;
+    expect(getBaseUrl(reqWith({ 'x-forwarded-host': 'xzawed.xyz' }))).toBe('https://xzawed.xyz');
+  });
+
+  it('포워드 헤더가 없으면 요청 origin으로 폴백한다', () => {
+    delete process.env.APP_URL;
+    expect(getBaseUrl(new Request('https://fallback.example.com/api', { method: 'POST' }))).toBe(
+      'https://fallback.example.com',
+    );
   });
 });

--- a/src/lib/auth/routeHelpers.ts
+++ b/src/lib/auth/routeHelpers.ts
@@ -37,3 +37,26 @@ export function enforceRateLimit(
     throw new RateLimitError();
   }
 }
+
+/**
+ * 이메일 링크(인증·비밀번호 재설정)에 쓸 공개 base URL을 도출한다.
+ *
+ * 프록시(Railway 등) 뒤에서는 `new URL(request.url).origin`이 내부 바인드 주소
+ * (예: `http://0.0.0.0:8080`)로 잡혀 메일 링크가 깨진다. 우선순위:
+ *  1) `APP_URL` 환경변수 — 가장 신뢰(호스트 헤더 인젝션과 무관). 프로덕션 권장.
+ *  2) `x-forwarded-host` (+ `x-forwarded-proto`) — 프록시가 설정한 공개 호스트.
+ *  3) 마지막 폴백으로 요청 origin.
+ * 후행 슬래시는 제거한다(호출부가 `${baseUrl}/verify-email` 식으로 이어 붙임).
+ */
+export function getBaseUrl(request: Request): string {
+  const envUrl = process.env.APP_URL;
+  if (envUrl) return envUrl.replace(/\/+$/, '');
+
+  const host = request.headers.get('x-forwarded-host') ?? request.headers.get('host');
+  if (host) {
+    const proto = request.headers.get('x-forwarded-proto') ?? 'https';
+    return `${proto}://${host}`;
+  }
+
+  return new URL(request.url).origin;
+}

--- a/src/lib/auth/routeHelpers.ts
+++ b/src/lib/auth/routeHelpers.ts
@@ -41,22 +41,25 @@ export function enforceRateLimit(
 /**
  * 이메일 링크(인증·비밀번호 재설정)에 쓸 공개 base URL을 도출한다.
  *
- * 프록시(Railway 등) 뒤에서는 `new URL(request.url).origin`이 내부 바인드 주소
- * (예: `http://0.0.0.0:8080`)로 잡혀 메일 링크가 깨진다. 우선순위:
- *  1) `APP_URL` 환경변수 — 가장 신뢰(호스트 헤더 인젝션과 무관). 프로덕션 권장.
- *  2) `x-forwarded-host` (+ `x-forwarded-proto`) — 프록시가 설정한 공개 호스트.
- *  3) 마지막 폴백으로 요청 origin.
+ * 보안: 비밀번호 재설정 같은 보안 링크를 **클라이언트가 위조 가능한 호스트 헤더**
+ * (`x-forwarded-host`/`host`)에서 만들면 host-header 인젝션(피해자에게 공격자 도메인
+ * 링크를 보내 토큰 탈취 → password reset poisoning)에 노출된다. 따라서 헤더를 신뢰하지
+ * 않고 **서버 설정에서만** 도출한다. 우선순위:
+ *  1) `APP_URL` 환경변수 (가장 명시적)
+ *  2) `NEXT_PUBLIC_ROOT_DOMAIN` (apex 도메인, https 가정)
+ *  3) 로컬/개발 폴백으로 요청 origin (프로덕션에선 위 둘 중 하나가 반드시 설정됨)
  * 후행 슬래시는 제거한다(호출부가 `${baseUrl}/verify-email` 식으로 이어 붙임).
+ *
+ * 참고: 프록시(Railway) 뒤에서 `new URL(request.url).origin`은 내부 바인드 주소
+ * (예: `http://0.0.0.0:8080`)로 잡히므로 프로덕션 폴백으로 쓰면 안 된다 —
+ * 그래서 신뢰 가능한 `APP_URL`/`NEXT_PUBLIC_ROOT_DOMAIN`을 먼저 사용한다.
  */
 export function getBaseUrl(request: Request): string {
-  const envUrl = process.env.APP_URL;
-  if (envUrl) return envUrl.replace(/\/+$/, '');
+  const appUrl = process.env.APP_URL;
+  if (appUrl) return appUrl.replace(/\/+$/, '');
 
-  const host = request.headers.get('x-forwarded-host') ?? request.headers.get('host');
-  if (host) {
-    const proto = request.headers.get('x-forwarded-proto') ?? 'https';
-    return `${proto}://${host}`;
-  }
+  const rootDomain = process.env.NEXT_PUBLIC_ROOT_DOMAIN;
+  if (rootDomain) return `https://${rootDomain.replace(/\/+$/, '')}`;
 
   return new URL(request.url).origin;
 }

--- a/src/lib/auth/routeHelpers.ts
+++ b/src/lib/auth/routeHelpers.ts
@@ -48,7 +48,8 @@ export function enforceRateLimit(
  *  1) `APP_URL` 환경변수 (가장 명시적)
  *  2) `NEXT_PUBLIC_ROOT_DOMAIN` (apex 도메인, https 가정)
  *  3) 로컬/개발 폴백으로 요청 origin (프로덕션에선 위 둘 중 하나가 반드시 설정됨)
- * 후행 슬래시는 제거한다(호출부가 `${baseUrl}/verify-email` 식으로 이어 붙임).
+ * `URL.origin`을 사용하므로 경로·후행 슬래시는 자동 정규화된다(호출부가
+ * `${baseUrl}/verify-email` 식으로 이어 붙임).
  *
  * 참고: 프록시(Railway) 뒤에서 `new URL(request.url).origin`은 내부 바인드 주소
  * (예: `http://0.0.0.0:8080`)로 잡히므로 프로덕션 폴백으로 쓰면 안 된다 —
@@ -56,10 +57,10 @@ export function enforceRateLimit(
  */
 export function getBaseUrl(request: Request): string {
   const appUrl = process.env.APP_URL;
-  if (appUrl) return appUrl.replace(/\/+$/, '');
+  if (appUrl) return new URL(appUrl).origin;
 
   const rootDomain = process.env.NEXT_PUBLIC_ROOT_DOMAIN;
-  if (rootDomain) return `https://${rootDomain.replace(/\/+$/, '')}`;
+  if (rootDomain) return new URL(`https://${rootDomain}`).origin;
 
   return new URL(request.url).origin;
 }


### PR DESCRIPTION
## 문제
배포(Railway) 환경에서 비밀번호 재설정/이메일 인증 메일의 링크가 `https://0.0.0.0:8080/...`(컨테이너 내부 바인드 주소)로 생성되어 클릭 시 `ERR_ADDRESS_INVALID`. 원인: 인증 라우트가 `new URL(request.url).origin`으로 base URL을 도출 — 프록시 뒤에서는 내부 주소로 잡힘.

## 수정
`src/lib/auth/routeHelpers.ts`에 `getBaseUrl(request)` 추가. **클라이언트가 위조 가능한 호스트 헤더를 신뢰하지 않고**, 신뢰 가능한 서버 설정에서만 도출:
1. `APP_URL` 환경변수
2. `NEXT_PUBLIC_ROOT_DOMAIN` (apex 도메인, https 가정)
3. 요청 origin (로컬/개발 폴백 — 프로덕션에선 위 둘 중 하나가 설정됨)

`signup`·`forgot-password`·`resend-verification` 라우트에 적용.

## 보안 (코드 리뷰 반영)
초기 구현은 `x-forwarded-host`를 폴백으로 신뢰했는데, 이는 **password reset poisoning**(공격자가 위조 `X-Forwarded-Host`로 forgot-password 호출 → 피해자 메일 링크가 공격자 도메인 → 토큰 탈취)에 노출됨. 백그라운드 보안 리뷰 지적에 따라 **호스트 헤더 신뢰를 전면 제거**하고 서버 설정만 사용하도록 변경. 위조 host 헤더를 무시하는지 검증하는 테스트 포함.

배포 측: `APP_URL=https://xzawed.xyz` 설정 완료(`NEXT_PUBLIC_ROOT_DOMAIN=xzawed.xyz`도 존재 — 이중 안전망).

## 검증
routeHelpers + auth 라우트 테스트 19개 통과 · type-check clean · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)