### PR TITLE
feat(db): SQLite 자동 백업 (P6.3) — 인프로세스 주기 .backup 덤프 + 보관 정책

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ src/
 │   ├── catalog/     # API 카탈로그 — healthCheck.ts(DB기반 라이브 검증 분류), keyCheck.ts(플랫폼 키 검증), activeApiCount.ts(활성 개수 동적 카운트 — 랜딩/카탈로그 마케팅 카피, 하드코딩 금지)
 │   ├── constants/   # 공용 상수 — cdn.ts (CSP CDN 화이트리스트, buildSiteCsp)
 │   ├── countries/   # 자체 호스팅 국가 데이터 API 로직 — transform(mledoze 변환), query(region/search 필터·코드 조회), types
-│   ├── db/          # 임베디드 SQLite — sqlite/(connection WAL/FK, schema 10테이블, migrator, bootstrap, seedCatalog, ensureCatalog), errors(UNIQUE 위반 감지)
+│   ├── db/          # 임베디드 SQLite — sqlite/(connection WAL/FK, schema 10테이블, migrator, bootstrap, seedCatalog, ensureCatalog, backup 주기 .backup 덤프+보관정책), errors(UNIQUE 위반 감지)
 │   ├── email/       # 이메일 발송 — emailService(sendVerificationEmail/sendPasswordResetEmail), Resend provider, no-op console fallback(RESEND_API_KEY 미설정 시)
 │   ├── deploy/      # 배포 관련
 │   ├── events/      # EventBus (pub/sub) + eventPersister (전체 이벤트 자동 DB 기록)
@@ -127,6 +127,7 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 - `EMAIL_FROM` — 발신자 주소 (예: `noreply@xzawed.xyz`, `RESEND_API_KEY` 설정 시 필수. 빈 문자열 금지 — 발송 실패)
 - `APP_URL` — 이메일 링크(인증·재설정)의 공개 base URL (예: `https://xzawed.xyz`). 미설정 시 `NEXT_PUBLIC_ROOT_DOMAIN`→요청 origin 폴백. 프록시 뒤 0.0.0.0 링크 방지 + 호스트 헤더 미신뢰(reset poisoning 차단). 로직: `getBaseUrl`(`src/lib/auth/routeHelpers.ts`)
 - `SQLITE_PATH` — SQLite 파일 경로 (기본 `/data/app.db`, Railway Volume 마운트 필수)
+- `SQLITE_BACKUP_ENABLED`/`SQLITE_BACKUP_INTERVAL_MS`/`SQLITE_BACKUP_RETENTION`/`SQLITE_BACKUP_DIR` — 자동 SQLite 백업(P6.3). 부팅 시 `scheduleBackups`가 주기 `.backup` 덤프를 `<SQLITE 디렉터리>/backups/`에 남기고 최근 N개만 보관. 기본: enabled=true·24h·7개·`/data/backups`. 로직: `src/lib/db/sqlite/backup.ts` (상세: [env-vars.md](docs/reference/env-vars.md))
 - `NEXT_PUBLIC_ROOT_DOMAIN` (서브도메인 가상 호스팅)
 - `ANTHROPIC_API_KEY`
 - `ADMIN_API_KEY` — 관리자 API 인증 (QC 통계, 수동 QC 트리거)
@@ -261,6 +262,7 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 - **SonarCloud vs Codecov 지표 불일치**: Codecov/Vitest는 `vitest.config.ts`의 `coverage.include` 범위(`src/lib/**`, `src/services/**`, `src/providers/**`, `src/repositories/**`, `src/components/**`)를 측정. SonarCloud는 전체 TypeScript를 더 넓게 측정할 수 있어 두 숫자는 구조적으로 차이가 날 수 있으며, 단순 설정 오류로 단정하지 않는다.
 - **temperature deprecated (Claude 4.x)**: Claude 4.x 모델(`claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-opus-4-7`)은 `temperature` 파라미터를 지원하지 않음. ClaudeProvider에서 완전히 제거됨 (Extended Thinking 포함). `IAiPrompt.temperature` 필드는 legacy 호환용으로 유지하나 실제 API 호출에 사용하지 않음
 - **인메모리 rate limit 한계**: proxy의 Map 기반 리밋은 서버 재시작 시 초기화됨 (분당 카운터라 보안 영향 낮음). Railway 단일 인스턴스 전제 — 멀티 인스턴스 전환 시 Redis 등 외부 저장소 필요 (generationTracker와 동일 제약)
+- **SQLite 자동 백업 (P6.3, 인프로세스)**: `src/lib/db/sqlite/backup.ts`의 `scheduleBackups`가 `instrumentation.register()`에서 배선되어 주기적으로 `raw.backup()` 온라인 덤프를 `<SQLITE 디렉터리>/backups/app-YYYYMMDD-HHmmss.db`로 남기고 보관 정책(`SQLITE_BACKUP_RETENTION`, 기본 7)에 따라 오래된 파일을 정리한다. 타이머는 `.unref()`되어 종료를 막지 않고, `':memory:'`/비활성(`SQLITE_BACKUP_ENABLED=false`) 시 건너뛴다. **단일 인스턴스·동일 볼륨 전제** — 논리 손상·잘못된 마이그레이션·실수 삭제 방어용이며, 볼륨 자체 손실 대비(오프-볼륨 DR)는 Railway 볼륨 스냅샷 또는 Litestream→S3(옵션·비용) 담당. `selectBackupsToPrune`은 `app-<timestamp>.db` 패턴만 후보로 삼아 라이브 DB·WAL/SHM은 절대 삭제하지 않음
 - **배포/생성 레이트리밋 환불 (SQLite)**: 배포·생성 실패 시 `SqliteRateLimitRepository`가 일일 카운터를 in-process로 환불한다(`GREATEST(count-1, 0)`, 동기 트랜잭션). 과거 Supabase PG 함수(`decrement_daily_deploy`/`decrement_daily_generation`, migration 007/021)와 동일 보상 의미를 SQLite 레포 메서드로 재현 — `.rpc()` 호출 없음
 - **생성 상태 폴링 `not_found` 처리**: `/api/v1/generate/status`는 프로젝트 미존재·권한 없음 시 `status: 'not_found'`를 반환한다. `pollGenerationStatus`의 `GenerationStatusData.status` union에 `'not_found'`가 포함되어야 하며(누락 시 'unknown'으로 오처리되어 잘못된 사용자 메시지 표시), 전용 핸들러로 "프로젝트를 찾을 수 없습니다" 메시지를 낸다
 - **레이트리밋 우회 로깅**: `RATE_LIMIT_BYPASS_USER_IDS` 우회 적용 시 `logger.info('Rate limit bypass applied', ...)` 감사 로그를 남긴다(무로깅 우회는 운영 사각지대)

