### PR TITLE
fix(deploy): GithubPagesDeployer.deleteProject 실제 구현 — orphan repo 정리

### DIFF
--- a/src/lib/deploy/githubService.test.ts
+++ b/src/lib/deploy/githubService.test.ts
@@ -381,3 +381,41 @@ describe('enableGithubPages()', () => {
     expect(body.source.path).toBe('/docs');
   });
 });
+
+// ── deleteRepository ────────────────────────────────────────────────────────
+
+describe('deleteRepository()', () => {
+  it('204 → DELETE /repos/:full_name 호출 후 정상 반환', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({}, 204));
+
+    const { deleteRepository } = await import('./githubService');
+    await expect(deleteRepository('test-org/svc-app')).resolves.toBeUndefined();
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://api.github.com/repos/test-org/svc-app');
+    expect(init.method).toBe('DELETE');
+  });
+
+  it('404(이미 삭제됨) → 멱등 처리, 에러 throw 없음', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Not Found' }, 404));
+
+    const { deleteRepository } = await import('./githubService');
+    await expect(deleteRepository('test-org/gone')).resolves.toBeUndefined();
+  });
+
+  it('403(권한 없음) → "GitHub repo deletion failed: 403" throw', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ message: 'Forbidden' }, 403));
+
+    const { deleteRepository } = await import('./githubService');
+    await expect(deleteRepository('test-org/svc-app')).rejects.toThrow(
+      'GitHub repo deletion failed: 403'
+    );
+  });
+
+  it('GITHUB_TOKEN 미설정 → "GITHUB_TOKEN is not set" throw', async () => {
+    vi.stubEnv('GITHUB_TOKEN', '');
+
+    const { deleteRepository } = await import('./githubService');
+    await expect(deleteRepository('test-org/svc-app')).rejects.toThrow('GITHUB_TOKEN is not set');
+  });
+});

--- a/src/lib/deploy/githubService.ts
+++ b/src/lib/deploy/githubService.ts
@@ -60,6 +60,21 @@ export async function createRepository(
   };
 }
 
