### PR TITLE
fix: P1 프로덕션 결함 3건 — 비root 실행 복원 · 모델 허용목록 · XFF 최우측 IP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ AI 기반 노코드 플랫폼. 무료 API를 선택하고 서비스를 설명하
 | Form | React Hook Form + Zod |
 | Database | 임베디드 SQLite (better-sqlite3 + drizzle-orm, WAL · Railway Volume `/data/app.db`) |
 | Auth | Auth.js v5 (Credentials + JWT 무상태) — 공개 셀프서비스 회원가입, DB 사용자별 scrypt 인증, 이메일 인증 게이트 |
-| AI | Claude API (Anthropic SDK, claude-opus-4-7 기본, 조건부 Extended Thinking) |
+| AI | Claude API (Anthropic SDK, claude-opus-4-8 기본, 조건부 Extended Thinking) |
 | Testing | Vitest, happy-dom, MSW |
 | CI/CD | GitHub Actions → lint → type-check → test → build → deploy |
 | Package Manager | pnpm |
@@ -136,7 +136,9 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 - `GITHUB_TOKEN`, `RAILWAY_TOKEN` — 배포용
 - `MAX_APIS_PER_PROJECT`, `MAX_DAILY_GENERATIONS` 등 제한 설정
 - `AI_MODEL_SUGGESTION` — 추천용 모델 (기본: `claude-haiku-4-5`)
-- `AI_MODEL_GENERATION` — 코드 생성 모델 (기본: `claude-opus-4-7`, Sonnet 폴백: `claude-sonnet-4-6`)
+- `AI_MODEL_GENERATION` — 코드 생성 모델 (기본: `claude-opus-4-8`, Sonnet 폴백: `claude-sonnet-4-6`)
+- `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN` / `SLACK_WEBHOOK_URL` — 에러·알림 sink. **셋 다 미설정이면 프로덕션에 활성 에러 sink가 없다**(Sentry `enabled:false`, `sendSlackAlert` no-op) → `errorRateMonitor` 알림이 유실된다
+- `LOG_LEVEL` — 로그 상세도 (`debug`/`info`/`warn`/`error`, 기본 `info`)
 - `ET_COMPLEXITY_THRESHOLD` — Extended Thinking 활성화 임계값 (기본: 35점, `evaluateComplexityScore()` 결과 비교)
 - `QUALITY_LOOP_ITERATION_TIMEOUT_MS` — Quality Loop 반복당 타임아웃 (기본: 120000ms = 120초)
 - `QUALITY_LOOP_ET_ITERATION_TIMEOUT_MS` — ET 활성화 시 Quality Loop 반복당 타임아웃 (기본: 200000ms = 200초). ET 응답이 최대 150초 소요되므로 일반 타임아웃(`QUALITY_LOOP_ITERATION_TIMEOUT_MS`)과 별도 설정
@@ -214,6 +216,16 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 - 수정한 함수/파일을 호출하는 모든 경로를 나열하고 각각 검증
 - 단일 파일만 보고 끝내지 않고 cross-cutting concern(미들웨어, 공통 함수) 영향 확인
 