--- a/docs/guides/sqlite-cutover-runbook.md
+++ b/docs/guides/sqlite-cutover-runbook.md
@@ -85,10 +85,15 @@ pnpm cutover:migrate --out ./app.db [--user <보존할_Supabase_user_id>]
 - 문서 전면 갱신(P8.3): `CLAUDE.md`(기술스택 표 Supabase→SQLite·아키텍처), `README`, `docs/reference/env-vars.md`.
 - 컷오버 ADR 작성(`docs/decisions/`).
 
-## 5. 운영 — 백업 (P6.3, 권장)
+## 5. 운영 — 백업 (P6.3, ✅ 구현됨 2026-06-25)
 
-- 자체보관 기본: Railway 볼륨 스냅샷 + 주기 SQLite `.backup` 덤프(컨테이너 내 크론 또는 사이드카).
-- (옵션) Litestream으로 WAL→S3 연속 복제(~1s 손실창, S3 의존).
+- **자동 인프로세스 백업**: 부팅 시 `instrumentation.register() → scheduleBackups`(`src/lib/db/sqlite/backup.ts`)가
+  주기적으로 `raw.backup()` 온라인 덤프를 `<SQLITE 디렉터리>/backups/app-YYYYMMDD-HHmmss.db`로 남기고,
+  `SQLITE_BACKUP_RETENTION`(기본 7)개만 보관(오래된 파일 자동 정리). 외부 의존·비용 없음.
+  - 환경변수: `SQLITE_BACKUP_ENABLED`(기본 true)·`SQLITE_BACKUP_INTERVAL_MS`(기본 24h)·`SQLITE_BACKUP_RETENTION`(기본 7)·`SQLITE_BACKUP_DIR`(기본 `/data/backups`). 상세: [env-vars.md](../reference/env-vars.md).
+  - **방어 범위**: 논리 손상·잘못된 마이그레이션·실수 삭제. **볼륨 자체 손실**은 Railway 볼륨 스냅샷이 담당.
+  - 복구: `cp /data/backups/app-<ts>.db /data/app.db`(서비스 중지 후) 또는 디버그 컨테이너에서 교체.
+- (옵션·향후) Litestream으로 WAL→S3 연속 복제(~1s 손실창, S3 의존·비용)로 오프-볼륨 DR 강화.
 - 크리티컬 쓰기 내구성은 이미 `synchronous=NORMAL` + 원자적 카운터(`BEGIN IMMEDIATE` 직렬화)로 확보.
 
 ## 6. 프로덕션 클린 리셋 (다중 사용자 전환 초기화)

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -16,6 +16,17 @@
 |------|--------|---------|------|
 | `SQLITE_PATH` | `/data/app.db` | ➖ | SQLite DB 파일 경로. Railway 영속 볼륨 마운트 경로(`/data`)에 위치. 로컬 개발 시 별도 경로로 오버라이드 가능 |
 
+### 자동 백업 (P6.3)
+
+부팅 시 `instrumentation.ts → scheduleBackups`가 컨테이너 내에서 주기적으로 SQLite `.backup()` 온라인 덤프를 `<SQLITE 디렉터리>/backups/app-YYYYMMDD-HHmmss.db`로 남기고 보관 정책에 따라 오래된 파일을 정리한다. 외부 의존·비용 없음(단일 인스턴스·Railway 볼륨 전제). 로직: `src/lib/db/sqlite/backup.ts`. **논리 손상·잘못된 마이그레이션·실수 삭제 방어용**이며, 볼륨 자체 손실 대비는 Railway 볼륨 스냅샷이 담당(오프-볼륨 DR은 Litestream→S3 옵션, 비용 발생).
+
+| 변수 | 기본값 | Railway | 설명 |
+|------|--------|---------|------|
+| `SQLITE_BACKUP_ENABLED` | `true` | ➖ | `false`로 설정 시 자동 백업 비활성화 |
+| `SQLITE_BACKUP_INTERVAL_MS` | `86400000` (24h) | ➖ | 백업 주기(ms). 잘못된 값은 기본값으로 폴백 |
+| `SQLITE_BACKUP_RETENTION` | `7` | ➖ | 보관할 백업 개수(가장 최근 N개 유지, 나머지 삭제). 1 미만/비정수는 기본값으로 폴백 |
+| `SQLITE_BACKUP_DIR` | `<SQLITE_PATH 디렉터리>/backups` | ➖ | 백업 파일 디렉터리. 미설정 시 DB 파일과 같은 볼륨 하위 `backups/` |
+
 ---
 
 ## Auth (로컬 — Auth.js v5 Credentials)

--- a/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
+++ b/docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md
@@ -1,7 +1,7 @@
 # DB 제거 → 임베디드 SQLite 전환 (단일 사용자·셀프호스트) — WBS 계획
 
 - 날짜: 2026-06-22 (착수 2026-06-23, 완료 2026-06-23)
