### PR TITLE
refactor(ai): 인지 복잡도(S3776) 감소 — 테스트 보유 lib 3종 헬퍼 추출

### DIFF
--- a/src/lib/ai/codeParser.ts
+++ b/src/lib/ai/codeParser.ts
@@ -200,6 +200,27 @@ function buildHeadInjections(html: string, safeCss: string): string {
   return parts.join('\n');
 }
 
+/** 너비/높이 속성을 (아직 없을 때만) 부여한다. */
+function withDimensions(attrs: string, width: string, height: string): string {
+  let out = attrs;
+  if (!/\bwidth\s*=/i.test(out)) out += ` width="${width}"`;
+  if (!/\bheight\s*=/i.test(out)) out += ` height="${height}"`;
+  return out;
+}
+
+/** picsum.photos URL에서 치수를 추출해 부여한다(매칭 없으면 원본 유지). */
+function addPicsumDimensions(attrs: string): string {
+  const sizeMatch = /picsum\.photos\/(?:seed\/[^/]+\/)?(\d+)\/(\d+)/i.exec(attrs);
+  return sizeMatch ? withDimensions(attrs, sizeMatch[1], sizeMatch[2]) : attrs;
+}
+
+/** Unsplash URL에서 치수를 추출해 부여한다(매칭 없으면 원본 유지). */
+function addUnsplashDimensions(attrs: string): string {
+  const unsplashWH =
+    /[?&]w=(\d+)&h=(\d+)/i.exec(attrs) || /source\.unsplash\.com\/(\d+)x(\d+)/i.exec(attrs);
+  return unsplashWH ? withDimensions(attrs, unsplashWH[1], unsplashWH[2]) : attrs;
+}
+
 /**
  * Process a single <img> tag's attributes: add lazy loading, decoding, and dimensions.
  * First 2 images (imgIndex ≤ 2) skip lazy loading (above the fold).
@@ -213,19 +234,9 @@ function processImgTag(attrs: string, imgIndex: number): string {
     newAttrs += ' decoding="async"';
   }
   if (/picsum\.photos/i.test(newAttrs)) {
-    const sizeMatch = /picsum\.photos\/(?:seed\/[^/]+\/)?(\d+)\/(\d+)/i.exec(newAttrs);
-    if (sizeMatch) {
-      if (!/\bwidth\s*=/i.test(newAttrs)) newAttrs += ` width="${sizeMatch[1]}"`;
-      if (!/\bheight\s*=/i.test(newAttrs)) newAttrs += ` height="${sizeMatch[2]}"`;
-    }
+    newAttrs = addPicsumDimensions(newAttrs);
   } else if (/images\.unsplash\.com/i.test(newAttrs) || /source\.unsplash\.com/i.test(newAttrs)) {
-    const unsplashWH =
-      /[?&]w=(\d+)&h=(\d+)/i.exec(newAttrs) ||
-      /source\.unsplash\.com\/(\d+)x(\d+)/i.exec(newAttrs);
-    if (unsplashWH) {
-      if (!/\bwidth\s*=/i.test(newAttrs)) newAttrs += ` width="${unsplashWH[1]}"`;
-      if (!/\bheight\s*=/i.test(newAttrs)) newAttrs += ` height="${unsplashWH[2]}"`;
-    }
+    newAttrs = addUnsplashDimensions(newAttrs);
   }
   return newAttrs;
 }

--- a/src/lib/ai/qualityLoop.ts
+++ b/src/lib/ai/qualityLoop.ts
@@ -29,22 +29,21 @@ export function hasFunctionalIssue(metrics: QualityMetrics): boolean {
   );
 }
 
+/** 재시도를 유발하는 렌더링 QC 체크 이름(실패 시 retry). */
+const BLOCKING_QC_CHECKS = ['consoleErrors', 'horizontalScroll', 'footerVisible', 'noLayoutOverlap'];
+
+/** 차단 대상 렌더링 QC 체크 중 하나라도 실패했는지. */
+function hasBlockingQcFailure(qcReport: QcReport): boolean {
+  return qcReport.checks.some((c) => BLOCKING_QC_CHECKS.includes(c.name) && !c.passed);
+}
+
 export function shouldRetryGeneration(
   metrics: QualityMetrics,
   qcReport?: QcReport | null
 ): boolean {
   if (metrics.structuralScore < QC_THRESHOLDS.QUALITY) return true;
   if (metrics.mobileScore < QC_THRESHOLDS.MOBILE) return true;
-  if (qcReport) {
-    const consoleCheck = qcReport.checks.find(c => c.name === 'consoleErrors');
-    const scrollCheck = qcReport.checks.find(c => c.name === 'horizontalScroll');
-    const footerCheck = qcReport.checks.find(c => c.name === 'footerVisible');
-    const overlapCheck = qcReport.checks.find(c => c.name === 'noLayoutOverlap');
-    if (consoleCheck && !consoleCheck.passed) return true;
-    if (scrollCheck && !scrollCheck.passed) return true;
-    if (footerCheck && !footerCheck.passed) return true;
-    if (overlapCheck && !overlapCheck.passed) return true;
-  }
+  if (qcReport && hasBlockingQcFailure(qcReport)) return true;
   if (hasFunctionalIssue(metrics)) return true;
   return false;
 }