+### railway.toml `startCommand` 금지 (비root 실행 유지)
+- Railway는 **Dockerfile 배포에서 `startCommand`로 이미지의 `ENTRYPOINT`를 덮어쓴다**([공식 문서](https://docs.railway.com/deployments/start-command): *"the start command overrides the image's ENTRYPOINT in exec form"*)
+- `startCommand`를 지정하면 `Dockerfile`의 `/docker-entrypoint.sh`(→ `chown /data` + `su-exec nextjs:nodejs`)가 실행되지 않아 **컨테이너가 root로 뜬다**. Dockerfile에 `USER` 지시자가 없는 이유는 마운트 볼륨 쓰기 크래시 때문(의도적)
+- 기동 명령을 바꿔야 하면 `startCommand`가 아니라 `docker-entrypoint.sh`의 `exec su-exec ...` 줄을 고칠 것
+- 2026-07-10 수정 이력: `startCommand = "node server.js"` 제거로 비root 실행 복원
+
+### 클라이언트 IP 도출 규칙 (레이트리밋)
+- `x-forwarded-for`는 **최우측** 항목만 신뢰한다. 최좌측은 클라이언트가 위조할 수 있어 per-IP 리밋이 무력화된다
+- 단일 출처: `getClientIp()`(`src/lib/auth/rateLimit.ts`) — `adminAuth.verifyAdminKey()`와 동일 규칙. 새 리밋을 추가할 때 XFF를 직접 파싱하지 말 것
+
 ### QC 프로세스 (생성/재생성 공통)
 - **상세 절차**: [docs/guides/qc-process.md](docs/guides/qc-process.md) 참조 (8단계 표준 프로세스)
 - **파이프라인 설계**: [docs/architecture/ai-pipeline.md](docs/architecture/ai-pipeline.md) 참조 (3단계 Stage + Quality Loop)
@@ -247,7 +259,8 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 ## 타입 주의사항
 
 - `IAiProvider.tokensUsed` — `{ input: number; output: number }` 구조 (`inputTokens`/`outputTokens` 아님)
-- **Anthropic 모델 ID 주의**: 4.x 모델은 날짜 suffix 없이 사용 — `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-opus-4-7`. 날짜 포함 ID(예: `claude-haiku-4-5-20251001`)는 404 반환 확인됨
+- **Anthropic 모델 ID 주의**: 4.x 모델은 날짜 suffix 없이 사용 — `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-opus-4-7`, `claude-opus-4-8`. 날짜 포함 ID(예: `claude-haiku-4-5-20251001`)는 404 반환 확인됨
+- **모델 허용목록은 조용히 폴백한다**: `AI_MODEL_*` env가 `ALLOWED_CLAUDE_MODELS`(`AiProviderFactory.ts`)에 없으면 `logger.warn` 한 줄만 남기고 `TASK_DEFAULTS`로 폴백한다. 즉 **Railway env에 새 모델을 넣는 것만으로는 적용되지 않으며** 허용목록도 함께 고쳐야 한다. (2026-07-10: env가 `claude-opus-4-8`인데 허용목록에 없어 `opus-4-7`로 폴백 중이던 것을 발견·수정)
 - `AiProviderFactory.ts` 모델 ID 수정 시 `.test.ts`도 반드시 동시에 업데이트 (CI 파손 방지)
 - **JSON 필드명 이중성**: `parseEndpoints()`(`@/repositories/utils/endpointParser`, `SqliteCatalogRepository`가 사용) 같은 JSON 매퍼는 snake_case(`example_call`)와 camelCase(`exampleCall`) 둘 다 처리 필요 — 시드 JSON 직접 삽입 vs 코드 경로 차이
 - **Playwright 병렬 체크 주의**: 단일 `page` 인스턴스에서 `Promise.allSettled` 사용 시 viewport를 변경하는 체크는 반드시 다른 체크 완료 후 순차 실행 (`renderingQc.ts` 참고)

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -54,8 +54,8 @@ DB 어댑터 없는 JWT 무상태 세션. 공개 셀프서비스 회원가입, D
 |------|------|---------|------|
 | `ANTHROPIC_API_KEY` | ✅ | ✅ | Claude API 키 |
 | `AI_PROVIDER` | 선택 | ➖ | AI Provider 선택. 현재 허용값은 `claude` 하나뿐 (기본). 그 외 값 설정 시 `AiProviderFactory.create()`가 `Unknown AI provider` 에러를 던짐. 코드 위치: `src/providers/ai/AiProviderFactory.ts` |
-| `AI_MODEL_SUGGESTION` | 선택 | ➖ | 컨텍스트 추천용 모델 (기본: `claude-haiku-4-5`). 허용값: `claude-haiku-4-5` · `claude-sonnet-4-6` · `claude-opus-4-6` · `claude-opus-4-7` |
-| `AI_MODEL_GENERATION` | 선택 | ➖ | 코드 생성용 모델 (기본: `claude-opus-4-7`). 허용값 동일. **주의**: 날짜 suffix 포함 ID(예: `claude-haiku-4-5-20251001`)는 Anthropic 404 반환 |
+| `AI_MODEL_SUGGESTION` | 선택 | ✅ `claude-haiku-4-5` | 컨텍스트 추천용 모델 (기본: `claude-haiku-4-5`). 허용값: `claude-haiku-4-5` · `claude-sonnet-4-6` · `claude-opus-4-6` · `claude-opus-4-7` · `claude-opus-4-8` |
+| `AI_MODEL_GENERATION` | 선택 | ✅ `claude-opus-4-8` | 코드 생성용 모델 (기본: `claude-opus-4-8`). 허용값 동일. **허용목록(`ALLOWED_CLAUDE_MODELS`)에 없는 값을 넣으면 경고 로그만 남기고 조용히 기본값으로 폴백**하므로, 모델 추가 시 `src/providers/ai/AiProviderFactory.ts`를 함께 수정할 것. **주의**: 날짜 suffix 포함 ID(예: `claude-haiku-4-5-20251001`)는 Anthropic 404 반환 |
 | `ET_COMPLEXITY_THRESHOLD` | 선택 | ➖ | Extended Thinking 활성화 복잡도 임계값 (기본: `35`). 0-100 점수 중 이 값 이상이면 ET 활성화. **빈 문자열 또는 0 이하 값 설정 시 기본값 35로 폴백** |
 
 ---
@@ -97,14 +97,21 @@ DB 어댑터 없는 JWT 무상태 세션. 공개 셀프서비스 회원가입, D
 
 ## 모니터링
 
+> ⚠️ **현재 프로덕션에는 활성 에러·알림 sink가 없다.** `SENTRY_DSN`·`NEXT_PUBLIC_SENTRY_DSN`·`SLACK_WEBHOOK_URL`이 모두 미설정이라
+> Sentry는 `enabled: false`로 부팅하고(`sentry.{server,client,edge}.config.ts`), `sendSlackAlert()`는 경고 로그만 남기고 반환한다.
+> 결과적으로 `errorRateMonitor`가 감지하는 **코드 생성 실패율 임계값 초과 알림이 아무 곳에도 전달되지 않는다.**
+> 실사용자 서비스이므로 최소 하나(Sentry DSN 또는 Slack Webhook)는 설정할 것을 권장한다.
+
 | 변수 | 필수 | Railway | 설명 |
 |------|------|---------|------|
-| `SENTRY_DSN` | 선택 | ❌ | Sentry 에러 수집 DSN (미설정 시 비활성화) |
+| `SENTRY_DSN` | 선택 | ❌ | Sentry 서버·edge 런타임 에러 수집 DSN. 미설정 시 `enabled: false`로 비활성화 |
+| `NEXT_PUBLIC_SENTRY_DSN` | 선택 | ❌ | Sentry **브라우저** 런타임 DSN (`sentry.client.config.ts`). 서버용 `SENTRY_DSN`과 별개로 설정해야 클라이언트 에러가 수집된다 |
 | `SENTRY_ORG` | 선택 | ❌ | Sentry 조직 슬러그 (소스맵 업로드용) |
 | `SENTRY_PROJECT` | 선택 | ❌ | Sentry 프로젝트 슬러그 |
 | `SENTRY_AUTH_TOKEN` | 선택 | ❌ | Sentry 소스맵 업로드 토큰 |
 | `SLACK_WEBHOOK_URL` | 선택 | ❌ | Slack 알림 Webhook URL. 미설정 시 알림 스킵. `slackAlert()` + `errorRateMonitor`에서 사용 |
 | `ERROR_RATE_ALERT_THRESHOLD` | 선택 | ➖ | 코드 생성 실패율 알림 임계값 (기본: `5`). 5분 윈도우 내 `CODE_GENERATION_FAILED` 횟수가 이 값 이상이면 Slack 알림 1회 발송 (윈도우 내 중복 알림 방지). 인메모리·단일 인스턴스 전제. 코드 위치: `src/lib/monitoring/errorRateMonitor.ts` |
+| `LOG_LEVEL` | 선택 | ➖ | 로그 상세도 임계값 (`debug`/`info`/`warn`/`error`, 기본 `info`). 이 값보다 낮은 레벨은 출력하지 않는다. 코드 위치: `src/lib/utils/logger.ts` |
 
 ---
 

--- a/railway.toml
+++ b/railway.toml
@@ -5,6 +5,9 @@ dockerfilePath = "Dockerfile"
 [deploy]
 healthcheckPath = "/api/v1/health"
 healthcheckTimeout = 300
-startCommand = "node server.js"
+# startCommand를 두지 않는다. Railway는 Dockerfile 배포에서 startCommand로 이미지의 ENTRYPOINT를
+# 덮어쓰므로(docs.railway.com/deployments/start-command), 값을 지정하면 /docker-entrypoint.sh의
+# `chown /data` + `su-exec nextjs:nodejs` 권한 강하가 통째로 건너뛰어져 컨테이너가 root로 실행된다.
+# ENTRYPOINT가 동일하게 `node server.js`를 실행하므로 생략해도 기동 동작은 같다.
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3

--- a/src/lib/auth/rateLimit.test.ts
+++ b/src/lib/auth/rateLimit.test.ts
@@ -8,11 +8,30 @@ describe('rateLimit', () => {
     expect(checkRateLimit(key, 2, 60_000)).toBe(true);
     expect(checkRateLimit(key, 2, 60_000)).toBe(false);
   });
-  it('getClientIp는 x-forwarded-for 첫 IP', () => {
+  it('getClientIp는 x-forwarded-for 최우측 IP(마지막 프록시가 덧붙인 값)를 사용한다', () => {
     const req = new Request('https://x', { headers: { 'x-forwarded-for': '1.2.3.4, 5.6.7.8' } });
-    expect(getClientIp(req)).toBe('1.2.3.4');
+    expect(getClientIp(req)).toBe('5.6.7.8');
   });
-  it('getClientIp는 x-forwarded-for 헤더 없을 시 "unknown" 반환', () => {
+  it('getClientIp는 클라이언트가 위조한 최좌측 XFF 항목을 신뢰하지 않는다', () => {
+    // 공격자가 매 요청마다 다른 최좌측 값을 넣어도 레이트리밋 키가 갈라지면 안 된다.
+    const forge = (spoofed: string) =>
+      new Request('https://x', { headers: { 'x-forwarded-for': `${spoofed}, 203.0.113.9` } });
+    expect(getClientIp(forge('1.1.1.1'))).toBe('203.0.113.9');
+    expect(getClientIp(forge('2.2.2.2'))).toBe('203.0.113.9');
+  });
+  it('getClientIp는 단일 항목 XFF를 그대로 반환한다', () => {
+    const req = new Request('https://x', { headers: { 'x-forwarded-for': '203.0.113.9' } });
+    expect(getClientIp(req)).toBe('203.0.113.9');
+  });
+  it('getClientIp는 XFF가 없으면 x-real-ip로 폴백한다', () => {
+    const req = new Request('https://x', { headers: { 'x-real-ip': '198.51.100.7' } });
+    expect(getClientIp(req)).toBe('198.51.100.7');
+  });
+  it('getClientIp는 XFF가 빈 문자열이면 x-real-ip로 폴백한다', () => {
+    const req = new Request('https://x', { headers: { 'x-forwarded-for': '', 'x-real-ip': '198.51.100.7' } });
+    expect(getClientIp(req)).toBe('198.51.100.7');
+  });
+  it('getClientIp는 어떤 헤더도 없을 시 "unknown" 반환', () => {
     const req = new Request('https://x');
     expect(getClientIp(req)).toBe('unknown');
   });

--- a/src/lib/auth/rateLimit.ts
+++ b/src/lib/auth/rateLimit.ts
@@ -18,9 +18,16 @@ export function checkRateLimit(key: string, limit: number, windowMs: number): bo
   return true;
 }
 
-/** 프록시(Railway) 뒤 클라이언트 IP. x-forwarded-for 첫 항목. */
+/**
+ * 프록시(Railway) 뒤 클라이언트 IP.
+ *
+ * x-forwarded-for의 **최우측** 항목만 신뢰한다. 최좌측은 클라이언트가 임의로 위조할 수 있어
+ * per-IP 레이트리밋(미인증 signup·forgot-password의 이메일 발송 한도)을 무력화한다.
+ * 신뢰 경계인 마지막 프록시가 덧붙인 값이 최우측이다. adminAuth.verifyAdminKey와 동일 규칙.
+ */
 export function getClientIp(request: Request): string {
   const xff = request.headers.get('x-forwarded-for');
-  if (xff) return xff.split(',')[0]!.trim();
-  return 'unknown';
+  const rightmost = xff?.split(',').at(-1)?.trim();
+  if (rightmost) return rightmost;
+  return request.headers.get('x-real-ip')?.trim() || 'unknown';
 }

--- a/src/lib/utils/adminAuth.ts
+++ b/src/lib/utils/adminAuth.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import { getClientIp } from '@/lib/auth/rateLimit';
 import { ForbiddenError } from '@/lib/utils/errors';
 import { LRUMap } from '@/lib/utils/lruMap';
 import {
@@ -49,13 +50,8 @@ export function withAdminCors(response: Response): Response {
 }
 
 export function verifyAdminKey(request: Request): void {
-  // Rate limit check first
-  const forwarded = request.headers.get('x-forwarded-for');
-  const ip =
-    (forwarded ? forwarded.split(',').at(-1)?.trim() : null) ??
-    request.headers.get('x-real-ip') ??
-    'unknown';
-  checkRateLimit(ip);
+  // Rate limit check first. IP 도출은 getClientIp 단일 출처를 사용한다(XFF 최우측 — 위조 방지).
+  checkRateLimit(getClientIp(request));
 
   const header = request.headers.get('Authorization');
   if (!header?.startsWith('Bearer ')) {

--- a/src/providers/ai/AiProviderFactory.test.ts
+++ b/src/providers/ai/AiProviderFactory.test.ts
@@ -7,7 +7,7 @@ vi.mock('./ClaudeProvider', () => ({
   ClaudeProvider: vi.fn(function(_apiKey: string, model?: string) {
     return {
       name: 'claude',
-      model: model ?? 'claude-opus-4-7',
+      model: model ?? 'claude-opus-4-8',
       generateCode: vi.fn(),
       generateCodeStream: vi.fn(),
       checkAvailability: vi.fn().mockResolvedValue({ available: true }),
@@ -74,7 +74,7 @@ describe('AiProviderFactory.createForTask()', () => {
     process.env.ANTHROPIC_API_KEY = 'test-key';
     delete process.env.AI_PROVIDER;
     const provider = AiProviderFactory.createForTask('generation');
-    expect(provider.model).toBe('claude-opus-4-7');
+    expect(provider.model).toBe('claude-opus-4-8');
   });
 
   it('suggestion 태스크는 Haiku 모델을 사용한다', () => {
@@ -138,7 +138,21 @@ describe('AiProviderFactory.createForTask()', () => {
     process.env.ANTHROPIC_API_KEY = 'test-key';
     delete process.env.AI_MODEL_GENERATION;
     const provider = AiProviderFactory.createForTask('generation');
-    expect(provider.model).toBe('claude-opus-4-7');
+    expect(provider.model).toBe('claude-opus-4-8');
+  });
+
+  it('AI_MODEL_GENERATION=claude-opus-4-8은 허용목록에 있어 그대로 사용된다', () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    process.env.AI_MODEL_GENERATION = 'claude-opus-4-8';
+    const provider = AiProviderFactory.createForTask('generation');
+    expect(provider.model).toBe('claude-opus-4-8');
+  });
+
+  it('허용되지 않은 generation 모델은 기본값(opus-4-8)으로 폴백한다', () => {
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    process.env.AI_MODEL_GENERATION = 'claude-opus-4-8-20260101';
+    const provider = AiProviderFactory.createForTask('generation');
+    expect(provider.model).toBe('claude-opus-4-8');
   });
 
   it('모델이 다르면 다른 인스턴스를 반환한다', () => {

--- a/src/providers/ai/AiProviderFactory.ts
+++ b/src/providers/ai/AiProviderFactory.ts
@@ -5,12 +5,18 @@ import { ClaudeProvider } from './ClaudeProvider';
 export type AiProviderType = 'claude';
 export type AiTaskType = 'generation' | 'suggestion';
 
-const ALLOWED_CLAUDE_MODELS = ['claude-haiku-4-5', 'claude-sonnet-4-6', 'claude-opus-4-6', 'claude-opus-4-7'] as const;
+const ALLOWED_CLAUDE_MODELS = [
+  'claude-haiku-4-5',
+  'claude-sonnet-4-6',
+  'claude-opus-4-6',
+  'claude-opus-4-7',
+  'claude-opus-4-8',
+] as const;
 type AllowedClaudeModel = (typeof ALLOWED_CLAUDE_MODELS)[number];
 
 const TASK_DEFAULTS: Record<AiTaskType, AllowedClaudeModel> = {
   suggestion: 'claude-haiku-4-5',
-  generation: 'claude-opus-4-7',
+  generation: 'claude-opus-4-8',
 };
 
 const TASK_ENV_VARS: Record<AiTaskType, string> = {


### PR DESCRIPTION
## 배경

전체 잔여작업 감사(8축 병렬 스윕 → 항목별 2렌즈 반증 검증 → 독립 재현 2회)에서 **프로덕션에 실제 영향을 주는 것으로 확정된 3건**을 수정합니다. 나머지 확정 항목(위생 P2, 문서 drift P3)은 후속 PR로 분리합니다.

## 변경 사항

### 1. `railway.toml` — 컨테이너 비root 실행 복원 🔴

Railway는 Dockerfile 배포에서 `startCommand`로 이미지의 `ENTRYPOINT`를 **덮어씁니다**.

> [Railway 공식 문서](https://docs.railway.com/deployments/start-command): *"**Dockerfile / Image**: the start command overrides the image's `ENTRYPOINT` in exec form."*

따라서 `startCommand = "node server.js"`가 있는 동안 `Dockerfile`의 `ENTRYPOINT ["/docker-entrypoint.sh"]`가 실행되지 않았고, 그 안의

```sh
chown -R nextjs:nodejs /data
exec su-exec nextjs:nodejs node server.js
```

권한 강하가 **한 번도 수행되지 않아 프로덕션 컨테이너가 root(uid 0)로 동작**했습니다. Dockerfile에 `USER` 지시자가 없는 것은 마운트 볼륨 쓰기 크래시(컷오버 사고)를 피하기 위한 의도적 설계라, 다른 방어선도 없었습니다.

`startCommand`를 제거하면 ENTRYPOINT가 살아나 동일하게 `node server.js`를 실행하므로 **기동 동작은 불변**이고, 권한 강하만 복원됩니다.

### 2. `AiProviderFactory` — `claude-opus-4-8` 허용목록 추가 🔴

Railway env `AI_MODEL_GENERATION=claude-opus-4-8`이 `ALLOWED_CLAUDE_MODELS`에 없어 `logger.warn` 한 줄만 남기고 **조용히 `claude-opus-4-7`로 폴백**하고 있었습니다. 운영자가 지정한 모델이 실제 코드 생성에 쓰이지 않던 상태입니다.

- `ALLOWED_CLAUDE_MODELS`에 `claude-opus-4-8` 추가
- `TASK_DEFAULTS.generation`도 `claude-opus-4-8`로 정렬 → env를 지워도 조용히 다운그레이드되지 않음

> ⚠️ **비용 영향**: 머지·배포 후부터 실제로 opus-4-8 단가가 적용됩니다(현재는 4-7로 폴백 중이라 4-7 단가). 의도된 변경입니다.

### 3. `getClientIp` — XFF 최좌측 → 최우측 🔴

`x-forwarded-for`의 최좌측 항목은 클라이언트가 임의로 위조할 수 있습니다. 이 값을 소비하던 **미인증 엔드포인트의 per-IP 이메일 발송 리밋이 헤더 조작만으로 무제한 우회**됐습니다.

- `POST /api/v1/auth/signup` (5회 리밋)
- `POST /api/v1/auth/forgot-password` (5회 리밋)

신뢰 경계인 마지막 프록시가 덧붙인 **최우측** 값만 신뢰하도록 수정했습니다. `adminAuth.verifyAdminKey`는 이미 `.at(-1)`로 고쳐져 있었으므로, 상충하던 회귀를 정리하고 **인라인 XFF 파싱도 `getClientIp` 단일 출처로 통합**했습니다.

부수 개선: 공백만 있는 XFF(`"   "`)에서 빈 문자열 IP가 나오던 엣지케이스가 제거되어 `x-real-ip`로 올바르게 폴백합니다.

## 문서

- **CLAUDE.md**: `railway.toml startCommand` 금지 규칙(배포 품질 원칙), 클라이언트 IP 도출 단일 출처 규칙, 모델 허용목록의 조용한 폴백 주의를 추가
- **env-vars.md**: `AI_MODEL_*` 허용값·실제 Railway 값 반영, 누락돼 있던 `NEXT_PUBLIC_SENTRY_DSN`·`LOG_LEVEL` 추가, 그리고 **현재 프로덕션에 활성 에러/알림 sink가 없다**는 경고 명시(`SENTRY_DSN`·`NEXT_PUBLIC_SENTRY_DSN`·`SLACK_WEBHOOK_URL` 모두 미설정 → Sentry `enabled:false` + `sendSlackAlert` no-op → `errorRateMonitor` 알림 유실)

## 검증

| 항목 | 결과 |
|------|------|
| `pnpm type-check` | ✅ 통과 |
| `pnpm lint` | ✅ 0 errors (기존 warning 2건, 본 변경과 무관) |
| `pnpm test` | ✅ **165 파일 / 1,993 테스트 전부 통과** (신규 6건 추가) |
| `pnpm build` | ✅ 성공 |

신규 테스트: 최우측 IP 채택, 최좌측 위조 무시(공격자가 매 요청 다른 값을 넣어도 리밋 키 고정), 단일 항목 XFF, `x-real-ip` 폴백, 빈 XFF 폴백, `claude-opus-4-8` 허용/폴백.

## 배포 시 확인

1. 머지 → Railway 자동 배포 → `/api/v1/health` 200
2. **비root 확인**: 배포 로그에 `/data` 권한 오류가 없어야 함(엔트리포인트가 `chown` 후 강하). SQLite 쓰기·백업(`SQLite backup written`)이 계속 동작하는지 확인
3. 생성 1건 실행 → 저장된 `ai_model`이 `claude-opus-4-8`인지 확인
4. 정상 확인 후 `git tag deploy/YYYY-MM-DD-HHmm && git push origin --tags`

> ⚠️ 3번 항목(비root 전환)은 `/data` 소유권이 root → `nextjs`로 바뀌는 첫 배포입니다. 엔트리포인트의 `chown -R nextjs:nodejs /data`가 이를 처리하지만, 볼륨이 크면 첫 기동이 다소 느려질 수 있습니다.

## 후속 (별도 PR)

- **P1 잔여(사용자 작업)**: `SENTRY_DSN` 또는 `SLACK_WEBHOOK_URL` 설정 — 값 발급이 필요해 코드로 해결 불가
- **P2 위생**: 죽은 코드·의존성 제거(`featureSmokeTest`, `react-hook-form` 외 4종 등), 무한 증가 테이블 3종 보존정책, `sonarcloud-github-action` 이관, `health?detailed` 인증 통일, `user-api-keys`·`regenerate` 라우트 테스트, 죽은 Supabase 시크릿 폐기
- **P3 문서**: 컷오버·다중사용자 전환 미반영 문서 일괄 정정(`incident-response.md` 최우선)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