-- 상태: **✅ 완료 (2026-06-23 컷오버·배포 완료, 프로덕션 라이브)** — Phase 1~8 반영. 코드성 이연 2건: P5.2(verification cron 컨테이너 내부화) · P6.3(SQLite 백업 자동화). 진행 현황은 §0 참조.
+- 상태: **✅ 완료 (2026-06-23 컷오버·배포 완료, 프로덕션 라이브)** — Phase 1~8 반영. P6.3(SQLite 백업 자동화)는 2026-06-25 인프로세스 구현 완료. **코드성 이연 1건만 잔존**: P5.2(verification cron 컨테이너 내부화). 진행 현황은 §0 참조.
 - 근거: 정합성 감사(7차원 persistence surface) + 딥리서치(SQLite/Railway/Auth.js, 출처 포함) + 사용자 범위 결정 3건
 - 관련: [Supabase 사용 요소](../../../CLAUDE.md), provider 추상화([src/lib/config/providers.ts](../../../src/lib/config/providers.ts))
 
@@ -16,7 +16,7 @@
 | **Phase 3 — 직접-DB/RPC 정리** | ✅ 완료 (callback·repo `.rpc`는 Phase 8 이연) | `a9688f2`, `4b7b75a`, `768da35`, `7cddeef` |
 | **Phase 4 — 서빙/런타임 검증** | ✅ 완료 — P4.1 서빙 검증 + P4.3 외부 배포 통합은 컷오버 후 프로덕션 라이브로 검증됨 | (검증, 코드 무변경) |
 | **Phase 5 — 설정·번들 데이터 시드** | 🔵 P5.1·P5.3 완료, P5.2 이연 | `1ff1834` |
-| **Phase 6 — 인프라/배포** | ✅ P6.1·P6.2·P6.4 완료(docker 검증·supabase env 0 부팅은 P8.2로 충족), P6.3 이연(백업 자동화) | `c5adbdf` |
+| **Phase 6 — 인프라/배포** | ✅ P6.1~P6.4 완료(docker 검증·supabase env 0 부팅은 P8.2로 충족, P6.3 자동 백업은 2026-06-25 인프로세스 구현) | `c5adbdf` |
 | **Phase 7 — 테스트 정리** | 🔵 P7.2·P7.3 완료, P7.1·P7.4는 Phase 8 동반 | `c343ab0` |
 | **Phase 8 — 컷오버 + 정리** | ✅ **완료 (2026-06-23)** — 컷오버 + P8.2(supabase/pg/authjs 코드·의존 제거) + P8.3(문서) | `#162`·`#163`·`#164` → `28acede`+`4c528f3d`, 이후 P8.2/P8.3 |
 
@@ -40,7 +40,7 @@
   - **검증(docker build + run)**: 이미지 빌드 성공 → 컨테이너(`DB_PROVIDER=sqlite`+`AUTH_PROVIDER=local`, **supabase env 0개**) 부팅 → 부트스트랩이 볼륨에 마이그레이션+시드(`catalog=49·active=23·flags=7·users=1`) → `/api/v1/health` 200·`/dashboard` 307→`/login`·`/site/nope` 404·`/api/v1/catalog` 시드 서빙·부팅 에러 0. **P6.2 "supabase env 0 부팅" AC 충족**.
   - ⚠️ **테스트 함정**(코드 무관): Git Bash(MSYS)가 `docker run -e SQLITE_PATH=/data/app.db`의 `/data/...`를 `C:/Program Files/Git/...`로 변환 → "directory does not exist". `MSYS_NO_PATHCONV=1`로 우회(SQLITE_PATH 미지정 시 코드 기본값 `/data/app.db`는 문자열 리터럴이라 무영향).
   - **컷오버 빌드/런타임**: 빌드 `--build-arg NEXT_PUBLIC_AUTH_PROVIDER=local`(+기존 supabase args 불필요 시 빈 값), 런타임 env `DB_PROVIDER=sqlite`·`AUTH_PROVIDER=local`·`AUTH_SECRET`·`ADMIN_EMAIL`·`ADMIN_PASSWORD_HASH`. **Railway Volume을 `/data`에 마운트 필수**.
-  - **P6.2 잔여**: `@supabase/*` 의존 제거는 Phase 8(supabase 경로 제거와 함께). **P6.3 이연**(옵션 백업 크론) + P5.2 verification cron 컨테이너 내부화.
+  - **P6.2 잔여**: `@supabase/*` 의존 제거는 Phase 8(supabase 경로 제거와 함께)에서 완료. **P6.3 완료(2026-06-25)**: 인프로세스 주기 `.backup` 덤프 + 보관 정책(`src/lib/db/sqlite/backup.ts`, instrumentation 배선). 남은 이연은 P5.2 verification cron 컨테이너 내부화뿐.
 - **완료(Phase 7 — 테스트 정리, 컷오버 전 가능 범위)**: P7.2(인증·미들웨어 테스트)는 Phase 2에서 완료. P7.3 라우트 테스트 모킹 일관화 — Phase 3에서 getDbProvider를 추가한 라우트(test-generation·qc-stats·trigger-qc) 테스트(`admin-test-generation`·`admin`)에 `@/lib/config/providers` 모킹 추가(native pg cold-init 차단). **P7.1**(supabase/Drizzle 레포 테스트 → `:memory:` 단순화)·**P7.4**(factory/connection/failover 테스트 정리)는 **Phase 8에서 supabase/postgres 레포를 제거할 때 동반**(현재 supabase 레포는 프로덕션 경로라 테스트를 선제거하면 안 됨).
 - **🚦 현재 위치 = 컷오버 게이트**: Phase 1~6 + 검증(P4.1)·테스트 정리(P7.2/P7.3)까지 **프로덕션 무영향으로 완료**. sqlite/local 스택이 docker로 빌드·실행·검증됨. **Phase 8(컷오버)부터는 프로덕션 supabase 경로를 제거**하므로 "무영향" 불변식을 깨는 비가역 변경 — **사용자 승인 + Railway 볼륨 준비 후** 진행한다.
 - **컷오버 준비물 작성 완료(프로덕션 무변경)**: ① **단계별 런북** [docs/guides/sqlite-cutover-runbook.md](../../guides/sqlite-cutover-runbook.md)(볼륨·env·빌드인자·스위치·검증·롤백·P8.2 제거·백업). ② **데이터 이관 스크립트**(P8.1, 선택) `scripts/migrateSupabaseToSqlite.ts`(`pnpm cutover:migrate --out ./app.db [--user <id>]`) — self-contained(마이그레이션+카탈로그/플래그/관리자 시드+사용자 데이터 복사, user_id→단일 관리자 리맵). 산출 app.db를 볼륨 `/data`로 업로드. 둘 다 작성·type-check 통과, 실행은 사용자 컷오버 시점.
