### PR TITLE
docs: APP_URL 환경변수 문서화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,8 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 - `AUTH_TRUST_HOST=true` — 커스텀 도메인/프록시 뒤 필수 (없으면 `/api/auth/*` 500)
 - `NEXT_PUBLIC_AUTH_PROVIDER=local` — 클라이언트 빌드타임 상수
 - `RESEND_API_KEY` — 이메일 발송 Resend API 키 (미설정 시 콘솔 no-op 폴백 — 이메일 실제 미발송)
-- `EMAIL_FROM` — 발신자 주소 (예: `noreply@xzawed.xyz`, `RESEND_API_KEY` 설정 시 필수)
+- `EMAIL_FROM` — 발신자 주소 (예: `noreply@xzawed.xyz`, `RESEND_API_KEY` 설정 시 필수. 빈 문자열 금지 — 발송 실패)
+- `APP_URL` — 이메일 링크(인증·재설정)의 공개 base URL (예: `https://xzawed.xyz`). 미설정 시 `NEXT_PUBLIC_ROOT_DOMAIN`→요청 origin 폴백. 프록시 뒤 0.0.0.0 링크 방지 + 호스트 헤더 미신뢰(reset poisoning 차단). 로직: `getBaseUrl`(`src/lib/auth/routeHelpers.ts`)
 - `SQLITE_PATH` — SQLite 파일 경로 (기본 `/data/app.db`, Railway Volume 마운트 필수)
 - `NEXT_PUBLIC_ROOT_DOMAIN` (서브도메인 가상 호스팅)
 - `ANTHROPIC_API_KEY`

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -29,7 +29,8 @@ DB 어댑터 없는 JWT 무상태 세션. 공개 셀프서비스 회원가입, D
 | `AUTH_TRUST_HOST` | ✅ (프록시 뒤) | ✅ `true` | 리버스 프록시(Railway) 뒤에서 호스트 헤더 신뢰. `true` 설정 |
 | `NEXT_PUBLIC_AUTH_PROVIDER` | ✅ | ✅ `local` | 클라이언트 컴포넌트용 빌드 타임 상수. 값은 `local` 고정 |
 | `RESEND_API_KEY` | 선택 | ➖ | Resend 이메일 API 키. 미설정 시 no-op 콘솔 폴백(이메일 인증 링크가 실제로 발송되지 않음 — 로컬/테스트 환경 전용) |
-| `EMAIL_FROM` | 선택 | ➖ | 이메일 발신자 주소 (예: `noreply@xzawed.xyz`). `RESEND_API_KEY` 설정 시 필수. 도메인 SPF/DKIM 설정 필요(Resend 대시보드) |
+| `EMAIL_FROM` | 선택 | ➖ | 이메일 발신자 주소 (예: `noreply@xzawed.xyz`). `RESEND_API_KEY` 설정 시 필수. 도메인 SPF/DKIM 설정 필요(Resend 대시보드). ⚠️ 빈 문자열이면 `?? 기본값` 폴백이 안 됨(null/undefined만 폴백) → 발송 실패하므로 반드시 값 지정. 도메인 미인증 시 `onboarding@resend.dev`는 Resend 가입 계정 이메일로만 발송 |
+| `APP_URL` | 권장 | ✅ `https://xzawed.xyz` | 이메일 링크(인증·비밀번호 재설정)의 공개 base URL. 미설정 시 `NEXT_PUBLIC_ROOT_DOMAIN` → 요청 origin 순으로 폴백. 프록시(Railway) 뒤에서 링크가 내부 주소(`0.0.0.0:8080`)로 잡히는 문제 방지 + 요청 호스트 헤더를 신뢰하지 않아 reset-password poisoning 차단 (`getBaseUrl`, `src/lib/auth/routeHelpers.ts`) |
 
 > **제거된 변수 (2026-06-24)**: `ADMIN_EMAIL`, `ADMIN_PASSWORD_HASH`, `ADMIN_NAME`, `ADMIN_USER_ID` — env 단일 관리자 경로 완전 제거. 계정은 `/signup` 공개 회원가입으로 생성.
 > **유지**: `ADMIN_API_KEY`(진단 엔드포인트 `/api/v1/admin/*` 보호 — 사용자 인증과 무관, 아래 보안 섹션 참조).


### PR DESCRIPTION
#167에서 추가된 `APP_URL`(이메일 링크 base URL · host-header poisoning 방지)을 `docs/reference/env-vars.md`와 `CLAUDE.md` 환경변수 섹션에 기재. `EMAIL_FROM` 빈 문자열 시 발송 실패하는 함정도 명시. 문서 전용 변경(코드/동작 무변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)