--- a/src/lib/ai/slugSuggester.test.ts
+++ b/src/lib/ai/slugSuggester.test.ts
@@ -141,6 +141,33 @@ describe('suggestSlugs()', () => {
     expect(result).toEqual([]);
   });
 
+  it('유효 후보가 3개를 초과해도 최대 3개만 반환한다 (limit break)', async () => {
+    const { AiProviderFactory } = await import('@/providers/ai/AiProviderFactory');
+    vi.mocked(AiProviderFactory.createForTask).mockReturnValue(
+      makeProvider('["alpha-one", "beta-two", "gamma-three", "delta-four", "epsilon-five"]') as never,
+    );
+
+    const { suggestSlugs } = await import('./slugSuggester');
+    const result = await suggestSlugs({ context: '후보 다수 테스트' });
+
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(['alpha-one', 'beta-two', 'gamma-three']);
+  });
+
+  it('비-Error 값으로 reject돼도 빈 배열 반환 (String(err) 경로)', async () => {
+    const { AiProviderFactory } = await import('@/providers/ai/AiProviderFactory');
+    vi.mocked(AiProviderFactory.createForTask).mockReturnValue({
+      name: 'claude',
+      model: 'claude-haiku-4-5',
+      generateCode: vi.fn().mockRejectedValue('문자열 에러'),
+      generateCodeStream: vi.fn(),
+      checkAvailability: vi.fn(),
+    } as never);
+
+    const { suggestSlugs } = await import('./slugSuggester');
+    await expect(suggestSlugs({ context: '문자열 에러 테스트' })).resolves.toEqual([]);
+  });
+
   it('pageTitle과 categoryHints 있을 때 user prompt에 포함됨', async () => {
     const { AiProviderFactory } = await import('@/providers/ai/AiProviderFactory');
     const mockProvider = makeProvider('["news-reader", "daily-news", "news-feed"]');

--- a/src/lib/ai/slugSuggester.ts
+++ b/src/lib/ai/slugSuggester.ts
@@ -8,22 +8,7 @@ export interface SlugSuggestInput {
   categoryHints?: string[];  // 선택된 API 카테고리
 }
 
-/** AI 영문 slug 후보 최대 3개. 실패 시 빈 배열(폴백 트리거) */
-export async function suggestSlugs(input: SlugSuggestInput): Promise<string[]> {
-  try {
-    const provider = AiProviderFactory.createForTask('suggestion');
-
-    const userParts: string[] = [`Service description: ${input.context}`];
-    if (input.pageTitle) {
-      userParts.push(`Page title: ${input.pageTitle}`);
-    }
-    if (input.categoryHints && input.categoryHints.length > 0) {
-      userParts.push(`Categories: ${input.categoryHints.join(', ')}`);
-    }
-    userParts.push('\nReturn a JSON array of exactly 3 slug suggestions.');
-
-    const aiResponse = await provider.generateCode({
-      system: `You are a URL slug generator for web services.
+const SLUG_SYSTEM_PROMPT = `You are a URL slug generator for web services.
 Given a service description, generate exactly 3 English kebab-case URL slugs.
 Rules:
 - Each slug must be 3–40 characters long
@@ -32,43 +17,70 @@ Rules:
 - Do not use reserved words like: admin, dashboard, login, api, www, auth, settings, profile, help, support, blog, docs, status, health
 - Each slug must be unique and reflect the service content
 - Return ONLY a raw JSON array, no markdown, no code blocks, no explanation
-Example output: ["my-weather-app", "weather-dashboard", "daily-forecast"]`,
-      user: userParts.join('\n'),
+Example output: ["my-weather-app", "weather-dashboard", "daily-forecast"]`;
+
+function buildUserPrompt(input: SlugSuggestInput): string {
+  const userParts: string[] = [`Service description: ${input.context}`];
+  if (input.pageTitle) {
+    userParts.push(`Page title: ${input.pageTitle}`);
+  }
+  if (input.categoryHints && input.categoryHints.length > 0) {
+    userParts.push(`Categories: ${input.categoryHints.join(', ')}`);
+  }
+  userParts.push('\nReturn a JSON array of exactly 3 slug suggestions.');
+  return userParts.join('\n');
+}
+
+/** AI 응답 본문에서 JSON 배열을 추출한다. 미발견/파싱 실패 시 null(폴백 트리거). */
+function extractJsonArray(content: string): unknown[] | null {
+  const match = /\[[\s\S]*?\]/.exec(content);
+  if (!match) {
+    logger.warn('slugSuggester: could not find JSON array in AI response', {
+      content: content.slice(0, 200),
+    });
+    return null;
+  }
+  try {
+    const raw: unknown = JSON.parse(match[0]);
+    if (!Array.isArray(raw)) throw new Error('Not an array');
+    return raw;
+  } catch {
+    logger.warn('slugSuggester: JSON parse failed', { raw: match[0].slice(0, 200) });
+    return null;
+  }
+}
+
+/** 후보를 정규화·검증·중복 제거해 최대 `limit`개의 유효 slug로 만든다. */
+function normalizeUniqueSlugs(parsed: unknown[], limit = 3): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const item of parsed) {
+    if (result.length >= limit) break;
+    const normalized = toSlug(String(item)).slice(0, 50);
+    if (!normalized || !isValidSlug(normalized)) continue;
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
+/** AI 영문 slug 후보 최대 3개. 실패 시 빈 배열(폴백 트리거) */
+export async function suggestSlugs(input: SlugSuggestInput): Promise<string[]> {
+  try {
+    const provider = AiProviderFactory.createForTask('suggestion');
+
+    const aiResponse = await provider.generateCode({
+      system: SLUG_SYSTEM_PROMPT,
+      user: buildUserPrompt(input),
       temperature: 0.7,
       maxTokens: 200,
     });
 
-    const match = aiResponse.content.match(/\[[\s\S]*?\]/);
-    if (!match) {
-      logger.warn('slugSuggester: could not find JSON array in AI response', {
-        content: aiResponse.content.slice(0, 200),
-      });
-      return [];
-    }
+    const parsed = extractJsonArray(aiResponse.content);
+    if (!parsed) return [];
 
-    let parsed: unknown[];
-    try {
-      const raw = JSON.parse(match[0]);
-      if (!Array.isArray(raw)) throw new Error('Not an array');
-      parsed = raw;
-    } catch {
-      logger.warn('slugSuggester: JSON parse failed', { raw: match[0].slice(0, 200) });
-      return [];
-    }
-
-    const seen = new Set<string>();
-    const result: string[] = [];
-
-    for (const item of parsed) {
-      if (result.length >= 3) break;
-      const normalized = toSlug(String(item)).slice(0, 50);
-      if (!normalized || !isValidSlug(normalized)) continue;
-      if (seen.has(normalized)) continue;
-      seen.add(normalized);
-      result.push(normalized);
-    }
-
-    return result;
+    return normalizeUniqueSlugs(parsed);
   } catch (err) {
     logger.warn('slugSuggester: unexpected error', {
       error: err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
## 배경
잔여 감사가 \"CRITICAL 코드스멜 15건\"으로 분류한 항목은 **전부 `S3776`(인지 복잡도)** 리팩토링이며 단순 lint 정리가 아니었음. 분포:
- **프로덕션 핵심 경로**: `middleware.ts`(Edge/보안), `proxy/route.ts`(서빙·키 해결) — 메트릭 위해 건드리면 위험 대비 이득 없음
- **무테스트**: `qcChecks.ts`, `health/route.ts` — 동작 보존 검증 불가
- **대형 UI**: `builder/page.tsx`(48→15), `RePromptPanel.tsx`(47→15), `GenerationProgress.tsx`(28→15)
- **테스트 보유 lib**(이 PR 대상): `slugSuggester`·`qualityLoop`·`codeParser`

품질 게이트는 이미 **GREEN**(기능·보안 영향 0). 따라서 위험 대비 이득이 명확한 **테스트 보유 lib 3종만** 처리하고, **나머지 12건은 의도적으로 미수정**(프로덕션 핵심 경로를 메트릭 위해 리팩토링하지 않는다는 배포 품질 원칙).

## 변경 (순수 리팩토링 — 공개 동작 무변경)
- `slugSuggester.suggestSlugs`: `buildUserPrompt`·`extractJsonArray`·`normalizeUniqueSlugs` 추출 + `.match()`→`.exec()`(S6594)
- `qualityLoop.shouldRetryGeneration`: 렌더링 QC 차단 체크를 `hasBlockingQcFailure`로 추출(고유 체크명 전제 동일)
- `codeParser.processImgTag`: picsum·unsplash 치수 로직을 `withDimensions`/`addPicsumDimensions`/`addUnsplashDimensions`로 추출

## 검증
- 동작 보존: 기존 테스트로 확인(slugSuggester 10·qualityLoop 63·codeParser 전체 그린). slugSuggester는 limit-break·String(err) 분기 테스트 추가.
- `pnpm type-check`·`pnpm lint` clean. 신규 헬퍼는 기존 테스트 경로로 커버.

🤖 Generated with [Claude Code](https://claude.com/claude-code)