@@ -134,12 +134,12 @@
 | P5.2 | `verification_status` cron `--write` 경로를 SQLite write로 전환 | P5.1,P1.4 | S | cron이 SQLite 갱신 |
 | P5.3 | `feature_flags`(7) → SQLite 시드 또는 config 파일 | P1.2 | S | 플래그 읽기 동작 |
 
-### Phase 6 — 인프라/배포 (규모 M) — 🔵 P6.1·P6.4 완료(docker build+run 검증), P6.2 일부·P6.3 이연
+### Phase 6 — 인프라/배포 (규모 M) — ✅ P6.1~P6.4 완료 (P6.3 자동 백업 2026-06-25 구현)
 | ID | 작업 | 선행 | 규모 | AC |
 |---|---|---|---|---|
 | P6.1 | Dockerfile: `better-sqlite3` 네이티브 빌드(빌드 의존), 볼륨 경로, 부팅 시 마이그레이션 실행 | P1.2 | M | 컨테이너 부팅→마이그레이션→서비스 정상 |
 | P6.2 | 환경변수 정리(Supabase 제거), `DB_PROVIDER=sqlite`·`AUTH_PROVIDER` 단일화, supabase-js 의존 제거 | P3.3,P2.2 | S | Supabase env 0건에서 부팅 |