+export async function deleteRepository(repoFullName: string): Promise<void> {
+  const res = await fetch(`${GITHUB_API}/repos/${repoFullName}`, {
+    method: 'DELETE',
+    headers: getHeaders(),
+  });
+
+  // 204 = 삭제됨. 404 = 이미 없음 → 멱등 처리(성공으로 간주). 그 외는 에러.
+  if (!res.ok && res.status !== 404) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(`GitHub repo deletion failed: ${res.status} ${JSON.stringify(body)}`);
+  }
+
+  logger.info('GitHub repository deleted', { repoFullName, status: res.status });
+}
+
 export async function pushCode(repoFullName: string, files: FileEntry[]): Promise<void> {
   const headers = getHeaders();
 

--- a/src/providers/deploy/GithubPagesDeployer.test.ts
+++ b/src/providers/deploy/GithubPagesDeployer.test.ts
@@ -8,6 +8,7 @@ vi.mock('@/lib/deploy/githubService', () => ({
   pushCode: vi.fn(),
   setSecrets: vi.fn(),
   enableGithubPages: vi.fn(),
+  deleteRepository: vi.fn(),
 }));
 
 vi.mock('@/lib/utils/logger', () => ({
@@ -175,12 +176,33 @@ describe('GithubPagesDeployer', () => {
   // deleteProject
   // ─────────────────────────────────────────────
   describe('deleteProject()', () => {
-    it('logger.warn을 호출하고 void를 반환한다', async () => {
-      const { logger } = await import('@/lib/utils/logger');
+    it('resolveRepo 결과로 github.deleteRepository를 호출한다', async () => {
+      mockGithub.deleteRepository.mockResolvedValue(undefined);
 
       await deployer.deleteProject('org/repo');
 
-      expect(logger.warn).toHaveBeenCalled();
+      expect(mockGithub.deleteRepository).toHaveBeenCalledWith('org/repo');
+    });
+
+    it('createProject로 등록된 name 키로도 삭제하고 repoMap에서 제거한다', async () => {
+      mockGithub.createRepository.mockResolvedValue({
+        repoUrl: 'https://github.com/org/svc-app',
+        fullName: 'org/svc-app',
+      });
+      mockGithub.deleteRepository.mockResolvedValue(undefined);
+
+      await deployer.createProject('app');
+      await deployer.deleteProject('app');
+
+      expect(mockGithub.deleteRepository).toHaveBeenCalledWith('org/svc-app');
+      // 맵에서 제거되어 이후 조회는 실패해야 한다
+      await expect(deployer.pushFiles('app', [])).rejects.toThrow('Repo not found for project: app');
+    });
+
+    it('github.deleteRepository 실패를 전파한다', async () => {
+      mockGithub.deleteRepository.mockRejectedValue(new Error('GitHub repo deletion failed: 403'));
+
+      await expect(deployer.deleteProject('org/repo')).rejects.toThrow('deletion failed: 403');
     });
   });
 

--- a/src/providers/deploy/GithubPagesDeployer.ts
+++ b/src/providers/deploy/GithubPagesDeployer.ts
@@ -6,7 +6,7 @@ export class GithubPagesDeployer implements IDeployProvider {
   readonly name = 'github_pages';
   readonly supportedFeatures = ['static_only'] as const;
 
-  private repoMap = new Map<string, string>(); // projectId -> repoFullName
+  private readonly repoMap = new Map<string, string>(); // projectId -> repoFullName
 
   async createProject(name: string): Promise<{ projectId: string; repoUrl?: string }> {
     const repoName = `svc-${name}`;
@@ -68,10 +68,12 @@ export class GithubPagesDeployer implements IDeployProvider {
   }
 
   async deleteProject(projectId: string): Promise<void> {
-    // Deleting the repo is destructive; just log for now
-    logger.warn('GitHub Pages project deletion not implemented (requires repo deletion)', {
-      projectId,
-    });
+    const repoFullName = this.resolveRepo(projectId);
+    // GitHub repo 삭제는 비가역. 호출부(프로젝트 삭제 플로우)가 확인 게이트를 책임진다.
+    // 404(이미 없음)는 githubService가 멱등 처리한다.
+    await github.deleteRepository(repoFullName);
+    this.repoMap.delete(projectId);
+    logger.info('GitHub Pages project deleted', { projectId, repoFullName });
   }
 
   private resolveRepo(projectId: string): string {


### PR DESCRIPTION
## 배경
잔여 작업 감사 항목: `GithubPagesDeployer.deleteProject`가 `logger.warn`만 남기는 no-op이라 프로젝트 삭제 시 GitHub Pages repo가 정리되지 않음(orphan repo 누적).

> 참고: 현재 `IDeployProvider.deleteProject`를 호출하는 서비스 계층 코드는 없음(인터페이스 메서드만 존재) → **자동 트리거 없음**. 향후 프로젝트 삭제 플로우 배선을 위한 정확한 구현이며, 비가역 작업의 확인 게이트는 호출부 책임으로 명시.

## 변경
- `githubService.deleteRepository(repoFullName)` 추가
  - `DELETE /repos/:full_name` — **204 삭제** / **404 멱등**(이미 없음 → 성공 간주) / 그 외 에러 throw
- `GithubPagesDeployer.deleteProject` — `resolveRepo` → `github.deleteRepository` 호출 + `repoMap` 정리
- `repoMap`을 `readonly`로 (SonarLint S2933 코드스멜 정정)

## 검증
- **TDD** (RED→GREEN): deleteRepository 4 + deleteProject 3 = 7 테스트. deploy 스위트 48 통과.
- `pnpm type-check` clean, `pnpm lint` 0 errors. githubService 신규코드 라인 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)