### PR TITLE
feat(admin): catalog-dump 진단 엔드포인트 — 전체 카탈로그(비활성 포함) 덤프

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ AI 기반 노코드 플랫폼. 무료 API를 선택하고 서비스를 설명하
 ```
 src/
 ├── app/             # Next.js App Router (pages, layouts, API routes)
-│   ├── api/         # /api/v1/* REST endpoints (admin/ 하위 진단 라우트: debug, keys-verify, verify-catalog, qc-stats, test-generation, trigger-qc)
+│   ├── api/         # /api/v1/* REST endpoints (admin/ 하위 진단 라우트: debug, keys-verify, verify-catalog, catalog-dump, qc-stats, test-generation, trigger-qc)
 │   ├── (auth)/      # 인증 관련 페이지
 │   ├── (main)/      # 메인 페이지 그룹
 │   └── site/        # 서브도메인 서빙 ([slug])

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1061,3 +1061,30 @@ Authorization: Bearer <ADMIN_API_KEY>
 | 에러 코드 | HTTP | 설명 |
 |-----------|------|------|
 | `FORBIDDEN` | 403 | `Authorization` 헤더 누락 또는 잘못된 `ADMIN_API_KEY` |
+
+### GET /api/v1/admin/catalog-dump
+프로덕션 `api_catalog` **전체 행(활성·비활성 포함)** 을 시드 동기화 diff용으로 덤프합니다. 공개 `GET /api/v1/catalog`는 활성 행만 반환하므로, 비활성(키 의존) 행까지 포함한 전체 파리티 검증에 사용합니다. `auth_config` 등 민감 필드는 제외한 **안전 투영**(id·name·category·authType·isActive·verificationStatus·verifiedAt·deprecatedAt·successorId·requiresProxy·apiVersion)만 반환하는 **읽기 전용** 진단입니다. 배포 런타임 전용(프로덕션 SQLite 읽기).
+
+**Request:**
+```http
+GET /api/v1/admin/catalog-dump
+Authorization: Bearer <ADMIN_API_KEY>
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "generatedAt": "2026-06-29T...",
+    "summary": { "total": 61, "active": 36, "inactive": 25, "byVerificationStatus": { "verified": 30, "broken": 1, "key_gated": 24 } },
+    "items": [
+      { "id": "...", "name": "Countries (Self-hosted)", "category": "data", "authType": "none", "isActive": true, "verificationStatus": "verified", "verifiedAt": "2026-06-22T...", "deprecatedAt": null, "successorId": null, "requiresProxy": false, "apiVersion": "v1" }
+    ]
+  }
+}
+```
+
+| 에러 코드 | HTTP | 설명 |
+|-----------|------|------|
+| `FORBIDDEN` | 403 | `Authorization` 헤더 누락 또는 잘못된 `ADMIN_API_KEY` |

--- a/src/__tests__/api/admin-catalog-dump.test.ts
+++ b/src/__tests__/api/admin-catalog-dump.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// 카탈로그 레포가 반환하는 도메인 항목(활성 1 + 비활성 1) — camelCase
+const activeItem = {
+  id: 'cat-active',
+  name: 'Active API',
+  category: 'data',
+  authType: 'none',
+  authConfig: { default_key: 'SHOULD_NOT_LEAK' },
+  isActive: true,
+  verificationStatus: 'verified',
+  verifiedAt: '2026-06-25T00:00:00.000Z',
+  deprecatedAt: null,
+  successorId: null,
+  requiresProxy: false,
+  apiVersion: 'v1',
+};
+const inactiveItem = {
+  id: 'cat-inactive',
+  name: 'Inactive API',
+  category: 'geo',
+  authType: 'api_key',
+  authConfig: { env_var: 'API_KEY_X', default_key: undefined },
+  isActive: false,
+  verificationStatus: 'broken',
+  verifiedAt: null,
+  deprecatedAt: '2026-06-21T00:00:00.000Z',
+  successorId: 'cat-active',
+  requiresProxy: true,
+  apiVersion: null,
+};
+
+const findMany = vi.fn();
+
+vi.mock('@/repositories/factory', () => ({ createCatalogRepository: vi.fn(() => ({ findMany })) }));
+
+const VALID_ADMIN_KEY = 'test-admin-secret-key';
+
+function makeReq(key: string | null = VALID_ADMIN_KEY): Request {
+  const headers: Record<string, string> = { 'x-real-ip': '127.0.0.1' };
+  if (key !== null) headers['Authorization'] = `Bearer ${key}`;
+  return new Request('http://localhost/api/v1/admin/catalog-dump', { headers });
+}
+
+describe('GET /api/v1/admin/catalog-dump', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env.ADMIN_API_KEY = VALID_ADMIN_KEY;
+    findMany.mockResolvedValue({ items: [activeItem, inactiveItem], total: 2 });
+  });
+
+  it('Authorization 헤더 없음 → 403', async () => {
+    const { GET } = await import('@/app/api/v1/admin/catalog-dump/route');
+    const res = await GET(makeReq(null));
+    expect(res.status).toBe(403);
+  });
+
+  it('잘못된 키 → 403', async () => {
+    const { GET } = await import('@/app/api/v1/admin/catalog-dump/route');
+    const res = await GET(makeReq('wrong'));
+    expect(res.status).toBe(403);
+  });
+
+  it('유효한 키 → 전체 행을 요약·투영해 반환(200)', async () => {
+    const { GET } = await import('@/app/api/v1/admin/catalog-dump/route');
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(body.data.summary).toMatchObject({
+      total: 2,
+      active: 1,
+      inactive: 1,
+      byVerificationStatus: { verified: 1, broken: 1 },
+    });
+    expect(body.data.items).toHaveLength(2);
+    expect(body.data.items[0]).toMatchObject({
+      id: 'cat-active',
+      name: 'Active API',
+      isActive: true,
+      verificationStatus: 'verified',
+    });
+  });
+
+  it('비활성·전체 행을 위해 빈 필터로 findMany를 호출한다', async () => {
+    const { GET } = await import('@/app/api/v1/admin/catalog-dump/route');
+    await GET(makeReq());
+    expect(findMany).toHaveBeenCalledWith({}, expect.objectContaining({ limit: 500 }));
+  });
+
+  it('auth_config 등 민감 필드를 응답에 노출하지 않는다', async () => {
+    const { GET } = await import('@/app/api/v1/admin/catalog-dump/route');
+    const res = await GET(makeReq());
+    const body = await res.json();
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain('SHOULD_NOT_LEAK');
+    expect(serialized).not.toContain('authConfig');
+    expect(serialized).not.toContain('env_var');
+  });
+});

--- a/src/__tests__/api/admin-catalog-dump.test.ts
+++ b/src/__tests__/api/admin-catalog-dump.test.ts
@@ -99,4 +99,28 @@ describe('GET /api/v1/admin/catalog-dump', () => {
     expect(serialized).not.toContain('authConfig');
     expect(serialized).not.toContain('env_var');
   });
+
+  it('verificationStatus가 없는 행은 null로 투영하고 요약에 집계한다', async () => {
+    const noStatusItem = { ...activeItem, id: 'cat-nostatus', verificationStatus: undefined, verifiedAt: undefined };
+    findMany.mockResolvedValue({ items: [noStatusItem], total: 1 });
+    const { GET } = await import('@/app/api/v1/admin/catalog-dump/route');
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.data.items[0].verificationStatus).toBeNull();
+    expect(body.data.summary.byVerificationStatus).toMatchObject({ null: 1 });
+  });
+
+  it('레포 오류 시 handleApiError로 위임한다(인증 통과 후)', async () => {
+    findMany.mockRejectedValue(new Error('db read fail'));
+    const { GET } = await import('@/app/api/v1/admin/catalog-dump/route');
+    const res = await GET(makeReq());
+    expect(res.status).toBeGreaterThanOrEqual(500);
+  });
+
+  it('OPTIONS 프리플라이트는 204 + CORS 헤더를 반환한다', async () => {
+    const { OPTIONS } = await import('@/app/api/v1/admin/catalog-dump/route');
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get('Access-Control-Allow-Methods')).toContain('GET');
+  });
 });

--- a/src/app/api/v1/admin/catalog-dump/route.ts
+++ b/src/app/api/v1/admin/catalog-dump/route.ts
@@ -1,0 +1,67 @@
+import { createCatalogRepository } from '@/repositories/factory';
+import { adminCorsHeaders, verifyAdminKey, withAdminCors } from '@/lib/utils/adminAuth';
+import { handleApiError, jsonResponse } from '@/lib/utils/errors';
+import type { ApiCatalogItem } from '@/types/api';
+
+// 배포 런타임에서 실행돼야 프로덕션 SQLite(/data/app.db)를 읽는다.
+export const runtime = 'nodejs';
+
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, { status: 204, headers: adminCorsHeaders });
+}
+
+/** auth_config 등 민감 필드를 제외하고 시드 동기화 diff에 필요한 안전한 필드만 투영한다. */
+function projectRow(a: ApiCatalogItem): Record<string, unknown> {
+  return {
+    id: a.id,
+    name: a.name,
+    category: a.category,
+    authType: a.authType,
+    isActive: a.isActive,
+    verificationStatus: a.verificationStatus ?? null,
+    verifiedAt: a.verifiedAt ?? null,
+    deprecatedAt: a.deprecatedAt,
+    successorId: a.successorId,
+    requiresProxy: a.requiresProxy,
+    apiVersion: a.apiVersion,
+  };
+}
+
+/**
+ * GET /api/v1/admin/catalog-dump
+ * 프로덕션 api_catalog 전체 행(활성·비활성 포함)을 시드 동기화 diff용으로 덤프한다.
+ * auth_config 등 민감 필드는 제외한 안전 투영만 반환한다. 읽기 전용.
+ * 관리자 인증 필요(Authorization: Bearer <ADMIN_API_KEY>).
+ */
+export async function GET(request: Request): Promise<Response> {
+  const res = await (async () => {
+    try {
+      verifyAdminKey(request);
+
+      const { items, total } = await createCatalogRepository().findMany(
+        {},
+        { limit: 500, orderBy: 'name', orderDirection: 'asc' },
+      );
+
+      const rows = items.map(projectRow);
+      const summary = {
+        total,
+        active: items.filter((a) => a.isActive).length,
+        inactive: items.filter((a) => !a.isActive).length,
+        byVerificationStatus: items.reduce<Record<string, number>>((acc, a) => {
+          const key = a.verificationStatus ?? 'null';
+          acc[key] = (acc[key] ?? 0) + 1;
+          return acc;
+        }, {}),
+      };
+
+      return jsonResponse({
+        success: true,
+        data: { generatedAt: new Date().toISOString(), summary, items: rows },
+      });
+    } catch (error) {
+      return handleApiError(error);
+    }
+  })();
+  return withAdminCors(res);
+}


### PR DESCRIPTION
## 배경

2026-06-29 전체 잔여 작업 감사의 **Phase 2(카탈로그 시드 재동기화)** 검증 과정에서, 공개 `GET /api/v1/catalog`가 **활성 행만** 반환해 비활성(키 의존) 행을 확인할 수 없는 가시성 공백을 발견.

## Phase 2 검증 결과 (이 PR의 동기)

공개 엔드포인트로 **활성 36행** diff 결과 prod ↔ bundle **완전 동기화**(id·verification_status·name 불일치 0). `verify-catalog`는 활성 행만 갱신 → 비활성 행 drift 불가, `ensureCatalog`가 누락 bundle 행 재삽입(prod ⊇ bundle) → **재동기화 작업 자체가 불필요**함을 확인. 단, 비활성 행 전체 파리티를 직접 검증할 수단이 없어 이 진단 엔드포인트를 추가.

## 변경

- `src/app/api/v1/admin/catalog-dump/route.ts` (신규) — `GET /api/v1/admin/catalog-dump`
  - ADMIN_API_KEY 보호, `runtime=nodejs`, 읽기 전용
  - `findMany({})` 빈 필터로 활성·비활성 전체 조회
  - 응답: `summary(total/active/inactive/byVerificationStatus)` + `items`(안전 투영 — `auth_config` 등 민감 필드 제외)
- `src/__tests__/api/admin-catalog-dump.test.ts` (신규, 5 테스트) — 403/200/빈필터 호출/민감필드 미노출
- `docs/reference/api-endpoints.md`·`CLAUDE.md` — 엔드포인트 문서화

## 검증

- 테스트 5건 통과, `pnpm lint`(해당 파일)·`pnpm type-check` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)