-| P6.3 | (옵션) Litestream 사이드카(S3 허용 시) 또는 주기 `.backup` 크론(자체보관) | P0.4 | M | 백업 산출물 생성·복구 리허설 |
+| P6.3 | ✅ 인프로세스 주기 `.backup` 덤프 + 보관 정책(`src/lib/db/sqlite/backup.ts`, instrumentation 배선, 2026-06-25). Litestream→S3는 향후 옵션 | P0.4 | M | 백업 산출물 생성·정리 단위 검증(22 테스트). 복구 리허설은 운영 시 |
 | P6.4 | `pnpm test:prod` standalone 헬스체크 + 배포 검증 | P6.1,P6.2 | S | 헬스 200, 핵심 플로우 동작 |
 
 ### Phase 7 — 테스트 재작성 (규모 L) — 🔵 P7.2·P7.3 완료, P7.1·P7.4는 Phase 8 동반(레포 제거 시)

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -9,9 +9,19 @@ export async function register() {
 
     // SQLite 영속성 부팅 부트스트랩: 마이그레이션 적용 + 단일 관리자 시드 + 카탈로그/플래그 시드(모두 멱등).
     // 임베디드 SQLite가 유일한 DB 백엔드이므로 무조건 실행한다.
-    const { getSqliteDb } = await import('./lib/db/sqlite/connection');
+    const { getSqliteDb, getSqliteRawConnection, getSqlitePath } = await import(
+      './lib/db/sqlite/connection'
+    );
     const { bootstrapSqlite } = await import('./lib/db/sqlite/bootstrap');
     bootstrapSqlite(getSqliteDb());
+
+    // 주기 SQLite 백업(P6.3): 컨테이너 내 `.backup` 덤프 + 보관 정책. 외부 의존·비용 없음.
+    // 단일 인스턴스(Railway 볼륨) 전제. ':memory:'(테스트/특수 환경)에서는 건너뛴다.
+    const { getBackupConfig, scheduleBackups } = await import('./lib/db/sqlite/backup');
+    const backupConfig = getBackupConfig();
+    if (backupConfig.enabled && getSqlitePath() !== ':memory:') {
+      scheduleBackups(getSqliteRawConnection(), backupConfig);
+    }
   }
 
   if (process.env.NEXT_RUNTIME === 'edge') {

--- a/src/lib/db/sqlite/backup.test.ts
+++ b/src/lib/db/sqlite/backup.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  formatBackupTimestamp,
+  selectBackupsToPrune,
+  getBackupConfig,
+  runBackup,
+  scheduleBackups,
+  BACKUP_FILE_REGEX,
+} from './backup';
+
+describe('formatBackupTimestamp', () => {
+  it('formats a Date as app-YYYYMMDD-HHmmss in UTC', () => {
+    const d = new Date(Date.UTC(2026, 5, 25, 14, 5, 9)); // 2026-06-25 14:05:09 UTC
+    expect(formatBackupTimestamp(d)).toBe('20260625-140509');
+  });
+
+  it('zero-pads month, day, hour, minute, second', () => {
+    const d = new Date(Date.UTC(2026, 0, 1, 0, 0, 0)); // 2026-01-01 00:00:00 UTC
+    expect(formatBackupTimestamp(d)).toBe('20260101-000000');
+  });
+
+  it('produces a string matched by the backup file regex when wrapped', () => {
+    const d = new Date(Date.UTC(2026, 11, 31, 23, 59, 59));
+    expect(`app-${formatBackupTimestamp(d)}.db`).toMatch(BACKUP_FILE_REGEX);
+  });
+});
+
+describe('selectBackupsToPrune', () => {
+  const mk = (ts: string): string => `app-${ts}.db`;
+
+  it('returns the oldest files beyond the retention count', () => {
+    const files = [
+      mk('20260625-100000'),
+      mk('20260625-110000'),
+      mk('20260625-120000'),
+      mk('20260625-130000'),
+    ];
+    // retention 2 → keep 2 newest (12:00, 13:00), prune 2 oldest
+    expect(selectBackupsToPrune(files, 2)).toEqual([
+      mk('20260625-100000'),
+      mk('20260625-110000'),
+    ]);
+  });
+
+  it('returns [] when file count is within retention', () => {
+    const files = [mk('20260625-100000'), mk('20260625-110000')];
+    expect(selectBackupsToPrune(files, 7)).toEqual([]);
+  });
+
+  it('ignores files that do not match the backup pattern (never prunes the live DB or WAL)', () => {
+    const files = [
+      'app.db',
+      'app.db-wal',
+      'app.db-shm',
+      'notes.txt',
+      mk('20260625-100000'),
+      mk('20260625-110000'),
+    ];
+    // only the 2 real backups are candidates; retention 1 → prune the oldest backup only
+    expect(selectBackupsToPrune(files, 1)).toEqual([mk('20260625-100000')]);
+  });
+
+  it('is order-independent (sorts by timestamp regardless of input order)', () => {
+    const files = [mk('20260625-130000'), mk('20260625-100000'), mk('20260625-120000')];
+    expect(selectBackupsToPrune(files, 1)).toEqual([
+      mk('20260625-100000'),
+      mk('20260625-120000'),
+    ]);
+  });
+});
+
+describe('getBackupConfig', () => {
+  it('uses safe defaults when no env vars are set', () => {
+    const cfg = getBackupConfig({}, '/data/app.db');
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.intervalMs).toBe(86_400_000);
+    expect(cfg.retention).toBe(7);
+    expect(cfg.dir).toBe(join('/data', 'backups'));
+  });
+
+  it('disables only when SQLITE_BACKUP_ENABLED is exactly "false"', () => {
+    expect(getBackupConfig({ SQLITE_BACKUP_ENABLED: 'false' }, '/data/app.db').enabled).toBe(false);
+    expect(getBackupConfig({ SQLITE_BACKUP_ENABLED: 'true' }, '/data/app.db').enabled).toBe(true);
+  });
+
+  it('honors interval, retention, and dir overrides', () => {
+    const cfg = getBackupConfig(
+      {
+        SQLITE_BACKUP_INTERVAL_MS: '3600000',
+        SQLITE_BACKUP_RETENTION: '3',
+        SQLITE_BACKUP_DIR: '/mnt/backups',
+      },
+      '/data/app.db'
+    );
+    expect(cfg.intervalMs).toBe(3_600_000);
+    expect(cfg.retention).toBe(3);
+    expect(cfg.dir).toBe('/mnt/backups');
+  });
+
+  it('falls back to defaults for invalid retention/interval (NaN, zero, negative)', () => {
+    const cfg = getBackupConfig(
+      { SQLITE_BACKUP_RETENTION: '-1', SQLITE_BACKUP_INTERVAL_MS: 'abc' },
+      '/data/app.db'
+    );
+    expect(cfg.retention).toBe(7);
+    expect(cfg.intervalMs).toBe(86_400_000);
+  });
+});
+
+describe('runBackup (integration with a real file DB)', () => {
+  let dir: string;
+  let dbPath: string;
+  let raw: Database.Database;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'sqlite-backup-'));
+    dbPath = join(dir, 'app.db');
+    raw = new Database(dbPath);
+    raw.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
+    raw.prepare('INSERT INTO t (v) VALUES (?)').run('hello');
+  });
+
+  afterEach(() => {
+    try {
+      raw.close();
+    } catch {
+      /* ignore */
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes a consistent backup file that contains the live data', async () => {
+    const backupDir = join(dir, 'backups');
+    const cfg = { enabled: true, intervalMs: 1000, retention: 7, dir: backupDir };
+    const date = new Date(Date.UTC(2026, 5, 25, 14, 0, 0));
+
+    const result = await runBackup(raw, cfg, date);
+
+    expect(existsSync(result.path)).toBe(true);
+    expect(result.path).toBe(join(backupDir, 'app-20260625-140000.db'));
+
+    // Backup is a standalone DB readable on its own with the same data.
+    const restored = new Database(result.path, { readonly: true });
+    const row = restored.prepare('SELECT v FROM t WHERE id = 1').get() as { v: string };
+    restored.close();
+    expect(row.v).toBe('hello');
+  });
+
+  it('creates the backup directory if it does not exist', async () => {
+    const backupDir = join(dir, 'nested', 'backups');
+    expect(existsSync(backupDir)).toBe(false);
+    const cfg = { enabled: true, intervalMs: 1000, retention: 7, dir: backupDir };
+
+    await runBackup(raw, cfg, new Date(Date.UTC(2026, 5, 25, 14, 0, 0)));
+
+    expect(existsSync(backupDir)).toBe(true);
+  });
+
+  it('prunes the oldest backups beyond retention, keeping the live DB untouched', async () => {
+    const backupDir = join(dir, 'backups');
+    const cfg = { enabled: true, intervalMs: 1000, retention: 2, dir: backupDir };
+
+    const paths: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      const date = new Date(Date.UTC(2026, 5, 25, 10 + i, 0, 0));
+      const r = await runBackup(raw, cfg, date);
+      paths.push(r.path);
+    }
+
+    const remaining = readdirSync(backupDir).filter((f) => BACKUP_FILE_REGEX.test(f)).sort();
+    expect(remaining).toEqual(['app-20260625-120000.db', 'app-20260625-130000.db']);
+    // live DB still intact
+    expect(existsSync(dbPath)).toBe(true);
+  });
+});
+
+describe('scheduleBackups', () => {
+  it('runs an initial backup immediately and returns a stop() that clears the interval', async () => {
+    const calls: number[] = [];
+    let intervalCb: (() => void) | null = null;
+    let cleared = false;
+
+    const stop = scheduleBackups(
+      {} as Database.Database,
+      { enabled: true, intervalMs: 1000, retention: 7, dir: '/tmp/x' },
+      {
+        runFn: async () => {
+          calls.push(1);
+          return { path: '/tmp/x/app.db', prunedCount: 0 };
+        },
+        setIntervalFn: (cb: () => void) => {
+          intervalCb = cb;
+          return 42;
+        },
+        clearIntervalFn: () => {
+          cleared = true;
+        },
+        now: () => new Date(Date.UTC(2026, 5, 25, 0, 0, 0)),
+      }
+    );
+
+    // initial backup fired synchronously on schedule
+    expect(calls.length).toBe(1);
+
+    // interval callback drives subsequent backups
+    intervalCb!();
+    await Promise.resolve();
+    expect(calls.length).toBe(2);
+
+    stop();
+    expect(cleared).toBe(true);
+  });
+
+  it('does nothing and returns a no-op when disabled', () => {
+    let scheduled = false;
+    const stop = scheduleBackups(
+      {} as Database.Database,
+      { enabled: false, intervalMs: 1000, retention: 7, dir: '/tmp/x' },
+      {
+        runFn: async () => ({ path: '', prunedCount: 0 }),
+        setIntervalFn: () => {
+          scheduled = true;
+          return 0;
+        },
+        clearIntervalFn: () => {},
+        now: () => new Date(Date.UTC(2026, 5, 25, 0, 0, 0)),
+      }
+    );
+    expect(scheduled).toBe(false);
+    expect(() => stop()).not.toThrow();
+  });
+});

--- a/src/lib/db/sqlite/backup.test.ts
+++ b/src/lib/db/sqlite/backup.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
-import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { logger } from '@/lib/utils/logger';
 import {
   formatBackupTimestamp,
   selectBackupsToPrune,
@@ -232,5 +233,79 @@ describe('scheduleBackups', () => {
     );
     expect(scheduled).toBe(false);
     expect(() => stop()).not.toThrow();
+  });
+
+  it('uses real timers (unref + clearInterval) when timer deps are omitted', async () => {
+    let backups = 0;
+    // Only runFn is injected → default setIntervalFn/clearIntervalFn/now (real timers) are exercised.
+    // Large interval so the periodic tick never fires during the test; only the initial backup runs.
+    const stop = scheduleBackups(
+      {} as Database.Database,
+      { enabled: true, intervalMs: 1_000_000, retention: 7, dir: '/tmp/x' },
+      {
+        runFn: async () => {
+          backups++;
+          return { path: '/tmp/x/app.db', prunedCount: 0 };
+        },
+      }
+    );
+
+    expect(backups).toBe(1); // initial backup fired through the real schedule path
+    expect(() => stop()).not.toThrow(); // default clearIntervalFn clears the real interval
+  });
+
+  it('logs an error (without throwing) when a backup run rejects', async () => {
+    const errSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+    const stop = scheduleBackups(
+      {} as Database.Database,
+      { enabled: true, intervalMs: 1000, retention: 7, dir: '/tmp/x' },
+      {
+        runFn: async () => {
+          throw new Error('disk full');
+        },
+        setIntervalFn: () => 0,
+        clearIntervalFn: () => {},
+        now: () => new Date(0),
+      }
+    );
+
+    // flush the rejection-handling microtasks
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(errSpy).toHaveBeenCalledWith(
+      'SQLite backup failed',
+      expect.objectContaining({ error: 'disk full' })
+    );
+
+    stop();
+    errSpy.mockRestore();
+  });
+
+  it('stringifies non-Error rejections in the failure log', async () => {
+    const errSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+    const stop = scheduleBackups(
+      {} as Database.Database,
+      { enabled: true, intervalMs: 1000, retention: 7, dir: '/tmp/x' },
+      {
+        runFn: () => Promise.reject('boom'),
+        setIntervalFn: () => 0,
+        clearIntervalFn: () => {},
+        now: () => new Date(0),
+      }
+    );
+
+    // drain microtasks (rejection handler runs asynchronously)
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(errSpy).toHaveBeenCalledWith(
+      'SQLite backup failed',
+      expect.objectContaining({ error: 'boom' })
+    );
+
+    stop();
+    errSpy.mockRestore();
   });
 });

--- a/src/lib/db/sqlite/backup.ts
+++ b/src/lib/db/sqlite/backup.ts
@@ -1,0 +1,144 @@
+import { existsSync, mkdirSync, readdirSync, unlinkSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type Database from 'better-sqlite3';
+import { logger } from '@/lib/utils/logger';
+import { getSqlitePath } from './connection';
+
+/** 백업 파일명 패턴: `app-YYYYMMDD-HHmmss.db`. 라이브 DB(`app.db`)·WAL/SHM과 명확히 구분된다. */
+export const BACKUP_FILE_REGEX = /^app-\d{8}-\d{6}\.db$/;
+
+const DEFAULT_INTERVAL_MS = 86_400_000; // 24h
+const DEFAULT_RETENTION = 7;
+
+export interface BackupConfig {
+  /** 백업 스케줄러 활성 여부 (`SQLITE_BACKUP_ENABLED !== 'false'`). */
+  enabled: boolean;
+  /** 백업 주기(ms). */
+  intervalMs: number;
+  /** 보관할 백업 개수(가장 최근 N개 유지). */
+  retention: number;
+  /** 백업 파일을 쓰는 디렉터리. 기본 `<sqlite dir>/backups`. */
+  dir: string;
+}
+
+export interface BackupResult {
+  /** 생성된 백업 파일의 절대/상대 경로. */
+  path: string;
+  /** 이번 실행에서 보관 정책으로 삭제한 오래된 백업 수. */
+  prunedCount: number;
+}
+
+/** Date → `YYYYMMDD-HHmmss`(UTC). 파일명 정렬이 곧 시간순이 되도록 고정폭·UTC를 사용한다. */
+export function formatBackupTimestamp(date: Date): string {
+  const p = (n: number): string => String(n).padStart(2, '0');
+  const y = date.getUTCFullYear();
+  return (
+    `${y}${p(date.getUTCMonth() + 1)}${p(date.getUTCDate())}` +
+    `-${p(date.getUTCHours())}${p(date.getUTCMinutes())}${p(date.getUTCSeconds())}`
+  );
+}
+
+/**
+ * 보관 정책에 따라 삭제 대상 백업 파일명을 고른다.
+ * 백업 패턴에 맞는 파일만 후보로 삼으므로 라이브 DB·WAL·기타 파일은 절대 삭제되지 않는다.
+ * 파일명이 `app-<timestamp>.db`라 사전식 정렬 = 시간순 정렬.
+ */
+export function selectBackupsToPrune(files: string[], retention: number): string[] {
+  const backups = files.filter((f) => BACKUP_FILE_REGEX.test(f)).sort((a, b) => a.localeCompare(b));
+  if (backups.length <= retention) return [];
+  return backups.slice(0, backups.length - retention);
+}
+
+/** 환경변수에서 백업 설정을 읽는다(잘못된 값은 안전한 기본값으로 폴백). */
+export function getBackupConfig(
+  env: Record<string, string | undefined> = process.env,
+  sqlitePath: string = getSqlitePath()
+): BackupConfig {
+  const enabled = env.SQLITE_BACKUP_ENABLED !== 'false';
+
+  const intervalRaw = Number(env.SQLITE_BACKUP_INTERVAL_MS);
+  const intervalMs = Number.isFinite(intervalRaw) && intervalRaw > 0 ? intervalRaw : DEFAULT_INTERVAL_MS;
+
+  const retentionRaw = Number(env.SQLITE_BACKUP_RETENTION);
+  const retention = Number.isInteger(retentionRaw) && retentionRaw >= 1 ? retentionRaw : DEFAULT_RETENTION;
+
+  const dir = env.SQLITE_BACKUP_DIR ?? join(dirname(sqlitePath), 'backups');
+
+  return { enabled, intervalMs, retention, dir };
+}
+
+/**
+ * SQLite 온라인 백업을 1회 수행한다. better-sqlite3의 `.backup()`은 WAL 모드에서도 일관된
+ * 스냅샷을 자체 완결 파일로 남긴다(라이브 쓰기를 차단하지 않음). 이후 보관 정책으로 오래된 백업을 정리한다.
+ */
+export async function runBackup(
+  raw: Database.Database,
+  config: BackupConfig,
+  date: Date
+): Promise<BackupResult> {
+  if (!existsSync(config.dir)) {
+    mkdirSync(config.dir, { recursive: true });
+  }
+
+  const path = join(config.dir, `app-${formatBackupTimestamp(date)}.db`);
+  await raw.backup(path);
+
+  const toPrune = selectBackupsToPrune(readdirSync(config.dir), config.retention);
+  for (const f of toPrune) {
+    try {
+      unlinkSync(join(config.dir, f));
+    } catch {
+      // 동시성/이미 삭제됨 — 무시
+    }
+  }
+
+  return { path, prunedCount: toPrune.length };
+}
+
+interface ScheduleDeps {
+  runFn?: typeof runBackup;
+  /** 테스트 주입용. 핸들 타입은 의도적으로 느슨하게(`unknown`) 둔다(DOM/Node `setInterval` 오버로드 회피). */
+  setIntervalFn?: (callback: () => void, ms: number) => unknown;
+  clearIntervalFn?: (handle: unknown) => void;
+  now?: () => Date;
+}
+
+/**
+ * 주기 백업을 시작한다(부팅 시 즉시 1회 + 이후 `intervalMs` 간격). 비활성이면 no-op.
+ * 타이머는 `unref()`하여 백업 때문에 프로세스가 종료를 못 하는 일이 없도록 한다.
+ * 반환된 함수를 호출하면 스케줄을 중단한다. 의존성 주입으로 결정적 단위 테스트가 가능하다.
+ */
+export function scheduleBackups(
+  raw: Database.Database,
+  config: BackupConfig,
+  deps: ScheduleDeps = {}
+): () => void {
+  const {
+    runFn = runBackup,
+    setIntervalFn = (cb: () => void, ms: number): unknown => setInterval(cb, ms),
+    clearIntervalFn = (handle: unknown): void => clearInterval(handle as ReturnType<typeof setInterval>),
+    now = (): Date => new Date(),
+  } = deps;
+
+  if (!config.enabled) return () => {};
+
+  const tick = (): void => {
+    void runFn(raw, config, now()).then(
+      (r) => logger.info('SQLite backup written', { path: r.path, pruned: r.prunedCount }),
+      (err: unknown) =>
+        logger.error('SQLite backup failed', {
+          error: err instanceof Error ? err.message : String(err),
+        })
+    );
+  };
+
+  const handle = setIntervalFn(tick, config.intervalMs);
+  const timer = handle as { unref?: () => void };
+  if (typeof timer.unref === 'function') {
+    timer.unref(); // 백업 타이머가 프로세스 종료를 막지 않도록
+  }
+
+  tick(); // 부팅 직후 즉시 1회 백업
+
+  return () => clearIntervalFn(handle);
+}

--- a/src/lib/db/sqlite/connection.test.ts
+++ b/src/lib/db/sqlite/connection.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { eq } from 'drizzle-orm';
 import type DatabaseType from 'better-sqlite3';
-import { createSqliteConnection, runSqliteMigrations } from './connection';
+import {
+  createSqliteConnection,
+  runSqliteMigrations,
+  getSqliteDb,
+  getSqliteRawConnection,
+  resetSqliteConnection,
+} from './connection';
 import * as schema from './schema';
 
 let raw: DatabaseType.Database | undefined;
@@ -56,6 +62,37 @@ describe('SQLite 스키마 round-trip', () => {
 
     const found = db.select().from(schema.projects).where(eq(schema.projects.id, p.id)).all();
     expect(found).toHaveLength(1);
+  });
+});
+
+describe('getSqliteRawConnection', () => {
+  const prevProvider = process.env.DB_PROVIDER;
+  const prevPath = process.env.SQLITE_PATH;
+
+  afterEach(() => {
+    resetSqliteConnection();
+    if (prevProvider === undefined) delete process.env.DB_PROVIDER;
+    else process.env.DB_PROVIDER = prevProvider;
+    if (prevPath === undefined) delete process.env.SQLITE_PATH;
+    else process.env.SQLITE_PATH = prevPath;
+  });
+
+  it('returns the better-sqlite3 connection backing the singleton', () => {
+    process.env.DB_PROVIDER = 'sqlite';
+    process.env.SQLITE_PATH = ':memory:';
+    getSqliteDb();
+
+    const conn = getSqliteRawConnection();
+    expect(conn.open).toBe(true);
+    expect(conn.pragma('foreign_keys', { simple: true })).toBe(1);
+  });
+
+  it('initializes the singleton on first access if not yet created', () => {
+    process.env.DB_PROVIDER = 'sqlite';
+    process.env.SQLITE_PATH = ':memory:';
+
+    const conn = getSqliteRawConnection();
+    expect(conn.open).toBe(true);
   });
 
   it('foreign_keys 제약을 강제한다 (존재하지 않는 user_id)', () => {

--- a/src/lib/db/sqlite/connection.ts
+++ b/src/lib/db/sqlite/connection.ts
@@ -43,6 +43,18 @@ export function getSqliteDb(): SqliteDb {
   return _db;
 }
 
+/**
+ * 싱글톤을 뒷받침하는 raw better-sqlite3 연결을 반환한다(없으면 초기화).
+ * 온라인 백업(`.backup()`)처럼 drizzle 래퍼가 노출하지 않는 기능에 접근할 때 사용한다.
+ */
+export function getSqliteRawConnection(): Database.Database {
+  getSqliteDb(); // 싱글톤 초기화 보장(DB_PROVIDER 가드도 여기서 적용)
+  if (!_raw) {
+    throw new Error('SQLite raw 연결이 초기화되지 않았습니다.');
+  }
+  return _raw;
+}
+
 /** 마이그레이션 적용 (부팅 시 또는 테스트 셋업). */
 export function runSqliteMigrations(db: SqliteDb, migrationsFolder = './drizzle/sqlite'): void {
   migrate(db, { migrationsFolder });


### PR DESCRIPTION
## 배경
잔여 작업 감사에서 **최우선 운영 리스크**로 식별된 항목: 실사용자 데이터를 가진 단일 SQLite 파일(`/data/app.db`)이 Railway 볼륨 스냅샷에만 의존하고 자동 백업이 없었음. 논리 손상·잘못된 마이그레이션·실수 삭제에 무방비.

## 설계 (런북 §5 + cost-priority 준수)
외부 의존·비용 없는 **인프로세스 주기 백업**. better-sqlite3 `.backup()` 온라인 덤프(WAL에서도 일관) → `<SQLITE 디렉터리>/backups/app-YYYYMMDD-HHmmss.db` → 보관 정책으로 오래된 파일 정리. 단일 인스턴스·Railway 볼륨 전제.

- **방어 범위**: 논리 손상·잘못된 마이그레이션·실수 삭제
- **볼륨 자체 손실**: Railway 볼륨 스냅샷이 담당 (오프-볼륨 DR은 Litestream→S3 향후 옵션·비용)

## 변경
- `src/lib/db/sqlite/backup.ts` (신규)
  - `formatBackupTimestamp` (UTC, 고정폭 → 파일명 정렬=시간순)
  - `selectBackupsToPrune` — **`app-<ts>.db` 패턴만 후보** → 라이브 DB·WAL/SHM·기타 파일 절대 미삭제
  - `getBackupConfig` (env 파싱, 잘못된 값은 안전 기본값 폴백)
  - `runBackup` / `scheduleBackups` (타이머 `.unref()`, DI 주입형)
- `connection.ts`: `getSqliteRawConnection()` accessor (drizzle 미노출 `.backup()` 접근용)
- `instrumentation.ts`: `bootstrapSqlite` 다음 백업 스케줄러 배선 (`:memory:`·비활성 시 스킵)
- env: `SQLITE_BACKUP_ENABLED`/`_INTERVAL_MS`/`_RETENTION`/`_DIR` (기본 `true`·24h·7·`/data/backups`)

## 검증
- **TDD** (RED→GREEN 확인): backup 16 + connection accessor 2 테스트. sqlite 디렉터리 전체 35 통과.
- `pnpm type-check` clean, `pnpm lint` 0 errors.
- SonarLint S2871(`.sort()` 무비교함수) 즉시 수정(localeCompare).

## 운영 메모
- 복구: 서비스 중지 후 `cp /data/backups/app-<ts>.db /data/app.db`
- env 미설정 시 기본값으로 즉시 동작. 비활성화는 `SQLITE_BACKUP_ENABLED=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)