### PR TITLE
fix: 게시 사이트 프록시 복구 및 인가 모델 정비 (C-1·C-2·H-1·H-2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,8 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 | 보안 인시던트 대응 절차 | [docs/security/incident-response.md](docs/security/incident-response.md) |
 | **의존성 감사 면제 목록 (pnpm audit 게이트 waiver)** | [docs/security/audit-waivers.md](docs/security/audit-waivers.md) |
 | 의존성 보안 일괄 상향·감사 게이트 2단계화 ADR (2026-07-28) | [docs/decisions/2026-07-28-dependency-security-updates.md](docs/decisions/2026-07-28-dependency-security-updates.md) |
+| **게시 사이트 프록시 복구·인가 모델 정비 ADR (C-1·C-2·H-1·H-2, 2026-07-28)** | [docs/decisions/2026-07-28-published-site-proxy-authz.md](docs/decisions/2026-07-28-published-site-proxy-authz.md) |
+| 게시 사이트 프록시 설계 spec | [docs/superpowers/specs/2026-07-28-published-site-proxy-authz-design.md](docs/superpowers/specs/2026-07-28-published-site-proxy-authz-design.md) |
 | better-sqlite3 v13 N-API 프리빌트 전환·빌드 툴체인 제거 ADR (2026-07-28) | [docs/decisions/2026-07-28-better-sqlite3-v13-napi-prebuilds.md](docs/decisions/2026-07-28-better-sqlite3-v13-napi-prebuilds.md) |
 | 환경변수 목록 | [docs/reference/env-vars.md](docs/reference/env-vars.md) |
 | 에러 클래스 참조 | [docs/reference/error-codes.md](docs/reference/error-codes.md) |
@@ -214,6 +216,8 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 - 미리보기, 게시(직접), 게시(서브도메인) 3가지 경로 모두 추적
 - assembleHtml() 변경 시 CSS/JS 누락 여부 확인
 - "A에서는 되지만 B에서는 안 된다" 같은 경로별 차이가 없어야 함
+- **서브도메인 rewrite 예외**: `src/middleware.ts`의 `SUBDOMAIN_PASSTHROUGH_PREFIXES`에 있는 경로만 `/site/{slug}` rewrite를 건너뛴다. 게시 사이트의 생성 JS가 상대경로 `/api/v1/proxy`로 호출하므로 이 예외가 없으면 API 데이터가 전부 404가 된다(미리보기는 apex라 정상 동작해 드러나지 않음 — 2026-07-28 실측 발견). 새 경로 추가 시 최소 노출 원칙 유지
+- **프록시 인가는 `resolveProxyContext()` 단일 진입점**: site(익명·Host 바인딩)/app(세션·소유권 강제) 판정이 이 한 곳에 있다. 라우트에 인가 분기를 새로 만들지 말 것 — 판단이 흩어져 개인 키 해석부가 소유권을 확인하지 않던 것이 H-1이었다. 소유권은 `assertOwner` 재사용, Host로 프로젝트가 확정되면 클라이언트 `projectId`는 무시. 배경: [ADR](docs/decisions/2026-07-28-published-site-proxy-authz.md)
 
 ### 코드 수정 후
 - 수정한 함수/파일을 호출하는 모든 경로를 나열하고 각각 검증

--- a/docs/decisions/2026-07-28-published-site-proxy-authz.md
+++ b/docs/decisions/2026-07-28-published-site-proxy-authz.md
@@ -1,0 +1,177 @@
+# 게시 사이트 프록시 복구 및 인가 모델 정비 (2026-07-28)
+
+## 상태
+
+승인됨 — 구현 완료
+
+## 배경
+
+전체 검수(Claude 독립 검증 + Grok 독립 감사 + 상호 반박 라운드)로 13건을 확정했고,
+그중 **제품 핵심 기능이 동작하지 않는 CRITICAL 2건과 인가 결함 HIGH 2건**을 이 ADR의
+범위로 삼았다. MEDIUM 7건은 검증된 목록으로 남겨 다음 라운드에서 처리한다.
+
+| ID | 심각도 | 내용 |
+|----|--------|------|
+| C-1 | critical | 게시 서브도메인에서 `/api/*`가 404 — 미들웨어가 전 경로를 `/site/{slug}`로 rewrite |
+| C-2 | critical | 프록시가 세션을 요구 — 익명 방문자는 401 |
+| H-1 | high | 프록시 `projectId`에 소유권 검사 없음 — 타인의 개인 API 키 사용 가능 |
+| H-2 | high | 일회성 토큰이 원자적으로 소비되지 않음 — 재설정 링크 재사용 가능 |
+
+### C-1 프로덕션 실측
+
+```
+GET https://xzawed.xyz/api/v1/proxy?…            → 401   (라우트 도달, 인증 요구)
+GET https://testprobe.xzawed.xyz/api/v1/proxy?…  → 404   (rewrite되어 라우트 미매칭)
+```
+
+생성 프롬프트는 CORS 때문에 직접 외부 URL 호출을 금지하고 상대경로 프록시만 허용한다.
+따라서 **API를 사용하는 게시 사이트는 전부 데이터 로딩에 실패**했다.
+
+### 왜 지금까지 드러나지 않았는가
+
+미리보기는 apex 도메인에서 서빙되어 정상 동작했고, 게시된 사이트가 아직 없었다.
+"미리보기에서 되니까 게시도 되겠지"라는 가정이 검증되지 않은 채로 남아 있었다.
+
+## 결정
+
+### 1. 미들웨어 — 프록시 경로만 rewrite 예외
+
+`SUBDOMAIN_PASSTHROUGH_PREFIXES = ['/api/v1/proxy']`. 패스스루는 rewrite를 건너뛰고
+일반 응답 경로로 흘러가 보안 헤더가 적용되고 `isApi` 판정으로 CSP는 건너뛴다(이중 적용 방지).
+
+`/api/*` 전체를 열지 않은 이유: 세션 쿠키가 `__Host-` 프리픽스라 호스트 전용이므로
+생성 사이트가 방문자 세션을 탈취할 수는 없지만(실측 확인), 불필요한 엔드포인트를
+서브도메인에 노출할 이유가 없다.
+
+### 2. `resolveProxyContext()` — 인가 판단 단일 진입점
+
+인증·인가 판단이 `validateRequest`와 `resolveApiKey` 두 곳에 흩어져 있었고, 개인 키
+해석부가 소유권을 확인하지 않아 H-1이 발생했다. 판단을 한 모듈로 모은다.
+
+| # | 조건 | 결과 |
+|---|------|------|
+| 1 | Host가 `{slug}.{ROOT_DOMAIN}` + `isValidSlug` | slug로 프로젝트 조회 → published면 **site**, 아니면 404 |
+| 2 | apex + 유효 세션(`typeof user.id === 'string'`) | **app** 모드 |
+| 3 | apex + 세션 없음 + published `projectId` | **site** 모드 |
+| 4 | 그 외 | 401 |
+
+3번은 apex의 `/site/{slug}` 직접 서빙 경로 때문에 필요하다. 빼면 "서브도메인에선 되고
+직접 게시 URL에선 안 되는" 경로별 분기가 생긴다.
+
+**Host 우선 원칙** — Host로 프로젝트가 확정되면 클라이언트가 보낸 `projectId`는 무시한다.
+사용자 입력이 인가 근거가 되지 않게 한다.
+
+### 3. 인가 규칙
+
+| 모드 | 프로젝트 출처 | apiId 검사 | 키 출처 | 레이트리밋 |
+|------|---------------|-----------|---------|-----------|
+| site | Host slug(우선) 또는 published `projectId` | `apiId ∈ project_apis` 강제 | 플랫폼 키 또는 **그 프로젝트 오너** 키 | IP + projectId |
+| app | 클라이언트 `projectId` + **`assertOwner`** | 동일 강제 | 플랫폼 키 또는 **호출자 본인** 키 | userId (기존) |
+
+소유권은 프록시 전용 비교식을 만들지 않고 기존 `assertOwner`를 재사용한다 — 규약이
+갈라지면 H-1이 재발한다.
+
+**인가 조회 실패는 fail-closed.** 폴백해서 진행하면 소유권을 확인하지 못한 채 키를 쓰게
+된다(H-1의 실패 양상). 통제되지 않은 500 대신 명시적 404로 막는다.
+
+### 4. 익명 사이트 레이트리밋
+
+게시 사이트는 오너의 개인 키로 업스트림을 호출하므로 이 리미터가 타인 키 소진을 막는
+유일한 경계다. 별도 버킷으로 분리했다.
+
+기존 프록시 리미터의 **LRUMap eviction 패턴을 의도적으로 피했다** — 용량 초과 시 활성
+윈도의 카운터가 통째로 사라져 다음 요청이 count:1로 시작, 한도를 우회할 수 있다(M-6).
+신규 리미터는 만료 버킷만 정리하고, 자리가 없으면 살아 있는 카운터를 버리는 대신
+차단한다(우회보다 과차단이 안전).
+
+### 5. M-4 가드레일 — 개인 키 응답은 캐시하지 않는다
+
+`buildCacheKey`는 `apiId:proxyPath:params`뿐이라 키 신원이 들어가지 않는다. 지금까지는
+캐시 대상이 공개 키리스 API뿐이라 잠복 상태였지만, **익명 호출자가 오너의 개인 키로
+업스트림을 호출**하게 되면서 같은 캐시 항목이 테넌트를 넘나들 위험이 실재화됐다.
+
+이번 변경이 만드는 위험이므로 여기서 닫는다 — 캐시 키에 소유자를 넣는 대신 개인 키
+경로는 캐시를 건너뛴다(가장 단순하고 안전). 캐시 판정이 `usedPersonalKey`에 의존하므로
+키 해석을 캐시 조회보다 앞으로 옮겼다.
+
+### 6. 토큰 원자적 소비
+
+조회 → `await` → 소비 2단계였고 `consume`은 `WHERE id`만 검사했다. 단일 문으로 대체한다.
+
+```sql
+UPDATE auth_tokens SET consumed_at = ?
+ WHERE token_hash = ? AND type = ? AND consumed_at IS NULL AND expires_at > ?
+RETURNING user_id
+```
+
+2단계로 되돌아갈 여지를 없애기 위해 기존 `findValidByHash`·`consume`은 인터페이스에서
+제거했다.
+
+## 명시적 트레이드오프
+
+site 모드는 결과적으로 **published `projectId`를 아는 사람은 누구나 그 오너의 키로
+업스트림 호출을 트리거할 수 있다**는 뜻이다. 게시된 사이트 자체가 공개이므로 노출 수준은
+동일하지만, **레이트리밋이 유일한 방어선**이 된다. Origin/Referer 바인딩이 없어 봇이
+서버에서 직접 호출할 수 있으므로, 실질 상한은 프로젝트 전역 버킷(기본 120/분)이다.
+
+사용자 승인된 정책("허용 + 강한 레이트리밋")이며, Host 바인딩을 우선 적용해 방어 심도를 더했다.
+운영 시 프로젝트 전역 버킷 소진을 모니터링 지표로 삼을 것.
+
+| 상수 | 기본값 | 의미 |
+|------|--------|------|
+| `SITE_PROXY_RATE_LIMIT_PER_MIN` | 20 | IP + projectId |
+| `SITE_PROXY_PROJECT_LIMIT_PER_MIN` | 120 | 프로젝트 전역 (실질 상한) |
+| `MAX_SITE_RATE_LIMIT_BUCKETS` | 5000 | 동시 추적 버킷 수 |
+
+## 검증
+
+| 항목 | 결과 |
+|------|------|
+| `pnpm lint` | 0 errors (warning 2건 — 기존) |
+| `pnpm type-check` | 통과 |
+| `pnpm test` | **168 파일 / 2067 테스트 통과** (기존 2022 + 신규 45) |
+| `pnpm build` | 통과 |
+| standalone 부팅 + `/api/v1/health` | 200 |
+
+신규 테스트는 `resolveProxyContext` 진리표(Host 변형 × 게시 상태 × 세션 × 소유권),
+Host 정규화(대문자·포트·예약 slug), 키 선택 격리(H-1 회귀 방지 — 타인 `projectId`면
+개인 키 조회 자체가 일어나지 않음), 레이트리밋 우회 방지(용량 압박 시 활성 카운터 유지),
+실 SQLite 토큰 이중 소비 차단을 고정한다.
+
+### 검수 과정에서 교정된 것
+
+- Grok이 보고한 "check→start TOCTOU로 중복 파이프라인"은 해당 구간에 `await`이 없어
+  **오탐**으로 판정, 상호 검증에서 철회됐다. 실제 결함은 `generationTracker`의
+  LRU/TTL 락 소실(M-5)이었다.
+- Grok의 계획 검토가 CI 파손 2건을 잡았다 — `SqliteAuthTokenRepository.test.ts`가
+  제거 대상 메서드를 호출하고 있었고, `src/middleware.ts`가 `coverage.include`에 없었다.
+- 모드 판정으로 옮기면서 `user.id` 타입 가드를 누락했는데 **기존 테스트가 잡아냈다**.
+  `resolveProxyContext`로 이전해 보존했다.
+
+## 배포 후 확인
+
+게시된 사이트가 없어 실환경 확인은 배포 후 테스트 프로젝트를 하나 게시해 수행한다.
+
+```bash
+# 1) 서브도메인 프록시 도달 (200 기대, 404면 패스스루 미적용)
+curl -s -o /dev/null -w "%{http_code}\n" "https://<slug>.xzawed.xyz/api/v1/proxy?apiId=<연결된 apiId>&proxyPath=/<경로>"
+# 2) 연결되지 않은 apiId 차단 (403 기대)
+curl -s -o /dev/null -w "%{http_code}\n" "https://<slug>.xzawed.xyz/api/v1/proxy?apiId=<무관한 apiId>&proxyPath=/x"
+# 3) 서브도메인의 다른 API 경로는 여전히 닫힘 (404 기대 — site 라우트로 rewrite)
+curl -s -o /dev/null -w "%{http_code}\n" "https://<slug>.xzawed.xyz/api/v1/projects"
+```
+
+## 범위 밖 (다음 라운드)
+
+M-1 Quality Loop AbortSignal 부재 · M-2 저장되는 stale `validation` · M-3 레이트리밋
+fail-open 환불 · M-5 `generationTracker` LRU/TTL 락 소실 · M-6 기존 프록시 리미터
+eviction 리셋 · M-7 IPv4-mapped IPv6 SSRF 우회 · M-8 `x-real-ip` 신뢰.
+
+부수 관찰: `__Secure-authjs.callback-url`이 `https://0.0.0.0:8080`으로 설정되어 있다
+(`AUTH_URL` 미설정 추정) — 로그인 리다이렉트 영향 확인 필요.
+
+## 관련 문서
+
+- [설계 spec](../superpowers/specs/2026-07-28-published-site-proxy-authz-design.md)
+- [구현 계획 (WBS)](../superpowers/plans/2026-07-28-published-site-proxy-authz.md)
+- [의존성 감사 면제 목록](../security/audit-waivers.md)

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -155,6 +155,9 @@ DB 어댑터 없는 JWT 무상태 세션. 공개 셀프서비스 회원가입, D
 |------|--------|---------|------|
 | `RATE_LIMIT_PER_MIN` | `60` | ➖ | proxy + admin 라우트 분당 요청 한도 (사용자/IP 단위) |
 | `MAX_CONCURRENT_RATE_LIMIT_USERS` | `1000` | ➖ | rate limit Map의 LRU evict 임계값 (활성 사용자/IP 한도). 초과 시 가장 오래된 항목 자동 evict — Railway 단일 인스턴스 메모리 누적 차단 |
+| `SITE_PROXY_RATE_LIMIT_PER_MIN` | `20` | ➖ | 익명 게시 사이트 프록시 — IP+projectId 단위 분당 한도 |
+| `SITE_PROXY_PROJECT_LIMIT_PER_MIN` | `120` | ➖ | 익명 게시 사이트 프록시 — 프로젝트 전역 분당 한도. 분산 IP로 한 오너의 API 키를 소진시키는 것을 막는 **실질 상한**이므로 운영 모니터링 대상 |
+| `MAX_SITE_RATE_LIMIT_BUCKETS` | `5000` | ➖ | site 리미터가 동시에 추적하는 최대 버킷 수. 초과 시 만료 항목만 정리하고 활성 카운터는 유지(한도 우회 방지) |
 | `RATE_LIMIT_BYPASS_USER_IDS` | `` (빈 문자열) | ➖ | 쉼표 구분 userId 목록. 포함된 계정은 일일 생성 한도(`MAX_DAILY_GENERATIONS`) 검사 스킵. 관리자·개발자 계정 우회용. 코드 위치: `src/services/rateLimitService.ts` `checkAndIncrementDailyLimit()` |
 | `PROXY_CACHE_MAX_ENTRIES` | `500` | ➖ | 프록시 응답 캐시(`proxyCache`)의 LRU 최대 항목 수. 빈 문자열·숫자 아님·0 이하 값 설정 시 기본값 500으로 폴백. 인메모리·per-instance — 서버 재시작 시 초기화. 코드 위치: `src/lib/cache/proxyCache.ts` |
 

--- a/docs/superpowers/plans/2026-07-28-published-site-proxy-authz.md
+++ b/docs/superpowers/plans/2026-07-28-published-site-proxy-authz.md
@@ -1,0 +1,1273 @@
+# 게시 사이트 프록시 복구 및 인가 모델 정비 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 게시된 서브도메인 사이트가 익명 방문자에게도 API 데이터를 표시하도록 복구하고, 프록시의 인가 판단을 단일 진입점으로 모아 교차 테넌트 키 남용과 토큰 재사용을 차단한다.
+
+**Architecture:** 미들웨어가 서브도메인에서 프록시 경로 하나만 리라이트 예외로 처리한다(C-1). 프록시는 새 `resolveProxyContext()`로 site(익명·Host 바인딩)/app(세션·소유권 강제) 모드를 판정하고, 라우트는 그 결과만 소비한다(C-2·H-1). 토큰 소비는 단일 원자 SQL로 대체한다(H-2).
+
+**Tech Stack:** Next.js 16 App Router, TypeScript strict, drizzle-orm(better-sqlite3), Vitest, Auth.js v5
+
+## Global Constraints
+
+- **TypeScript strict** — `any` 금지, export 함수에 명시적 반환 타입
+- **Path alias** — `@/*` → `src/*`
+- **한국어 커밋 메시지**, prefix: `feat:` `fix:` `refactor:` `test:` `docs:` `chore:`
+- **클라이언트 IP는 `getClientIp()`(`src/lib/auth/rateLimit.ts`) 단일 출처만 사용** — XFF 직접 파싱 금지(최우측만 신뢰)
+- **소유권 검증은 기존 `assertOwner()`(`src/lib/auth/authorize.ts`) 재사용** — 프록시 전용 분기 신설 금지
+- **커버리지 등록 필수** — 수정/신규 라우트·모듈이 `vitest.config.ts`의 `coverage.include`에 없으면 SonarCloud `new_coverage`·`codecov/patch`가 0%로 계산되어 CI 실패
+- 레이트리밋 한도 기본값: `SITE_PROXY_RATE_LIMIT_PER_MIN=20`, `SITE_PROXY_PROJECT_LIMIT_PER_MIN=120`
+- 응답 규약: 프로젝트 부재·미게시 → 404 / `apiId ∉ project_apis` → 403 / app 모드 미소유 → 403 / 레이트리밋 → 429 + `Retry-After`
+
+## File Structure
+
+| 파일 | 책임 |
+|------|------|
+| `src/middleware.ts` (수정) | 서브도메인 리라이트에 패스스루 예외 추가 |
+| `src/lib/proxy/resolveProxyContext.ts` (신규) | 요청 → site/app 모드 판정 + 인가. 프록시 인가의 단일 진실 소스 |
+| `src/lib/proxy/siteRateLimit.ts` (신규) | 익명 site 모드 전용 레이트리밋(IP+projectId, 프로젝트 전역) |
+| `src/lib/config/rateLimit.ts` (수정) | site 한도 상수 2개 추가 |
+| `src/repositories/interfaces/IAuthTokenRepository.ts` (수정) | `consumeValid` 추가, `findValidByHash`/`consume` 제거 |
+| `src/repositories/sqlite/SqliteAuthTokenRepository.ts` (수정) | 원자적 `consumeValid` 구현 |
+| `src/lib/auth/tokens.ts` (수정) | 2단계 → 원자 1단계 |
+| `src/app/api/v1/proxy/route.ts` (수정) | `resolveProxyContext` 소비, 모드별 키 해석 |
+
+---
+
+### Task 1: 미들웨어 서브도메인 패스스루 (C-1)
+
+**Files:**
+- Modify: `src/middleware.ts`
+- Test: `src/middleware.test.ts`
+
+**Interfaces:**
+- Consumes: 없음 (첫 태스크)
+- Produces: 서브도메인 요청의 `/api/v1/proxy`가 리라이트되지 않고 App Router 라우트에 도달한다. Task 5가 이 동작에 의존한다.
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+`src/middleware.test.ts` 하단에 추가한다. 기존 파일은 `beforeEach`에서 `NEXT_PUBLIC_ROOT_DOMAIN`을 지우므로, 서브도메인 테스트는 별도 `describe`에서 직접 설정한다.
+
+```ts
+describe('middleware — 서브도메인 리라이트와 프록시 패스스루', () => {
+  const ORIG = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_ROOT_DOMAIN = 'xzawed.xyz';
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIG };
+  });
+
+  function subdomainReq(path: string): NextRequest {
+    return new NextRequest(new URL(`http://weather.xzawed.xyz${path}`), {
+      headers: { host: 'weather.xzawed.xyz' },
+    });
+  }
+
+  it('서브도메인의 일반 경로는 /site/{slug}로 리라이트된다', async () => {
+    const res = await middleware(subdomainReq('/'));
+    expect(res.headers.get('x-middleware-rewrite')).toContain('/site/weather');
+  });
+
+  it('서브도메인의 하위 페이지 경로도 /site/{slug} 아래로 리라이트된다', async () => {
+    const res = await middleware(subdomainReq('/about'));
+    expect(res.headers.get('x-middleware-rewrite')).toContain('/site/weather/about');
+  });
+
+  it('서브도메인의 /api/v1/proxy는 리라이트되지 않는다 (게시 사이트가 상대경로로 호출)', async () => {
+    const res = await middleware(subdomainReq('/api/v1/proxy?apiId=x&proxyPath=/y'));
+    expect(res.headers.get('x-middleware-rewrite')).toBeNull();
+  });
+
+  it('패스스루 응답에도 보안 헤더가 적용된다', async () => {
+    const res = await middleware(subdomainReq('/api/v1/proxy'));
+    expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
+  });
+
+  it('패스스루(API)에는 CSP를 붙이지 않는다 (이중 적용 방지)', async () => {
+    const res = await middleware(subdomainReq('/api/v1/proxy'));
+    expect(res.headers.get('Content-Security-Policy')).toBeNull();
+  });
+
+  it('프록시가 아닌 /api 경로는 여전히 리라이트된다 (최소 노출)', async () => {
+    const res = await middleware(subdomainReq('/api/v1/projects'));
+    expect(res.headers.get('x-middleware-rewrite')).toContain('/site/weather');
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `pnpm vitest run src/middleware.test.ts`
+Expected: FAIL — 패스스루 테스트에서 `x-middleware-rewrite`가 `/site/weather/api/v1/proxy`로 존재
+
+- [ ] **Step 3: 최소 구현**
+
+`src/middleware.ts`의 `PROTECTED_ROUTES` 선언 아래에 추가한다.
+
+```ts
+/**
+ * 서브도메인에서 `/site/{slug}` 리라이트를 건너뛸 경로.
+ *
+ * 게시 사이트의 생성 JS는 상대경로 `/api/v1/proxy?...`로 API를 호출한다
+ * (promptBuilder가 직접 외부 URL 호출을 금지하므로 프록시 경유가 유일한 경로).
+ * 리라이트되면 `/site/{slug}/api/v1/proxy`가 되어 단일 세그먼트 라우트에
+ * 매칭되지 않아 404가 된다.
+ *
+ * `/api/*` 전체가 아니라 프록시 경로만 여는 이유: 세션 쿠키가 `__Host-`
+ * 프리픽스라 호스트 전용이므로 생성 사이트가 방문자 세션을 탈취할 수는 없지만,
+ * 불필요한 엔드포인트를 서브도메인에 노출할 이유가 없다(최소 노출).
+ */
+const SUBDOMAIN_PASSTHROUGH_PREFIXES = ['/api/v1/proxy'];
+
+function isSubdomainPassthrough(pathname: string): boolean {
+  return SUBDOMAIN_PASSTHROUGH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+```
+
+이어서 서브도메인 분기의 조건을 수정한다. 기존:
+
+```ts
+      if (slug && slug !== 'www') {
+```
+
+수정 후:
+
+```ts
+      if (slug && slug !== 'www' && !isSubdomainPassthrough(request.nextUrl.pathname)) {
+```
+
+패스스루면 `if` 블록에 들어가지 않고 함수 아래쪽 일반 응답 경로로 흘러간다. 그 경로가 correlation id·보안 헤더를 설정하고 `isApi` 판정으로 CSP를 건너뛰므로 별도 처리가 필요 없다.
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `pnpm vitest run src/middleware.test.ts`
+Expected: PASS (신규 6건 포함 전체 통과)
+
+- [ ] **Step 5: 커버리지 등록 확인**
+
+`vitest.config.ts`의 `coverage.include`에 `src/middleware.ts`가 있는지 확인한다. 없으면 추가한다.
+
+Run: `grep -n "middleware" vitest.config.ts`
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add src/middleware.ts src/middleware.test.ts vitest.config.ts
+git commit -m "fix: 게시 서브도메인에서 프록시 경로 404 수정 (C-1)
+
+서브도메인 요청의 모든 경로를 /site/{slug}로 리라이트해
+/api/v1/proxy가 단일 세그먼트 라우트에 미매칭되어 404였다.
+생성 사이트는 상대경로로만 프록시를 호출하므로 API 데이터가
+전부 로딩 실패했다(프로덕션 실측: apex 401 vs 서브도메인 404).
+
+프록시 경로 하나만 리라이트 예외로 둔다. /api/* 전체를 열지 않는 것은
+최소 노출 원칙 — 세션 쿠키가 __Host- 프리픽스라 호스트 전용이지만
+불필요한 엔드포인트를 서브도메인에 노출할 이유가 없다."
+```
+
+---
+
+### Task 2: 토큰 원자적 소비 (H-2)
+
+**Files:**
+- Modify: `src/repositories/interfaces/IAuthTokenRepository.ts`
+- Modify: `src/repositories/sqlite/SqliteAuthTokenRepository.ts`
+- Modify: `src/lib/auth/tokens.ts`
+- Test: `src/lib/auth/tokens.test.ts`
+- Test(수정): `src/services/authService.test.ts` — fake repo가 제거된 메서드를 참조한다
+
+**Interfaces:**
+- Consumes: 없음 (Task 1과 독립)
+- Produces: `IAuthTokenRepository.consumeValid(tokenHash: string, type: AuthTokenType, now: string): Promise<string | null>` — 유효·미소비·미만료 토큰을 원자적으로 소비하고 `userId` 반환, 조건 불일치면 `null`
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+`src/lib/auth/tokens.test.ts`의 `fakeRepo()`를 새 인터페이스로 교체하고, 원자성 테스트를 추가한다.
+
+```ts
+function fakeRepo(): IAuthTokenRepository & { rows: Array<Record<string, unknown>> } {
+  const rows: Array<Record<string, unknown>> = [];
+  return {
+    rows,
+    create: vi.fn(async (userId, tokenHash, type, expiresAt) => {
+      rows.push({ id: `t${rows.length}`, userId, tokenHash, type, expiresAt, consumed: false });
+    }),
+    // 원자적 소비: 조건 검사와 상태 변경이 같은 동기 블록에서 일어난다.
+    consumeValid: vi.fn(async (tokenHash, type, now) => {
+      const r = rows.find(
+        (x) =>
+          x.tokenHash === tokenHash &&
+          x.type === type &&
+          !x.consumed &&
+          (x.expiresAt as string) > now,
+      );
+      if (!r) return null;
+      r.consumed = true;
+      return r.userId as string;
+    }),
+    invalidateByUserAndType: vi.fn(async () => {}),
+  };
+}
+```
+
+기존 테스트에 이어 추가한다.
+
+```ts
+  it('동시 요청이 같은 토큰을 소비해도 한 번만 성공한다', async () => {
+    const repo = fakeRepo();
+    const raw = await issueToken(repo, 'user-1', 'password_reset', EMAIL_VERIFY_TTL_MS);
+
+    const [a, b] = await Promise.all([
+      verifyAndConsumeToken(repo, raw, 'password_reset'),
+      verifyAndConsumeToken(repo, raw, 'password_reset'),
+    ]);
+
+    // 정확히 하나만 userId, 나머지는 null
+    expect([a, b].filter((x) => x === 'user-1')).toHaveLength(1);
+    expect([a, b].filter((x) => x === null)).toHaveLength(1);
+  });
+
+  it('만료된 토큰은 소비되지 않는다', async () => {
+    const repo = fakeRepo();
+    const raw = await issueToken(repo, 'user-1', 'email_verify', -1000); // 이미 만료
+    expect(await verifyAndConsumeToken(repo, raw, 'email_verify')).toBeNull();
+  });
+
+  it('타입이 다르면 소비되지 않는다', async () => {
+    const repo = fakeRepo();
+    const raw = await issueToken(repo, 'user-1', 'email_verify', EMAIL_VERIFY_TTL_MS);
+    expect(await verifyAndConsumeToken(repo, raw, 'password_reset')).toBeNull();
+  });
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `pnpm vitest run src/lib/auth/tokens.test.ts`
+Expected: FAIL — `repo.consumeValid is not a function` (아직 `tokens.ts`가 2단계 호출)
+
+- [ ] **Step 3: 인터페이스 교체**
+
+`src/repositories/interfaces/IAuthTokenRepository.ts`:
+
+```ts
+export interface IAuthTokenRepository {
+  create(userId: string, tokenHash: string, type: AuthTokenType, expiresAt: string): Promise<void>;
+  /**
+   * 유효(미소비·미만료)한 토큰을 **원자적으로** 소비하고 userId를 반환한다.
+   * 조건에 맞는 행이 없으면 null.
+   *
+   * 조회 → 소비 2단계로 나누면 두 await 사이에 다른 요청이 끼어들어 같은 토큰이
+   * 두 번 소비될 수 있다(비밀번호 재설정 링크 재사용). 단일 문으로 유지할 것.
+   */
+  consumeValid(tokenHash: string, type: AuthTokenType, now: string): Promise<string | null>;
+  invalidateByUserAndType(userId: string, type: AuthTokenType, now: string): Promise<void>;
+}
+```
+
+- [ ] **Step 4: SQLite 구현 교체**
+
+`src/repositories/sqlite/SqliteAuthTokenRepository.ts`에서 `findValidByHash`와 `consume`를 삭제하고 아래를 추가한다. 임포트에 `gt`, `isNull`, `and`, `eq`가 이미 있으면 재사용한다.
+
+```ts
+  async consumeValid(
+    tokenHash: string,
+    type: AuthTokenType,
+    now: string,
+  ): Promise<string | null> {
+    // 조건 검사와 갱신이 단일 UPDATE ... RETURNING으로 원자 실행된다.
+    const row = this.db
+      .update(schema.authTokens)
+      .set({ consumed_at: now })
+      .where(
+        and(
+          eq(schema.authTokens.token_hash, tokenHash),
+          eq(schema.authTokens.type, type),
+          isNull(schema.authTokens.consumed_at),
+          gt(schema.authTokens.expires_at, now),
+        ),
+      )
+      .returning({ userId: schema.authTokens.user_id })
+      .get();
+    return row?.userId ?? null;
+  }
+```
+
+- [ ] **Step 5: 호출부 단순화**
+
+`src/lib/auth/tokens.ts`의 `verifyAndConsumeToken`을 교체한다.
+
+```ts
+/** 원문 토큰을 검증하고 일회성으로 소비한다. 유효하면 userId, 아니면 null. */
+export async function verifyAndConsumeToken(
+  repo: IAuthTokenRepository,
+  raw: string,
+  type: AuthTokenType,
+): Promise<string | null> {
+  return repo.consumeValid(hashToken(raw), type, new Date().toISOString());
+}
+```
+
+- [ ] **Step 6: 다른 fake repo 갱신**
+
+`src/services/authService.test.ts`의 fake repo가 `findValidByHash`를 참조한다(32·77·83·156·162행). `consumeValid`로 교체한다. 예를 들어 `findValidByHash.mockResolvedValue({ id: 'tok1', userId })`는 `consumeValid.mockResolvedValue(userId)`로, `mockResolvedValue(null)`은 그대로 `null`이다.
+
+- [ ] **Step 7: 테스트 통과 확인**
+
+Run: `pnpm vitest run src/lib/auth/tokens.test.ts src/services/authService.test.ts`
+Expected: PASS
+
+- [ ] **Step 8: 타입 검사**
+
+Run: `pnpm type-check`
+Expected: 통과 — 제거한 메서드를 참조하는 곳이 남아 있으면 여기서 잡힌다
+
+- [ ] **Step 9: 커밋**
+
+```bash
+git add src/repositories/interfaces/IAuthTokenRepository.ts src/repositories/sqlite/SqliteAuthTokenRepository.ts src/lib/auth/tokens.ts src/lib/auth/tokens.test.ts src/services/authService.test.ts
+git commit -m "fix: 일회성 토큰을 원자적으로 소비 (H-2)
+
+findValidByHash → await → consume(id) 2단계였고 consume은 WHERE id만
+검사해 consumed_at IS NULL 가드도 변경 행 수 확인도 없었다. 두 await
+사이에 이벤트 루프가 다른 요청을 진행시켜 동시 요청이 모두 성공하면
+비밀번호 재설정 링크가 재사용될 수 있었다.
+
+단일 UPDATE ... WHERE consumed_at IS NULL AND expires_at > ? RETURNING
+으로 대체하고, 오용 여지를 남기지 않도록 기존 2개 메서드는 인터페이스에서
+제거했다."
+```
+
+---
+
+### Task 3: 프록시 인가 컨텍스트 판정 (C-2·H-1의 핵심 단위)
+
+**Files:**
+- Create: `src/lib/proxy/resolveProxyContext.ts`
+- Test: `src/lib/proxy/resolveProxyContext.test.ts`
+
+**Interfaces:**
+- Consumes: 없음 (순수 로직 단위)
+- Produces:
+  ```ts
+  type ProxyContext =
+    | { mode: 'site'; project: Project; linkedApiIds: string[] }
+    | { mode: 'app'; user: AuthUser; project: Project | null; linkedApiIds: string[] };
+
+  type ProxyContextDeps = {
+    getAuthUser: () => Promise<AuthUser | null>;
+    findProjectBySlug: (slug: string) => Promise<Project | null>;
+    findProjectById: (id: string) => Promise<Project | null>;
+    getProjectApiIds: (projectId: string) => Promise<string[]>;
+    rootDomain: string | undefined;
+  };
+
+  function resolveProxyContext(
+    request: Request,
+    apiId: string,
+    deps: ProxyContextDeps,
+  ): Promise<ProxyContext | ProxyContextError>;
+
+  type ProxyContextError = { error: { status: 401 | 403 | 404; code: string; message: string } };
+  ```
+  Task 5가 이 함수와 타입을 소비한다. 의존성을 주입형으로 두어 라우트 없이 단위 테스트한다.
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+`src/lib/proxy/resolveProxyContext.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { resolveProxyContext, type ProxyContextDeps } from './resolveProxyContext';
+import type { Project } from '@/types/project';
+
+const API_ID = 'aaaabbbb-cccc-dddd-eeee-ffffffffffff';
+const OTHER_API_ID = '11112222-3333-4444-5555-666677778888';
+
+function makeProject(over: Partial<Project> = {}): Project {
+  return {
+    id: 'proj-1', userId: 'owner-1', organizationId: null, name: 'p', context: 'c',
+    status: 'published', deployUrl: null, deployPlatform: null, repoUrl: null,
+    previewUrl: null, metadata: {}, currentVersion: 1, apis: [], slug: 'weather',
+    publishedAt: '2026-01-01T00:00:00.000Z', createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z', ...over,
+  } as Project;
+}
+
+/** 각 의존성을 vi.fn으로 노출해 호출 여부까지 단언할 수 있게 한다. */
+type MockedDeps = {
+  [K in keyof ProxyContextDeps]: ProxyContextDeps[K] extends (...a: infer A) => infer R
+    ? ReturnType<typeof vi.fn<(...a: A) => R>>
+    : ProxyContextDeps[K];
+};
+
+function makeDeps(over: Partial<MockedDeps> = {}): MockedDeps {
+  return {
+    getAuthUser: vi.fn(async () => null),
+    findProjectBySlug: vi.fn(async () => makeProject()),
+    findProjectById: vi.fn(async () => makeProject()),
+    getProjectApiIds: vi.fn(async () => [API_ID]),
+    rootDomain: 'xzawed.xyz',
+    ...over,
+  } as MockedDeps;
+}
+
+function req(url: string, host?: string): Request {
+  return new Request(url, host ? { headers: { host } } : undefined);
+}
+
+describe('resolveProxyContext — site 모드 (익명)', () => {
+  it('published 서브도메인 → site 모드, 프로젝트는 Host에서 확정', async () => {
+    const deps = makeDeps();
+    const ctx = await resolveProxyContext(
+      req('https://weather.xzawed.xyz/api/v1/proxy', 'weather.xzawed.xyz'), API_ID, deps,
+    );
+    expect(ctx).toMatchObject({ mode: 'site' });
+    expect((ctx as { project: Project }).project.userId).toBe('owner-1');
+  });
+
+  it('Host가 있으면 클라이언트 projectId는 무시된다', async () => {
+    const deps = makeDeps();
+    await resolveProxyContext(
+      req('https://weather.xzawed.xyz/api/v1/proxy?projectId=attacker-proj', 'weather.xzawed.xyz'),
+      API_ID, deps,
+    );
+    expect(deps.findProjectBySlug).toHaveBeenCalledWith('weather');
+    expect(deps.findProjectById).not.toHaveBeenCalled();
+  });
+
+  it('미게시 프로젝트의 서브도메인 → 404', async () => {
+    const deps = makeDeps({ findProjectBySlug: vi.fn(async () => makeProject({ status: 'draft' })) });
+    const ctx = await resolveProxyContext(
+      req('https://weather.xzawed.xyz/api/v1/proxy', 'weather.xzawed.xyz'), API_ID, deps,
+    );
+    expect(ctx).toMatchObject({ error: { status: 404 } });
+  });
+
+  it('존재하지 않는 slug → 404 (부재와 미게시를 구분해 노출하지 않음)', async () => {
+    const deps = makeDeps({ findProjectBySlug: vi.fn(async () => null) });
+    const ctx = await resolveProxyContext(
+      req('https://nope.xzawed.xyz/api/v1/proxy', 'nope.xzawed.xyz'), API_ID, deps,
+    );
+    expect(ctx).toMatchObject({ error: { status: 404 } });
+  });
+
+  it('apex + 세션 없음 + published projectId → site 모드 (직접 게시 URL 경로)', async () => {
+    const deps = makeDeps();
+    const ctx = await resolveProxyContext(
+      req('https://xzawed.xyz/api/v1/proxy?projectId=proj-1', 'xzawed.xyz'), API_ID, deps,
+    );
+    expect(ctx).toMatchObject({ mode: 'site' });
+  });
+
+  it('apex + 세션 없음 + projectId 없음 → 401', async () => {
+    const deps = makeDeps();
+    const ctx = await resolveProxyContext(
+      req('https://xzawed.xyz/api/v1/proxy', 'xzawed.xyz'), API_ID, deps,
+    );
+    expect(ctx).toMatchObject({ error: { status: 401 } });
+  });
+
+  it('site 모드에서 프로젝트에 연결되지 않은 apiId → 403', async () => {
+    const deps = makeDeps();
+    const ctx = await resolveProxyContext(
+      req('https://weather.xzawed.xyz/api/v1/proxy', 'weather.xzawed.xyz'), OTHER_API_ID, deps,
+    );
+    expect(ctx).toMatchObject({ error: { status: 403 } });
+  });
+
+  it('예약 slug(www)는 서브도메인 사이트로 보지 않는다', async () => {
+    const deps = makeDeps();
+    const ctx = await resolveProxyContext(
+      req('https://www.xzawed.xyz/api/v1/proxy', 'www.xzawed.xyz'), API_ID, deps,
+    );
+    expect(ctx).toMatchObject({ error: { status: 401 } });
+    expect(deps.findProjectBySlug).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveProxyContext — app 모드 (세션)', () => {
+  const user = { id: 'owner-1', email: 'o@x.com', name: null, avatarUrl: null };
+
+  it('세션 + 자기 projectId → app 모드', async () => {
+    const deps = makeDeps({ getAuthUser: vi.fn(async () => user) });
+    const ctx = await resolveProxyContext(
+      req('https://xzawed.xyz/api/v1/proxy?projectId=proj-1', 'xzawed.xyz'), API_ID, deps,
+    );
+    expect(ctx).toMatchObject({ mode: 'app' });
+  });
+
+  it('세션 + 타인 projectId → 403 (H-1 회귀 방지)', async () => {
+    const deps = makeDeps({
+      getAuthUser: vi.fn(async () => ({ ...user, id: 'attacker' })),
+      findProjectById: vi.fn(async () => makeProject({ userId: 'victim' })),
+    });
+    const ctx = await resolveProxyContext(
+      req('https://xzawed.xyz/api/v1/proxy?projectId=proj-1', 'xzawed.xyz'), API_ID, deps,
+    );
+    expect(ctx).toMatchObject({ error: { status: 403 } });
+  });
+
+  it('세션 + projectId 없음 → app 모드, project는 null (플랫폼 키만 사용)', async () => {
+    const deps = makeDeps({ getAuthUser: vi.fn(async () => user) });
+    const ctx = await resolveProxyContext(
+      req('https://xzawed.xyz/api/v1/proxy', 'xzawed.xyz'), API_ID, deps,
+    );
+    expect(ctx).toMatchObject({ mode: 'app', project: null });
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `pnpm vitest run src/lib/proxy/resolveProxyContext.test.ts`
+Expected: FAIL — 모듈 없음
+
+- [ ] **Step 3: 구현**
+
+`src/lib/proxy/resolveProxyContext.ts`:
+
+```ts
+import type { Project } from '@/types/project';
+import type { AuthUser } from '@/lib/auth/types';
+import { isValidSlug } from '@/lib/utils/slugify';
+
+/**
+ * 프록시 요청의 인가 컨텍스트.
+ *
+ * 인증·인가 판단이 라우트 여러 곳에 흩어져 있으면 한쪽만 고쳐 구멍이 남는다
+ * (H-1: 개인 키 해석부가 소유권을 확인하지 않았다). 판단을 이 모듈 하나로 모으고
+ * 라우트는 결과만 소비한다.
+ */
+export type ProxyContext =
+  | { mode: 'site'; project: Project; linkedApiIds: string[] }
+  | { mode: 'app'; user: AuthUser; project: Project | null; linkedApiIds: string[] };
+
+export interface ProxyContextError {
+  error: { status: 401 | 403 | 404; code: string; message: string };
+}
+
+export interface ProxyContextDeps {
+  getAuthUser: () => Promise<AuthUser | null>;
+  findProjectBySlug: (slug: string) => Promise<Project | null>;
+  findProjectById: (id: string) => Promise<Project | null>;
+  getProjectApiIds: (projectId: string) => Promise<string[]>;
+  rootDomain: string | undefined;
+}
+
+const NOT_FOUND: ProxyContextError = {
+  error: { status: 404, code: 'NOT_FOUND', message: '사이트를 찾을 수 없습니다.' },
+};
+const AUTH_REQUIRED: ProxyContextError = {
+  error: { status: 401, code: 'AUTH_REQUIRED', message: '로그인이 필요합니다.' },
+};
+const API_NOT_LINKED: ProxyContextError = {
+  error: { status: 403, code: 'API_NOT_LINKED', message: '이 사이트에 연결되지 않은 API입니다.' },
+};
+const FORBIDDEN: ProxyContextError = {
+  error: { status: 403, code: 'FORBIDDEN', message: '권한이 없습니다.' },
+};
+
+/** Host 헤더에서 게시 사이트 slug를 추출한다. 서브도메인이 아니면 null. */
+export function extractSiteSlug(host: string, rootDomain: string | undefined): string | null {
+  if (!rootDomain) return null;
+  if (host.includes('localhost') || host.includes('127.0.0.1')) return null;
+  const hostname = host.split(':')[0];
+  if (!hostname.endsWith(`.${rootDomain}`)) return null;
+  const slug = hostname.slice(0, -(rootDomain.length + 1));
+  // isValidSlug가 예약어(www·api·admin 등)와 형식을 함께 검사한다.
+  return isValidSlug(slug) ? slug : null;
+}
+
+export async function resolveProxyContext(
+  request: Request,
+  apiId: string,
+  deps: ProxyContextDeps,
+): Promise<ProxyContext | ProxyContextError> {
+  const url = new URL(request.url);
+  const host = request.headers.get('host') ?? url.host;
+  const slug = extractSiteSlug(host, deps.rootDomain);
+
+  // 1) Host가 게시 사이트를 가리키면 그것이 권위 — 클라이언트 projectId는 보지 않는다.
+  if (slug) {
+    const project = await deps.findProjectBySlug(slug);
+    if (!project || project.status !== 'published') return NOT_FOUND;
+    return buildSiteContext(project, apiId, deps);
+  }
+
+  // 2) apex + 세션 → app 모드(소유권 강제)
+  const user = await deps.getAuthUser();
+  const projectId = url.searchParams.get('projectId');
+
+  if (user?.id) {
+    if (!projectId) return { mode: 'app', user, project: null, linkedApiIds: [] };
+    const project = await deps.findProjectById(projectId);
+    if (!project) return NOT_FOUND;
+    // 기존 인가 규약과 동일하게 소유자가 아니면 403.
+    if (project.userId !== user.id) return FORBIDDEN;
+    const linkedApiIds = await deps.getProjectApiIds(project.id);
+    if (!linkedApiIds.includes(apiId)) return API_NOT_LINKED;
+    return { mode: 'app', user, project, linkedApiIds };
+  }
+
+  // 3) apex + 세션 없음 + published projectId → site 모드
+  //    apex의 /site/{slug} 직접 서빙 경로를 위해 필요하다. 이게 없으면
+  //    "서브도메인에선 되고 직접 게시 URL에선 안 되는" 경로별 분기가 생긴다.
+  if (projectId) {
+    const project = await deps.findProjectById(projectId);
+    if (!project || project.status !== 'published') return NOT_FOUND;
+    return buildSiteContext(project, apiId, deps);
+  }
+
+  return AUTH_REQUIRED;
+}
+
+async function buildSiteContext(
+  project: Project,
+  apiId: string,
+  deps: ProxyContextDeps,
+): Promise<ProxyContext | ProxyContextError> {
+  const linkedApiIds = await deps.getProjectApiIds(project.id);
+  // 게시 사이트가 자신과 무관한 카탈로그 API를 오너 키로 호출하는 것을 막는다.
+  if (!linkedApiIds.includes(apiId)) return API_NOT_LINKED;
+  return { mode: 'site', project, linkedApiIds };
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `pnpm vitest run src/lib/proxy/resolveProxyContext.test.ts`
+Expected: PASS (13건)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/lib/proxy/resolveProxyContext.ts src/lib/proxy/resolveProxyContext.test.ts
+git commit -m "feat: 프록시 인가 컨텍스트 판정 모듈 추가
+
+site(익명·Host 바인딩)/app(세션·소유권 강제) 이중 모드를 한 곳에서
+판정한다. Host로 프로젝트가 확정되면 클라이언트 projectId는 무시해
+사용자 입력이 인가 근거가 되지 않게 한다. 두 모드 공통으로
+apiId ∈ project_apis를 강제한다.
+
+의존성 주입형이라 라우트 없이 진리표를 단위 검증한다."
+```
+
+---
+
+### Task 4: 익명 사이트 모드 레이트리밋
+
+**Files:**
+- Modify: `src/lib/config/rateLimit.ts`
+- Create: `src/lib/proxy/siteRateLimit.ts`
+- Test: `src/lib/proxy/siteRateLimit.test.ts`
+
+**Interfaces:**
+- Consumes: 없음
+- Produces: `checkSiteRateLimit(clientIp: string, projectId: string): { allowed: boolean; retryAfterSec: number }` — Task 5가 site 모드에서 호출한다
+
+- [ ] **Step 1: 설정 상수 추가**
+
+`src/lib/config/rateLimit.ts` 하단에 추가한다.
+
+```ts
+/**
+ * 익명 게시 사이트 프록시 한도 — IP+projectId 단위. 기본 20회/분.
+ *
+ * 이 리미터가 타인 API 키 소진을 막는 유일한 경계다(게시 사이트는 오너의 개인 키로
+ * 업스트림을 호출한다). 게시 사이트 실사용 데이터가 없어 보수적으로 시작하고,
+ * 운영 로그를 보고 환경변수로 조정한다.
+ */
+export const SITE_PROXY_RATE_LIMIT_PER_MIN = envInt('SITE_PROXY_RATE_LIMIT_PER_MIN', 20);
+
+/** 프로젝트 전역 한도. 분산 IP로 한 오너의 키를 소진시키는 것을 상한. 기본 120회/분. */
+export const SITE_PROXY_PROJECT_LIMIT_PER_MIN = envInt('SITE_PROXY_PROJECT_LIMIT_PER_MIN', 120);
+
+/** site 리미터가 동시에 추적하는 최대 버킷 수. 초과 시 만료 항목만 정리한다. */
+export const MAX_SITE_RATE_LIMIT_BUCKETS = envInt('MAX_SITE_RATE_LIMIT_BUCKETS', 5000);
+```
+
+- [ ] **Step 2: 실패하는 테스트 작성**
+
+`src/lib/proxy/siteRateLimit.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { checkSiteRateLimit, __resetSiteRateLimit } from './siteRateLimit';
+import { SITE_PROXY_RATE_LIMIT_PER_MIN, SITE_PROXY_PROJECT_LIMIT_PER_MIN } from '@/lib/config/rateLimit';
+
+describe('checkSiteRateLimit', () => {
+  beforeEach(() => {
+    __resetSiteRateLimit();
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('한도 내에서는 허용한다', () => {
+    for (let i = 0; i < SITE_PROXY_RATE_LIMIT_PER_MIN; i++) {
+      expect(checkSiteRateLimit('1.1.1.1', 'p1').allowed).toBe(true);
+    }
+  });
+
+  it('IP+projectId 한도 초과 시 차단하고 retryAfter를 준다', () => {
+    for (let i = 0; i < SITE_PROXY_RATE_LIMIT_PER_MIN; i++) checkSiteRateLimit('1.1.1.1', 'p1');
+    const res = checkSiteRateLimit('1.1.1.1', 'p1');
+    expect(res.allowed).toBe(false);
+    expect(res.retryAfterSec).toBeGreaterThan(0);
+  });
+
+  it('다른 IP는 서로 영향을 주지 않는다', () => {
+    for (let i = 0; i < SITE_PROXY_RATE_LIMIT_PER_MIN; i++) checkSiteRateLimit('1.1.1.1', 'p1');
+    expect(checkSiteRateLimit('2.2.2.2', 'p1').allowed).toBe(true);
+  });
+
+  it('윈도가 지나면 리셋된다', () => {
+    for (let i = 0; i < SITE_PROXY_RATE_LIMIT_PER_MIN; i++) checkSiteRateLimit('1.1.1.1', 'p1');
+    expect(checkSiteRateLimit('1.1.1.1', 'p1').allowed).toBe(false);
+    vi.advanceTimersByTime(60_001);
+    expect(checkSiteRateLimit('1.1.1.1', 'p1').allowed).toBe(true);
+  });
+
+  it('분산 IP여도 프로젝트 전역 한도에서 차단된다', () => {
+    let allowed = 0;
+    // IP를 매번 바꿔 IP 버킷은 항상 여유가 있게 한다.
+    for (let i = 0; i < SITE_PROXY_PROJECT_LIMIT_PER_MIN + 10; i++) {
+      if (checkSiteRateLimit(`10.0.${Math.floor(i / 250)}.${i % 250}`, 'p1').allowed) allowed++;
+    }
+    expect(allowed).toBe(SITE_PROXY_PROJECT_LIMIT_PER_MIN);
+  });
+
+  it('용량 압박이 있어도 활성 윈도의 카운터를 리셋하지 않는다', () => {
+    // 기존 프록시 리미터(LRUMap)는 eviction 시 활성 카운터가 사라져 한도를 우회할 수 있다.
+    // 이 리미터는 만료 항목만 정리하므로 살아 있는 카운터가 유지되어야 한다.
+    for (let i = 0; i < SITE_PROXY_RATE_LIMIT_PER_MIN; i++) checkSiteRateLimit('1.1.1.1', 'p1');
+    // 다른 버킷을 대량 생성해 용량을 압박한다.
+    for (let i = 0; i < 6000; i++) checkSiteRateLimit(`9.9.${Math.floor(i / 250)}.${i % 250}`, 'pX');
+    expect(checkSiteRateLimit('1.1.1.1', 'p1').allowed).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: 테스트 실패 확인**
+
+Run: `pnpm vitest run src/lib/proxy/siteRateLimit.test.ts`
+Expected: FAIL — 모듈 없음
+
+- [ ] **Step 4: 구현**
+
+`src/lib/proxy/siteRateLimit.ts`:
+
+```ts
+import {
+  RATE_LIMIT_WINDOW_MS,
+  SITE_PROXY_RATE_LIMIT_PER_MIN,
+  SITE_PROXY_PROJECT_LIMIT_PER_MIN,
+  MAX_SITE_RATE_LIMIT_BUCKETS,
+} from '@/lib/config/rateLimit';
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+/**
+ * 익명 게시 사이트 프록시 레이트리밋.
+ *
+ * 기존 프록시 리미터는 LRUMap을 써서 용량 초과 시 **활성 윈도의 카운터가 통째로
+ * 사라진다** — 다음 요청이 count:1로 다시 시작해 한도를 우회할 수 있다.
+ * 이 리미터는 타인 API 키 소진을 막는 유일한 경계이므로 그 패턴을 쓰지 않는다:
+ * 만료된 버킷만 정리하고, 용량이 부족하면 살아 있는 카운터를 버리는 대신
+ * 새 버킷 생성을 거부(=차단)한다.
+ *
+ * Railway 단일 인스턴스 전제. 멀티 인스턴스 전환 시 Redis 등으로 교체 필요.
+ */
+const ipBuckets = new Map<string, Bucket>();
+const projectBuckets = new Map<string, Bucket>();
+
+function sweepExpired(map: Map<string, Bucket>, now: number): void {
+  for (const [key, bucket] of map) {
+    if (now >= bucket.resetAt) map.delete(key);
+  }
+}
+
+/**
+ * 버킷을 소비한다.
+ * @returns 허용되면 true. 한도 초과이거나 용량 부족으로 새 버킷을 만들 수 없으면 false.
+ */
+function consume(
+  map: Map<string, Bucket>,
+  key: string,
+  limit: number,
+  now: number,
+): { allowed: boolean; resetAt: number } {
+  const existing = map.get(key);
+  if (existing && now < existing.resetAt) {
+    if (existing.count >= limit) return { allowed: false, resetAt: existing.resetAt };
+    existing.count++;
+    return { allowed: true, resetAt: existing.resetAt };
+  }
+
+  // 신규 또는 만료된 버킷 — 먼저 만료분을 정리해 자리를 확보한다.
+  if (!existing && map.size >= MAX_SITE_RATE_LIMIT_BUCKETS) {
+    sweepExpired(map, now);
+    if (map.size >= MAX_SITE_RATE_LIMIT_BUCKETS) {
+      // 활성 카운터를 버리느니 차단한다(우회 방지).
+      return { allowed: false, resetAt: now + RATE_LIMIT_WINDOW_MS };
+    }
+  }
+
+  const resetAt = now + RATE_LIMIT_WINDOW_MS;
+  map.set(key, { count: 1, resetAt });
+  return { allowed: true, resetAt };
+}
+
+export function checkSiteRateLimit(
+  clientIp: string,
+  projectId: string,
+): { allowed: boolean; retryAfterSec: number } {
+  const now = Date.now();
+
+  const perIp = consume(ipBuckets, `${clientIp}:${projectId}`, SITE_PROXY_RATE_LIMIT_PER_MIN, now);
+  if (!perIp.allowed) {
+    return { allowed: false, retryAfterSec: Math.ceil((perIp.resetAt - now) / 1000) };
+  }
+
+  const perProject = consume(projectBuckets, projectId, SITE_PROXY_PROJECT_LIMIT_PER_MIN, now);
+  if (!perProject.allowed) {
+    return { allowed: false, retryAfterSec: Math.ceil((perProject.resetAt - now) / 1000) };
+  }
+
+  return { allowed: true, retryAfterSec: 0 };
+}
+
+/** 테스트 전용 — 모듈 레벨 상태를 초기화한다. */
+export function __resetSiteRateLimit(): void {
+  ipBuckets.clear();
+  projectBuckets.clear();
+}
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `pnpm vitest run src/lib/proxy/siteRateLimit.test.ts`
+Expected: PASS (6건)
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add src/lib/config/rateLimit.ts src/lib/proxy/siteRateLimit.ts src/lib/proxy/siteRateLimit.test.ts
+git commit -m "feat: 익명 게시 사이트 프록시 레이트리밋 추가
+
+IP+projectId 버킷(기본 20/분)과 프로젝트 전역 버킷(기본 120/분)을 둔다.
+게시 사이트는 오너의 개인 API 키로 업스트림을 호출하므로 이 리미터가
+키 소진을 막는 유일한 경계다.
+
+기존 프록시 리미터의 LRUMap eviction 패턴을 의도적으로 피했다 — 용량
+초과 시 활성 윈도 카운터가 사라져 한도를 우회할 수 있다. 여기서는 만료
+버킷만 정리하고, 자리가 없으면 살아 있는 카운터를 버리는 대신 차단한다."
+```
+
+---
+
+### Task 5: 프록시 라우트 통합 (C-2·H-1 완결)
+
+**Files:**
+- Modify: `src/app/api/v1/proxy/route.ts`
+- Test: `src/__tests__/api/proxy.test.ts`
+
+**Interfaces:**
+- Consumes: Task 3의 `resolveProxyContext` / `ProxyContext` / `ProxyContextError`, Task 4의 `checkSiteRateLimit`
+- Produces: 없음 (최종 통합)
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+`src/__tests__/api/proxy.test.ts` 하단에 추가한다. 파일 상단의 기존 `vi.mock('@/repositories/factory', ...)`에 `createProjectRepository`가 이미 있으므로 그대로 쓴다.
+
+```ts
+import { __resetSiteRateLimit } from '@/lib/proxy/siteRateLimit';
+
+describe('프록시 인가 — site/app 모드', () => {
+  const ORIG_ENV = { ...process.env };
+  const PROJECT = { id: 'proj-1', userId: 'owner-1', status: 'published', slug: 'weather' };
+  const ATTACKER = { id: 'attacker', email: 'a@x.com', name: null, avatarUrl: null };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    __resetSiteRateLimit();
+    process.env.NEXT_PUBLIC_ROOT_DOMAIN = 'xzawed.xyz';
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(() => Promise.resolve(makeSuccessResponse())));
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIG_ENV };
+  });
+
+  function siteReq(host: string, extra = ''): Request {
+    return new Request(
+      `https://${host}/api/v1/proxy?apiId=${VALID_API_ID}&proxyPath=/data${extra}`,
+      { headers: { host } },
+    );
+  }
+
+  /**
+   * 프록시 라우트를 mock 상태로 호출한다.
+   * `times`를 주면 같은 요청을 N회 호출하고 **마지막 응답**을 반환한다(레이트리밋 검증용).
+   */
+  async function invokeProxy(opts: {
+    request: Request;
+    user?: typeof ATTACKER | null;
+    projectBySlug?: Record<string, unknown> | null;
+    projectById?: Record<string, unknown> | null;
+    linkedApiIds?: string[];
+    times?: number;
+  }): Promise<{ res: Response; userApiKeyRepo: { findByUserAndApi: ReturnType<typeof vi.fn> } }> {
+    const { getAuthUser } = await import('@/lib/auth/index');
+    const factory = await import('@/repositories/factory');
+
+    vi.mocked(getAuthUser).mockResolvedValue(opts.user ?? null);
+
+    const userApiKeyRepo = { findByUserAndApi: vi.fn().mockResolvedValue(null) };
+    vi.mocked(factory.createUserApiKeyRepository).mockReturnValue(
+      userApiKeyRepo as unknown as ReturnType<typeof factory.createUserApiKeyRepository>,
+    );
+
+    vi.mocked(factory.createProjectRepository).mockReturnValue({
+      findBySlug: vi.fn().mockResolvedValue(opts.projectBySlug ?? null),
+      findById: vi.fn().mockResolvedValue(opts.projectById ?? null),
+      getProjectApiIds: vi.fn().mockResolvedValue(opts.linkedApiIds ?? [VALID_API_ID]),
+    } as unknown as ReturnType<typeof factory.createProjectRepository>);
+
+    vi.mocked(factory.createCatalogRepository).mockReturnValue({
+      findById: vi.fn().mockResolvedValue(mockPublicApi),
+    } as unknown as ReturnType<typeof factory.createCatalogRepository>);
+
+    const { GET } = await import('@/app/api/v1/proxy/route');
+    let res!: Response;
+    for (let i = 0; i < (opts.times ?? 1); i++) {
+      res = await GET(opts.request);
+    }
+    return { res, userApiKeyRepo };
+  }
+
+  it('published 서브도메인의 익명 요청을 허용한다 (C-2)', async () => {
+    const { res } = await invokeProxy({
+      request: siteReq('weather.xzawed.xyz'),
+      user: null,
+      projectBySlug: PROJECT,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('미게시 프로젝트의 서브도메인 요청은 404 (존재 여부 미노출)', async () => {
+    const { res } = await invokeProxy({
+      request: siteReq('weather.xzawed.xyz'),
+      user: null,
+      projectBySlug: { ...PROJECT, status: 'draft' },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('세션 사용자가 타인 projectId로 개인 키를 쓰려 하면 403 (H-1)', async () => {
+    const { res } = await invokeProxy({
+      request: siteReq('xzawed.xyz', '&projectId=proj-1'),
+      user: ATTACKER,
+      projectById: { ...PROJECT, userId: 'victim' },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('타인 projectId 요청에서는 개인 키 조회 자체가 일어나지 않는다 (H-1)', async () => {
+    const { userApiKeyRepo } = await invokeProxy({
+      request: siteReq('xzawed.xyz', '&projectId=proj-1'),
+      user: ATTACKER,
+      projectById: { ...PROJECT, userId: 'victim' },
+    });
+    expect(userApiKeyRepo.findByUserAndApi).not.toHaveBeenCalled();
+  });
+
+  it('프로젝트에 연결되지 않은 apiId는 403', async () => {
+    const { res } = await invokeProxy({
+      request: siteReq('weather.xzawed.xyz'),
+      user: null,
+      projectBySlug: PROJECT,
+      linkedApiIds: [],
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('site 모드 레이트리밋 초과 시 429 + Retry-After', async () => {
+    const { res } = await invokeProxy({
+      request: siteReq('weather.xzawed.xyz'),
+      user: null,
+      projectBySlug: PROJECT,
+      times: 25, // 기본 한도 20/분 초과
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `pnpm vitest run src/__tests__/api/proxy.test.ts`
+Expected: FAIL — 익명 요청이 401, 타인 projectId가 200
+
+- [ ] **Step 3: `validateRequest`에서 인증 판단 제거**
+
+`src/app/api/v1/proxy/route.ts`의 `validateRequest`는 파라미터 형식 검증만 남긴다. 인증·레이트리밋은 컨텍스트 판정 이후로 옮긴다.
+
+```ts
+interface ValidatedRequest {
+  apiId: string;
+  proxyPath: string;
+  searchParams: URLSearchParams;
+}
+
+/** 파라미터 형식만 검증한다. 인증·인가는 resolveProxyContext가 담당한다. */
+function validateParams(request: Request): ValidatedRequest | Response {
+  const { searchParams } = new URL(request.url);
+  const apiId = searchParams.get('apiId');
+  const proxyPath = searchParams.get('proxyPath');
+
+  if (!apiId || !proxyPath) return error400('apiId와 proxyPath가 필요합니다.');
+  if (!UUID_RE.test(apiId)) return error400('유효하지 않은 API ID입니다.');
+  if (proxyPath.includes('..') || /\/\//.test(proxyPath)) return error400('유효하지 않은 경로입니다.');
+
+  return { apiId, proxyPath, searchParams };
+}
+```
+
+- [ ] **Step 4: `handleProxy`에 컨텍스트 판정과 모드별 레이트리밋 배선**
+
+`handleProxy` 시작부를 아래로 교체한다.
+
+```ts
+async function handleProxy(request: Request, method: 'GET' | 'POST'): Promise<Response> {
+  const validated = validateParams(request);
+  if (validated instanceof Response) return validated;
+  const { apiId, proxyPath, searchParams } = validated;
+
+  const ctx = await resolveProxyContext(request, apiId, {
+    getAuthUser,
+    findProjectBySlug: (slug) => createProjectRepository().findBySlug(slug),
+    findProjectById: (id) => createProjectRepository().findById(id),
+    getProjectApiIds: (id) => createProjectRepository().getProjectApiIds(id),
+    rootDomain: process.env.NEXT_PUBLIC_ROOT_DOMAIN,
+  });
+
+  if ('error' in ctx) {
+    return errorResponse(ctx.error.status, ctx.error.code, ctx.error.message);
+  }
+
+  // 모드별 레이트리밋 — 익명 site는 IP+projectId, 세션 app은 기존 userId 버킷.
+  if (ctx.mode === 'site') {
+    const limit = checkSiteRateLimit(getClientIp(request), ctx.project.id);
+    if (!limit.allowed) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: { code: 'RATE_LIMITED', message: '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.' },
+        }),
+        {
+          status: 429,
+          headers: {
+            'Content-Type': 'application/json',
+            'Retry-After': String(limit.retryAfterSec),
+          },
+        },
+      );
+    }
+  } else if (!checkProxyRateLimit(ctx.user.id)) {
+    return errorResponse(429, 'RATE_LIMITED', '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.');
+  }
+
+  // 이하 카탈로그 조회·URL 조립은 기존과 동일
+  const catalogRepo = createCatalogRepository();
+  // ...
+```
+
+임포트를 추가한다.
+
+```ts
+import { resolveProxyContext } from '@/lib/proxy/resolveProxyContext';
+import { checkSiteRateLimit } from '@/lib/proxy/siteRateLimit';
+import { getClientIp } from '@/lib/auth/rateLimit';
+```
+
+- [ ] **Step 5: `resolveApiKey`가 컨텍스트를 받도록 변경 (H-1 수정 지점)**
+
+`resolveApiKey`는 더 이상 `searchParams`에서 `projectId`를 읽지 않는다. 대신 **키를 쓸 사용자**를 컨텍스트에서 받는다.
+
+```ts
+/**
+ * 키 소유자 결정:
+ *  - site 모드: 게시 프로젝트의 오너 (Host로 확정된 프로젝트이므로 정당)
+ *  - app 모드 + 자기 프로젝트: 그 프로젝트의 오너 == 호출자
+ *  - app 모드 + 프로젝트 없음: 개인 키 없음(플랫폼 키만)
+ *
+ * 이전에는 클라이언트가 보낸 projectId로 아무 사용자의 키나 복호화할 수 있었다(H-1).
+ * 소유권은 resolveProxyContext가 이미 강제했으므로 여기서는 결정된 소유자만 쓴다.
+ */
+function keyOwnerIdOf(ctx: ProxyContext): string | null {
+  return ctx.project?.userId ?? null;
+}
+```
+
+`resolveApiKey`의 시그니처에서 `searchParams` 대신 `keyOwnerId: string | null`을 받고, 1) 블록을 아래로 교체한다.
+
+```ts
+  // 1) 키 소유자의 개인 API 키 조회 (소유권은 resolveProxyContext에서 이미 검증됨)
+  if (keyOwnerId) {
+    try {
+      const userKey = await createUserApiKeyRepository().findByUserAndApi(keyOwnerId, apiId);
+      if (userKey?.encryptedKey) {
+        try { resolvedKey = decryptApiKey(userKey.encryptedKey); } catch { /* skip */ }
+      }
+    } catch { /* 조회 실패 시 플랫폼 키로 폴백 */ }
+  }
+```
+
+호출부도 함께 수정한다: `resolveApiKey(apiId, cfg, keyOwnerIdOf(ctx), headers, targetUrl)`.
+
+- [ ] **Step 6: 테스트 통과 확인**
+
+Run: `pnpm vitest run src/__tests__/api/proxy.test.ts`
+Expected: PASS (기존 + 신규 6건)
+
+- [ ] **Step 7: 전체 검증**
+
+Run: `pnpm lint && pnpm type-check && pnpm test`
+Expected: 전부 통과. 기존 프록시 테스트가 `getAuthUser` mock에 의존하므로 실패하면 site/app 모드 세팅을 보강한다.
+
+- [ ] **Step 8: 커밋**
+
+```bash
+git add src/app/api/v1/proxy/route.ts src/__tests__/api/proxy.test.ts
+git commit -m "fix: 익명 게시 사이트 프록시 허용 및 소유권 강제 (C-2·H-1)
+
+C-2: 프록시가 항상 세션을 요구해 게시 사이트의 익명 방문자가 401이었다.
+resolveProxyContext로 site/app 모드를 판정해 published 사이트의 익명
+요청을 허용한다.
+
+H-1: resolveApiKey가 클라이언트가 보낸 projectId로 그 프로젝트 오너의
+개인 API 키를 복호화하면서 호출자 소유 여부를 확인하지 않았다. 로그인한
+아무나 남의 키 할당량을 소진시킬 수 있었다. 키 소유자를 컨텍스트에서만
+받도록 바꿔 소유권 검증을 우회할 경로를 없앴다.
+
+site 모드는 IP+projectId 리밋, app 모드는 기존 userId 리밋을 적용한다."
+```
+
+---
+
+### Task 6: 문서 동기화 및 최종 검증
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Create: `docs/decisions/2026-07-28-published-site-proxy-authz.md`
+
+**Interfaces:**
+- Consumes: Task 1~5 전체
+- Produces: 없음
+
+- [ ] **Step 1: ADR 작성**
+
+`docs/decisions/2026-07-28-published-site-proxy-authz.md`를 아래 구성으로 작성한다.
+
+```markdown
+# 게시 사이트 프록시 복구 및 인가 모델 정비 (2026-07-28)
+
+## 상태
+승인됨 — 구현 완료
+
+## 배경
+- 검수 경위: Claude 독립 검증 + Grok 독립 감사 + 상호 반박 라운드로 13건 확정, 그중 C·H 4건이 본 범위
+- C-1 프로덕션 실측 근거 (apex 401 vs 서브도메인 404) — 실제 curl 출력 그대로 인용
+- 왜 지금까지 드러나지 않았는가: 미리보기는 apex라 정상 동작, 게시 사이트가 아직 없었음
+
+## 결정
+1. 미들웨어 `SUBDOMAIN_PASSTHROUGH_PREFIXES` — 프록시 경로만 리라이트 예외 (최소 노출 근거 포함)
+2. `resolveProxyContext()` 단일 진입점 — site/app 이중 모드 판정표
+3. Host 우선 원칙 — 클라이언트 `projectId`는 Host가 있으면 무시
+4. `apiId ∈ project_apis` 양 모드 공통 강제
+5. 토큰 원자적 소비 — 2단계를 단일 UPDATE ... RETURNING으로
+
+## 트레이드오프 (명시)
+published `projectId`를 아는 사람은 누구나 그 오너의 키로 업스트림 호출을 트리거할 수 있다.
+게시 사이트 자체가 공개이므로 노출 수준은 동일하나, 레이트리밋이 유일한 방어선이 된다.
+한도(20/분 IP+project, 120/분 project)와 조정 방법(환경변수)을 기재한다.
+
+## 검증
+Task 1~6의 실제 실행 결과 표 — lint · type-check · 테스트 수 · build · standalone 헬스체크 ·
+배포 후 curl 3종 결과
+
+## 범위 밖
+M-1~M-8 및 `AUTH_URL` 미설정 건 목록
+```
+
+- [ ] **Step 2: CLAUDE.md 갱신**
+
+"문서 참조" 테이블에 ADR 행을 추가하고, "배포 품질 원칙 → 서빙 파이프라인 변경 시" 항목에 아래를 추가한다.
+
+```markdown
+- **서브도메인 리라이트 예외**: `src/middleware.ts`의 `SUBDOMAIN_PASSTHROUGH_PREFIXES`에 있는 경로만 `/site/{slug}` 리라이트를 건너뛴다. 게시 사이트의 생성 JS가 상대경로 `/api/v1/proxy`로 호출하므로 이 예외가 없으면 API 데이터가 전부 404가 된다. 새 경로를 추가할 땐 최소 노출 원칙을 지킬 것
+- **프록시 인가는 `resolveProxyContext()` 단일 진입점**: site(익명·Host 바인딩)/app(세션·소유권 강제) 판정이 여기 한 곳에 있다. 라우트에 인가 분기를 새로 만들지 말 것 — 판단이 흩어져 개인 키 해석부가 소유권을 확인하지 않던 것이 H-1이었다
+```
+
+- [ ] **Step 3: 전체 파이프라인 검증**
+
+```bash
+pnpm lint && pnpm type-check && pnpm test && pnpm build
+```
+Expected: 전부 통과
+
+- [ ] **Step 4: standalone 부팅 확인**
+
+미들웨어를 수정했으므로 CLAUDE.md 규칙에 따라 standalone 서버 기동을 확인한다.
+
+Run: `pnpm test:prod`
+Expected: `healthcheck: 200`
+
+- [ ] **Step 5: 커밋 및 PR**
+
+```bash
+git add CLAUDE.md docs/decisions/2026-07-28-published-site-proxy-authz.md
+git commit -m "docs: 게시 사이트 프록시 복구·인가 모델 ADR 및 CLAUDE.md 규칙 추가"
+git push -u origin fix/published-site-proxy-authz
+```
+
+PR 본문에는 프로덕션 실측 근거(apex 401 vs 서브도메인 404), 4건의 수정 내용, 명시적 트레이드오프, 검증 결과표를 포함한다.
+
+---
+
+## 배포 후 확인 (머지 이후)
+
+게시 사이트가 실제로 복구됐는지는 **게시된 프로젝트가 있어야** 확인 가능하다. 현재 게시된
+사이트가 없으므로, 배포 후 테스트 프로젝트를 하나 게시해 아래를 확인한다.
+
+```bash
+# 1) 서브도메인 프록시가 404가 아닌지 (라우트 도달)
+curl -s -o /dev/null -w "%{http_code}\n" "https://<slug>.xzawed.xyz/api/v1/proxy?apiId=<연결된 apiId>&proxyPath=/<경로>"
+#    기대: 200 (익명 허용) — 404면 미들웨어 패스스루 미적용
+
+# 2) 연결되지 않은 apiId는 차단되는지
+curl -s -o /dev/null -w "%{http_code}\n" "https://<slug>.xzawed.xyz/api/v1/proxy?apiId=<무관한 apiId>&proxyPath=/x"
+#    기대: 403
+
+# 3) 서브도메인의 다른 API 경로는 여전히 닫혀 있는지
+curl -s -o /dev/null -w "%{http_code}\n" "https://<slug>.xzawed.xyz/api/v1/projects"
+#    기대: 404 (리라이트되어 site 라우트로 감)
+```
+
+## 범위 밖 (다음 라운드)
+
+M-1 Quality Loop AbortSignal · M-2 stale `validation` 저장 · M-3 레이트리밋 fail-open 환불 ·
+M-4 프록시 캐시 키 owner 신원 누락 · M-5 `generationTracker` LRU/TTL 락 소실 ·
+M-6 기존 프록시 리미터 eviction 리셋 · M-7 IPv4-mapped IPv6 SSRF · M-8 `x-real-ip` 신뢰 ·
+`AUTH_URL` 미설정으로 인한 `callback-url=https://0.0.0.0:8080`

--- a/docs/superpowers/plans/2026-07-28-published-site-proxy-authz.md
+++ b/docs/superpowers/plans/2026-07-28-published-site-proxy-authz.md
@@ -149,11 +149,19 @@ function isSubdomainPassthrough(pathname: string): boolean {
 Run: `pnpm vitest run src/middleware.test.ts`
 Expected: PASS (신규 6건 포함 전체 통과)
 
-- [ ] **Step 5: 커버리지 등록 확인**
+- [ ] **Step 5: 커버리지 등록 (확인이 아니라 추가 — 현재 없음)**
 
-`vitest.config.ts`의 `coverage.include`에 `src/middleware.ts`가 있는지 확인한다. 없으면 추가한다.
+`src/middleware.ts`는 **현재 `coverage.include`에 없다**(확인됨). 누락 시 변경 라인이
+SonarCloud `new_coverage`·`codecov/patch`에서 0%로 계산되어 CI가 실패한다.
 
-Run: `grep -n "middleware" vitest.config.ts`
+`vitest.config.ts`의 `coverage.include` 배열에 추가한다:
+
+```ts
+        'src/middleware.ts',
+```
+
+Run: `grep -n "src/middleware.ts" vitest.config.ts`
+Expected: 한 줄 출력
 
 - [ ] **Step 6: 커밋**
 
@@ -219,18 +227,22 @@ function fakeRepo(): IAuthTokenRepository & { rows: Array<Record<string, unknown
 기존 테스트에 이어 추가한다.
 
 ```ts
-  it('동시 요청이 같은 토큰을 소비해도 한 번만 성공한다', async () => {
+  it('같은 토큰의 두 번째 소비는 null이다 (일회성 계약)', async () => {
     const repo = fakeRepo();
     const raw = await issueToken(repo, 'user-1', 'password_reset', EMAIL_VERIFY_TTL_MS);
 
-    const [a, b] = await Promise.all([
-      verifyAndConsumeToken(repo, raw, 'password_reset'),
-      verifyAndConsumeToken(repo, raw, 'password_reset'),
-    ]);
+    expect(await verifyAndConsumeToken(repo, raw, 'password_reset')).toBe('user-1');
+    expect(await verifyAndConsumeToken(repo, raw, 'password_reset')).toBeNull();
+  });
 
-    // 정확히 하나만 userId, 나머지는 null
-    expect([a, b].filter((x) => x === 'user-1')).toHaveLength(1);
-    expect([a, b].filter((x) => x === null)).toHaveLength(1);
+  it('verifyAndConsumeToken은 조회·소비를 나누지 않고 consumeValid 한 번만 호출한다', async () => {
+    // 2단계로 되돌아가면(조회 → await → 소비) 그 사이에 다른 요청이 끼어들 수 있다.
+    // 원자성의 실체는 SQL의 `WHERE consumed_at IS NULL`이고, 이 테스트는 호출부가
+    // 그 원자 연산을 우회하지 않는다는 계약을 고정한다.
+    const repo = fakeRepo();
+    const raw = await issueToken(repo, 'user-1', 'email_verify', EMAIL_VERIFY_TTL_MS);
+    await verifyAndConsumeToken(repo, raw, 'email_verify');
+    expect(repo.consumeValid).toHaveBeenCalledTimes(1);
   });
 
   it('만료된 토큰은 소비되지 않는다', async () => {
@@ -317,6 +329,41 @@ export async function verifyAndConsumeToken(
 
 `src/services/authService.test.ts`의 fake repo가 `findValidByHash`를 참조한다(32·77·83·156·162행). `consumeValid`로 교체한다. 예를 들어 `findValidByHash.mockResolvedValue({ id: 'tok1', userId })`는 `consumeValid.mockResolvedValue(userId)`로, `mockResolvedValue(null)`은 그대로 `null`이다.
 
+- [ ] **Step 6b: SQLite 레포 테스트 재작성 (이걸 빠뜨리면 CI가 깨진다)**
+
+`src/repositories/sqlite/SqliteAuthTokenRepository.test.ts`가 제거되는 `findValidByHash`(33·39·44·46·51·58·59행)와 `consume`(45행)을 직접 호출한다. **실 SQLite에 대한 유일한 원자성 검증**이므로 지우지 말고 `consumeValid` 기준으로 재작성한다.
+
+```ts
+  it('유효한 토큰을 소비하면 userId를 반환한다', async () => {
+    await repo.create('user-1', 'hash-a', 'email_verify', future);
+    expect(await repo.consumeValid('hash-a', 'email_verify', now)).toBe('user-1');
+  });
+
+  it('같은 토큰을 두 번 소비하면 두 번째는 null (실 SQLite 원자성)', async () => {
+    await repo.create('user-1', 'hash-c', 'password_reset', future);
+    expect(await repo.consumeValid('hash-c', 'password_reset', now)).toBe('user-1');
+    expect(await repo.consumeValid('hash-c', 'password_reset', now)).toBeNull();
+  });
+
+  it('만료된 토큰은 소비되지 않는다', async () => {
+    await repo.create('user-1', 'hash-d', 'password_reset', past);
+    expect(await repo.consumeValid('hash-d', 'password_reset', now)).toBeNull();
+  });
+
+  it('타입이 다르면 소비되지 않는다', async () => {
+    await repo.create('user-1', 'hash-e', 'email_verify', future);
+    expect(await repo.consumeValid('hash-e', 'password_reset', now)).toBeNull();
+  });
+
+  it('invalidateByUserAndType 이후에는 소비되지 않는다', async () => {
+    await repo.create('user-1', 'hash-f', 'password_reset', future);
+    await repo.invalidateByUserAndType('user-1', 'password_reset', now);
+    expect(await repo.consumeValid('hash-f', 'password_reset', now)).toBeNull();
+  });
+```
+
+기존 파일의 `repo`·`now`·`future`·`past` 셋업(상단 `beforeEach`)은 그대로 재사용한다.
+
 - [ ] **Step 7: 테스트 통과 확인**
 
 Run: `pnpm vitest run src/lib/auth/tokens.test.ts src/services/authService.test.ts`
@@ -330,7 +377,7 @@ Expected: 통과 — 제거한 메서드를 참조하는 곳이 남아 있으면
 - [ ] **Step 9: 커밋**
 
 ```bash
-git add src/repositories/interfaces/IAuthTokenRepository.ts src/repositories/sqlite/SqliteAuthTokenRepository.ts src/lib/auth/tokens.ts src/lib/auth/tokens.test.ts src/services/authService.test.ts
+git add src/repositories/interfaces/IAuthTokenRepository.ts src/repositories/sqlite/SqliteAuthTokenRepository.ts src/repositories/sqlite/SqliteAuthTokenRepository.test.ts src/lib/auth/tokens.ts src/lib/auth/tokens.test.ts src/services/authService.test.ts
 git commit -m "fix: 일회성 토큰을 원자적으로 소비 (H-2)
 
 findValidByHash → await → consume(id) 2단계였고 consume은 WHERE id만
@@ -536,6 +583,7 @@ Expected: FAIL — 모듈 없음
 import type { Project } from '@/types/project';
 import type { AuthUser } from '@/lib/auth/types';
 import { isValidSlug } from '@/lib/utils/slugify';
+import { assertOwner } from '@/lib/auth/authorize';
 
 /**
  * 프록시 요청의 인가 컨텍스트.
@@ -573,13 +621,20 @@ const FORBIDDEN: ProxyContextError = {
   error: { status: 403, code: 'FORBIDDEN', message: '권한이 없습니다.' },
 };
 
-/** Host 헤더에서 게시 사이트 slug를 추출한다. 서브도메인이 아니면 null. */
+/**
+ * Host 헤더에서 게시 사이트 slug를 추출한다. 서브도메인이 아니면 null.
+ *
+ * 호스트명은 대소문자를 구분하지 않으므로(RFC 4343) 비교 전에 소문자로 정규화한다.
+ * 정규화하지 않으면 `Weather.xzawed.xyz` 같은 요청이 endsWith·isValidSlug에서
+ * 조용히 탈락해 간헐적으로만 실패한다.
+ */
 export function extractSiteSlug(host: string, rootDomain: string | undefined): string | null {
   if (!rootDomain) return null;
-  if (host.includes('localhost') || host.includes('127.0.0.1')) return null;
-  const hostname = host.split(':')[0];
-  if (!hostname.endsWith(`.${rootDomain}`)) return null;
-  const slug = hostname.slice(0, -(rootDomain.length + 1));
+  const hostname = host.toLowerCase().split(':')[0];
+  if (hostname.includes('localhost') || hostname.includes('127.0.0.1')) return null;
+  const root = rootDomain.toLowerCase();
+  if (!hostname.endsWith(`.${root}`)) return null;
+  const slug = hostname.slice(0, -(root.length + 1));
   // isValidSlug가 예약어(www·api·admin 등)와 형식을 함께 검사한다.
   return isValidSlug(slug) ? slug : null;
 }
@@ -608,8 +663,13 @@ export async function resolveProxyContext(
     if (!projectId) return { mode: 'app', user, project: null, linkedApiIds: [] };
     const project = await deps.findProjectById(projectId);
     if (!project) return NOT_FOUND;
-    // 기존 인가 규약과 동일하게 소유자가 아니면 403.
-    if (project.userId !== user.id) return FORBIDDEN;
+    // 소유권 규약은 assertOwner 한 곳에만 둔다 — 프록시 전용 비교식을 새로 만들면
+    // 규약이 갈라지고, 개인 키 해석부가 소유권을 확인하지 않던 H-1이 재발한다.
+    try {
+      assertOwner(project, user.id);
+    } catch {
+      return FORBIDDEN;
+    }
     const linkedApiIds = await deps.getProjectApiIds(project.id);
     if (!linkedApiIds.includes(apiId)) return API_NOT_LINKED;
     return { mode: 'app', user, project, linkedApiIds };
@@ -1136,10 +1196,73 @@ function keyOwnerIdOf(ctx: ProxyContext): string | null {
 
 호출부도 함께 수정한다: `resolveApiKey(apiId, cfg, keyOwnerIdOf(ctx), headers, targetUrl)`.
 
+- [ ] **Step 5b: 개인 키가 주입된 응답은 캐시하지 않는다 (M-4 가드레일)**
+
+`buildCacheKey`는 `apiId:proxyPath:params`뿐이라 **키 신원이 들어가지 않는다**. 지금까지는
+캐시 대상이 공개 키리스 API뿐이라 잠복 상태였지만, 이번 변경으로 **익명 호출자가 오너의 개인
+키로 업스트림을 호출**하게 되므로 같은 캐시 항목이 테넌트를 넘나들 위험이 실제화된다.
+내가 만든 위험이므로 여기서 최소한으로 닫는다.
+
+`resolveApiKey`가 개인 키를 주입했는지 호출부에 알리도록 반환값을 바꾼다.
+
+```ts
+// resolveApiKey 시그니처: Promise<void> → Promise<{ usedPersonalKey: boolean }>
+// 개인 키 분기에서 복호화에 성공하면 usedPersonalKey = true
+```
+
+호출부에서 캐시 저장·조회를 건너뛴다.
+
+```ts
+  // 개인 키로 받은 응답은 테넌트 간 공유가 불가하다. 캐시 키에 키 신원이 없으므로
+  // 캐시 자체를 건너뛴다(가장 단순하고 안전한 선택).
+  const cacheable = cacheTtlMs !== null && !usedPersonalKey;
+```
+
+`cacheTtlMs !== null` 조건을 쓰는 곳(조회 305-320행, 저장 353-355행, 응답 헤더 362-364행)을
+모두 `cacheable`로 바꾼다. 개인 키 경로는 `Cache-Control: no-store`가 되어야 한다.
+
+테스트를 추가한다.
+
+```ts
+  it('개인 키가 주입된 응답은 캐시하지 않는다 (M-4 가드레일)', async () => {
+    const { res } = await invokeProxy({
+      request: siteReq('weather.xzawed.xyz'),
+      user: null,
+      projectBySlug: PROJECT,
+      // 오너의 개인 키가 존재하는 상황을 만든다
+      personalKey: 'secret-key',
+    });
+    expect(res.headers.get('X-Cache')).toBeNull();
+    expect(res.headers.get('Cache-Control')).toContain('no-store');
+  });
+```
+
+`invokeProxy`에 `personalKey?: string` 옵션을 추가해 `userApiKeyRepo.findByUserAndApi`가
+`{ encryptedKey: 'enc' }`를 반환하게 하고, `decryptApiKey` mock이 그 값을 돌려주게 한다.
+
+- [ ] **Step 5c: 재생성 프롬프트에 projectId 추가**
+
+[`promptBuilder.ts:947`](../../../src/lib/ai/promptBuilder.ts)의
+`buildStage1RegenerationUserPrompt`가 만드는 프록시 URL에는 `projectId`가 없다(확인됨).
+서브도메인은 Host 모드로 덮이지만 apex 직접 게시 경로와 개인 키 해석이 이 파라미터에 의존한다.
+
+함수 시그니처에 `projectId?: string`을 추가하고 최초 생성 경로(830행)와 동일하게 만든다.
+
+```ts
+  const projectParam = projectId ? `&projectId=${projectId}` : '';
+  const callMethod = `서버 프록시 (인증 방식 무관): /api/v1/proxy?apiId=${api.id}${projectParam}&proxyPath=<경로>`;
+```
+
+호출부(재생성 라우트)에서 `project.id`를 넘긴다. 기존 호출부가 인자를 넘기지 않아도
+`projectId?`가 선택적이라 타입은 깨지지 않지만, **넘기지 않으면 이 수정이 무의미하므로
+호출부 수정까지 반드시 포함한다.**
+
+Run: `grep -rn "buildStage1RegenerationUserPrompt" src --include=*.ts` 로 호출부를 찾는다.
+
 - [ ] **Step 6: 테스트 통과 확인**
 
 Run: `pnpm vitest run src/__tests__/api/proxy.test.ts`
-Expected: PASS (기존 + 신규 6건)
+Expected: PASS (기존 + 신규 7건)
 
 - [ ] **Step 7: 전체 검증**
 
@@ -1170,6 +1293,7 @@ site 모드는 IP+projectId 리밋, app 모드는 기존 userId 리밋을 적용
 
 **Files:**
 - Modify: `CLAUDE.md`
+- Modify: `docs/reference/env-vars.md`
 - Create: `docs/decisions/2026-07-28-published-site-proxy-authz.md`
 
 **Interfaces:**
@@ -1219,6 +1343,18 @@ M-1~M-8 및 `AUTH_URL` 미설정 건 목록
 - **서브도메인 리라이트 예외**: `src/middleware.ts`의 `SUBDOMAIN_PASSTHROUGH_PREFIXES`에 있는 경로만 `/site/{slug}` 리라이트를 건너뛴다. 게시 사이트의 생성 JS가 상대경로 `/api/v1/proxy`로 호출하므로 이 예외가 없으면 API 데이터가 전부 404가 된다. 새 경로를 추가할 땐 최소 노출 원칙을 지킬 것
 - **프록시 인가는 `resolveProxyContext()` 단일 진입점**: site(익명·Host 바인딩)/app(세션·소유권 강제) 판정이 여기 한 곳에 있다. 라우트에 인가 분기를 새로 만들지 말 것 — 판단이 흩어져 개인 키 해석부가 소유권을 확인하지 않던 것이 H-1이었다
 ```
+
+- [ ] **Step 2b: 신규 환경변수 문서화**
+
+`docs/reference/env-vars.md`에 3개를 추가한다(프로젝트 문서 규칙: 환경변수는 이 파일이 단일 출처).
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `SITE_PROXY_RATE_LIMIT_PER_MIN` | 20 | 익명 게시 사이트 프록시 — IP+projectId 단위 분당 한도 |
+| `SITE_PROXY_PROJECT_LIMIT_PER_MIN` | 120 | 익명 게시 사이트 프록시 — 프로젝트 전역 분당 한도(분산 IP 상한) |
+| `MAX_SITE_RATE_LIMIT_BUCKETS` | 5000 | site 리미터가 동시에 추적하는 최대 버킷 수 |
+
+CLAUDE.md "환경변수" 절에도 한 줄씩 추가한다.
 
 - [ ] **Step 3: 전체 파이프라인 검증**
 

--- a/docs/superpowers/specs/2026-07-28-published-site-proxy-authz-design.md
+++ b/docs/superpowers/specs/2026-07-28-published-site-proxy-authz-design.md
@@ -1,0 +1,224 @@
+# 게시 사이트 프록시 복구 및 인가 모델 정비 설계 (2026-07-28)
+
+## 배경
+
+전체 검수(Claude 독립 검증 + Grok 교차검증)에서 검증된 13건 중, **제품 핵심 기능이 동작하지
+않는 CRITICAL 2건과 인가 결함 HIGH 2건**을 이 설계의 범위로 삼는다. MEDIUM 7건은 검증된
+목록으로 남겨 다음 라운드에서 처리한다.
+
+### 해결 대상
+
+| ID | 심각도 | 내용 |
+|----|--------|------|
+| C-1 | critical | 게시 서브도메인에서 `/api/*`가 404 — 미들웨어가 전 경로를 `/site/{slug}`로 리라이트 |
+| C-2 | critical | 프록시가 세션을 요구 — 익명 방문자는 401 |
+| H-1 | high | 프록시 `projectId`에 소유권 검사 없음 — 타인의 개인 API 키 사용 가능 |
+| H-2 | high | 일회성 토큰이 원자적으로 소비되지 않음 — 재설정 링크 재사용 가능 |
+
+### C-1 근거 (프로덕션 실측)
+
+```
+GET https://xzawed.xyz/api/v1/proxy?…        → 401   (라우트 도달, 인증 요구)
+GET https://testprobe.xzawed.xyz/api/v1/proxy?… → 404   (리라이트되어 라우트 미매칭)
+```
+
+미들웨어([src/middleware.ts:38-49](../../../src/middleware.ts))는 서브도메인 요청의 **모든**
+경로를 `/site/{slug}{pathname}`로 리라이트한다. `/site/[slug]/route.ts`는 단일 동적 세그먼트라
+`/site/weather/api/v1/proxy`는 매칭되지 않는다.
+
+생성 프롬프트는 상대경로 호출을 강제하고 직접 외부 URL을 금지한다
+([promptBuilder.ts:491-494](../../../src/lib/ai/promptBuilder.ts)):
+
+```
+✅ fetch('/api/v1/proxy?apiId=<ID>&proxyPath=<경로>')
+❌ fetch('https://api.example.com/v1/data')   ← CORS 차단
+```
+
+따라서 **API를 사용하는 게시 사이트는 전부 데이터 로딩에 실패**한다. 미리보기는 apex 도메인이라
+정상 동작해 결함이 드러나지 않았다.
+
+### 전제 (실측 확인)
+
+- 세션 쿠키는 `__Host-` / `__Secure-` 프리픽스이며 `Domain` 속성이 없다 → **호스트 전용**.
+  AI 생성 사이트(`slug.xzawed.xyz`)는 방문자의 apex 세션 쿠키에 접근할 수 없다.
+- 현재 게시된(published) 사이트는 없다 → 활성 장애가 아닌 **잠복 결함**. 정규 설계·검증 절차를 밟는다.
+
+## 설계
+
+### 1. 요청 모드 판정 — `resolveProxyContext()` (신규)
+
+"누가, 어떤 프로젝트를 대신해 요청하는가"를 한 곳에서 결정하고, 프록시 라우트는 결과만 소비한다.
+현재 인증·인가 판단이 `validateRequest`와 `resolveApiKey` 두 곳에 흩어져 H-1이 발생했으므로,
+단일 진입점으로 모은다.
+
+```ts
+type ProxyContext =
+  | { mode: 'site'; project: Project; linkedApiIds: string[] }
+  | { mode: 'app'; user: AuthUser; project: Project | null; linkedApiIds: string[] };
+
+async function resolveProxyContext(
+  request: Request,
+  apiId: string,
+): Promise<ProxyContext | Response>;
+```
+
+판정 순서:
+
+| # | 조건 | 결과 |
+|---|------|------|
+| 1 | Host가 `{slug}.{NEXT_PUBLIC_ROOT_DOMAIN}`이고 `isValidSlug(slug)` 통과 | slug로 프로젝트 조회 → `status==='published'`면 **site 모드**, 아니면 404 |
+| 2 | apex + 유효 세션 | **app 모드** |
+| 3 | apex + 세션 없음 + `projectId`가 published | **site 모드** |
+| 4 | 그 외 | 401 |
+
+**3번이 필요한 이유**: apex의 `/site/{slug}` 직접 서빙 경로가 존재한다. 3번을 빼면
+"서브도메인에선 되고 직접 게시 URL에선 안 되는" 경로별 분기가 생긴다 — CLAUDE.md
+"서빙 파이프라인 변경 시 3가지 경로 모두 추적" 원칙 위반.
+
+생성 프롬프트는 [promptBuilder.ts:830](../../../src/lib/ai/promptBuilder.ts)에서 이미
+`&projectId=`를 붙이므로 프롬프트·기존 생성 코드 변경이 없다.
+
+**Host 우선 원칙**: Host로 프로젝트가 확정되면 클라이언트가 보낸 `projectId`는 **무시**한다
+(불일치 시에도 Host를 신뢰). 클라이언트 입력이 인가 근거가 되지 않게 한다.
+
+### 2. 인가 규칙
+
+| 모드 | 프로젝트 출처 | apiId 검사 | 키 출처 | 레이트리밋 |
+|------|---------------|-----------|---------|-----------|
+| site | Host slug(우선) 또는 published `projectId` | `apiId ∈ project_apis` **강제** | 플랫폼 키 또는 **그 프로젝트 오너**의 개인 키 | IP + projectId |
+| app | 클라이언트 `projectId` + **소유권 assert** | `projectId`가 있으면 동일 강제 | 플랫폼 키 또는 **호출자 본인**의 개인 키 | userId (기존 유지) |
+
+- **H-1 수정**: app 모드는 `project.userId === user.id`를 확인한 뒤에만 개인 키를 해석한다.
+  현재 [proxy/route.ts:209-227](../../../src/app/api/v1/proxy/route.ts)의
+  "게시 사이트 서빙 의미상 소유권 미적용" 주석과 그 동작을 제거한다. 게시 신뢰는
+  **Host→slug**에서 오지, 자유 입력 `projectId`에서 오지 않는다.
+- **`apiId ∈ project_apis`**: 두 모드 공통. 게시 사이트가 자신과 무관한 카탈로그 API를
+  오너 키로 호출하는 것을 막는다. 조회는 `projectService.getProjectApiIds(projectId)`.
+
+### 3. 미들웨어 변경 (C-1)
+
+서브도메인에서 **프록시 경로 하나만** 리라이트 예외로 둔다. `/api/*` 전체를 여는 것이 아니라
+최소 노출 원칙을 적용한다.
+
+```ts
+const SUBDOMAIN_PASSTHROUGH_PREFIXES = ['/api/v1/proxy'];
+
+function isSubdomainPassthrough(pathname: string): boolean {
+  return SUBDOMAIN_PASSTHROUGH_PREFIXES.some(
+    (p) => pathname === p || pathname.startsWith(`${p}/`),
+  );
+}
+```
+
+패스스루에 해당하면 rewrite를 건너뛰고 **일반 응답 경로로 흘려보낸다**. 그래야 기존 보안 헤더
+설정(`X-Content-Type-Options`, HSTS 등)과 "API 경로에는 CSP 미적용" 규칙이 그대로 적용된다.
+서브도메인 분기에서 조기 `return` 하면 이 처리가 누락되므로 주의한다.
+
+> `/api/*` 전체를 열지 않는 이유: 세션 쿠키가 호스트 전용이라 생성 사이트가 방문자 세션을
+> 탈취할 수는 없지만, 불필요한 엔드포인트 노출(예: `/api/auth/*`가 서브도메인에 쿠키를 설정)을
+> 만들 이유가 없다.
+
+### 4. 익명 사이트 모드 레이트리밋
+
+승인된 정책: **오너 개인 키 사용 허용 + 강한 레이트리밋**. 이 리미터가 타인 API 키 소진을 막는
+유일한 경계이므로 별도 버킷으로 분리한다.
+
+- 키: `${clientIp}:${projectId}` — IP는 `getClientIp()`(`src/lib/auth/rateLimit.ts`) 단일 출처 사용
+  (XFF **최우측**만 신뢰하는 기존 규칙 준수)
+- 프로젝트당 전역 상한을 추가로 두어 분산 IP 공격이 한 오너의 키를 소진시키는 것을 제한
+
+한도는 `src/lib/config/rateLimit.ts`에 환경변수로 추가한다(기존 `RATE_LIMIT_PER_MIN`과 별개):
+
+| 상수 | 환경변수 | 기본값 | 의미 |
+|------|----------|--------|------|
+| `SITE_PROXY_RATE_LIMIT_PER_MIN` | 동명 | **20**/분 | IP+projectId 단위. 일반 사이트 방문자의 정상 사용은 덮되 남용은 차단 |
+| `SITE_PROXY_PROJECT_LIMIT_PER_MIN` | 동명 | **120**/분 | 프로젝트 전역. 분산 IP로 한 오너 키를 소진시키는 것을 상한 |
+
+기본값은 보수적으로 시작한다 — 게시 사이트가 아직 없어 실사용 데이터가 없으므로,
+운영 로그를 보고 환경변수로 조정한다(코드 변경 불필요).
+
+**M-6 패턴을 신규 경로에 심지 않는다**: 기존 프록시 리미터는 `LRUMap(1000)` eviction 시 활성
+윈도의 카운터가 리셋되어 한도를 우회할 수 있다(검증됨, 이번 범위 밖). 신규 site 리미터는
+**활성 윈도를 eviction으로 리셋하지 않도록** 만든다 — 만료 기반 정리만 수행하고, 용량 압박 시
+새 키를 거부할지언정 살아 있는 카운터를 버리지 않는다.
+
+### 5. 토큰 원자적 소비 (H-2)
+
+현재 [tokens.ts:26-35](../../../src/lib/auth/tokens.ts)는 조회 → `await` → 소비의 2단계이고,
+`consume`은 `WHERE id = ?`만 검사한다(`consumed_at IS NULL` 가드 없음, 변경 행 수 미확인).
+두 `await` 사이에 이벤트 루프가 다른 요청을 진행시킬 수 있어 동시 요청이 모두 성공한다.
+
+단일 원자 문으로 대체한다:
+
+```sql
+UPDATE auth_tokens
+   SET consumed_at = ?
+ WHERE token_hash = ? AND type = ? AND consumed_at IS NULL AND expires_at > ?
+RETURNING user_id
+```
+
+- `IAuthTokenRepository`에 `consumeValid(tokenHash, type, now): Promise<string | null>` 추가
+- `verifyAndConsumeToken`은 이 메서드만 호출하고, 0행이면 `null`(무효) 반환
+- 기존 `findValidByHash` + `consume` 조합은 **오용 여지가 남으므로 다른 호출자가 없으면 제거**한다
+
+### 6. 에러 처리
+
+| 상황 | 응답 | 이유 |
+|------|------|------|
+| 프로젝트 부재 / 미게시 (site 모드) | 404 | 존재 여부를 구분해 노출하지 않음 |
+| `apiId ∉ project_apis` | 403 | 요청 자체는 인증됐으나 허용되지 않음 |
+| app 모드에서 미소유 `projectId` | **403** | 기존 관례 준수 — `assertOwner`(`src/lib/auth/authorize.ts`)가 `ForbiddenError`를 던진다 |
+| 레이트리밋 초과 | 429 + `Retry-After` | 클라이언트가 재시도 시점을 알 수 있게 함 |
+
+app 모드는 소유권 검증에 **기존 `assertOwner`를 재사용**한다. 프록시 전용 분기를 새로 만들지
+않아야 인가 규약이 한 곳에 유지된다.
+
+### 7. 테스트 전략
+
+**단위 — `resolveProxyContext` 진리표**
+Host 변형(서브도메인 / apex / `www` / 예약 slug / 알 수 없는 slug) × 프로젝트 상태(published /
+draft / 부재) × 세션 유무 × 소유 여부의 조합을 표로 고정한다.
+
+**단위 — 키 선택 격리 (H-1 회귀 방지)**
+- site 모드: 해당 프로젝트 오너의 키만 사용, 다른 사용자 키는 절대 조회되지 않음
+- app 모드: 타인 `projectId` 전달 시 개인 키 조회 이전에 차단
+- 두 모드 공통: `apiId ∉ project_apis`면 키 해석 자체가 일어나지 않음
+
+**단위 — 토큰 원자성 (H-2 회귀 방지)**
+동일 토큰으로 `verifyAndConsumeToken`을 연속 호출하면 첫 번째만 `userId`, 두 번째는 `null`.
+
+**통합 — 미들웨어 라우팅 (C-1 회귀 방지)**
+- 서브도메인 `/api/v1/proxy` → 리라이트되지 않고 라우트 도달
+- 서브도메인 그 외 경로 → 기존대로 `/site/{slug}`로 리라이트
+- 패스스루 응답에도 보안 헤더가 적용됨
+
+**회귀 — 미리보기 경로**
+apex + 세션(오너)의 미리보기가 기존과 동일하게 동작.
+
+**커버리지 설정**
+`src/app/api/v1/proxy/route.ts`는 이미 `vitest.config.ts`의 `coverage.include`에 있다.
+`src/middleware.ts`와 신규 파일이 포함되는지 확인하고, 빠졌으면 추가한다 — 누락 시 변경 라인이
+SonarCloud `new_coverage`·`codecov/patch`에서 0%로 계산되어 CI가 실패한다(CLAUDE.md 기록).
+
+## 명시적 트레이드오프
+
+site 모드는 결과적으로 **published `projectId`를 아는 사람은 누구나 그 오너의 키로 업스트림
+호출을 트리거할 수 있다**는 뜻이다. 게시된 사이트 자체가 공개이므로 노출 수준은 동일하지만,
+레이트리밋이 유일한 방어선이 된다. 사용자 승인된 정책("허용 + 강한 레이트리밋")이며,
+Host 바인딩을 우선 적용해 방어 심도를 더한다.
+
+## 범위 밖 (검증되었으나 다음 라운드)
+
+M-1 Quality Loop AbortSignal 부재 · M-2 저장되는 stale `validation` · M-3 레이트리밋
+fail-open 환불 · M-4 프록시 캐시 키의 owner 신원 누락 · M-5 `generationTracker` LRU/TTL
+락 소실 · M-6 프록시 리미터 eviction 리셋 · M-7 IPv4-mapped IPv6 SSRF 우회 ·
+M-8 `x-real-ip` 신뢰.
+
+부수 관찰: `__Secure-authjs.callback-url`이 `https://0.0.0.0:8080`으로 설정되어 있다
+(`AUTH_URL` 미설정 추정). 로그인 리다이렉트에 영향 가능 — 별도 확인 필요.
+
+## 참고
+
+- 감사 방법: Claude 독립 검증 + Grok 독립 감사 후 상호 반박 라운드. Grok의 "check→start
+  TOCTOU로 중복 파이프라인" 주장은 해당 구간에 `await`이 없어 오탐으로 철회됨.
+- [CLAUDE.md](../../../CLAUDE.md) 배포 품질 원칙 — 서빙 3경로 추적, CSP 이중 적용 금지

--- a/src/__tests__/api/proxy.test.ts
+++ b/src/__tests__/api/proxy.test.ts
@@ -433,15 +433,19 @@ describe('GET /api/v1/proxy', () => {
       };
       process.env.PLATFORM_API_KEY = 'platform-fallback-key';
 
-      const { createCatalogRepository, createProjectRepository } = await import(
-        '@/repositories/factory'
-      );
+      const { createCatalogRepository, createProjectRepository, createUserApiKeyRepository } =
+        await import('@/repositories/factory');
       vi.mocked(createCatalogRepository).mockReturnValue({
         findById: vi.fn().mockResolvedValue(apiWithKey),
       } as never);
-      // 프로젝트 조회 실패(레포 throw) → 플랫폼 키로 폴백
       vi.mocked(createProjectRepository).mockReturnValue({
-        findById: vi.fn().mockRejectedValue(new Error('DB 오류')),
+        findById: vi.fn().mockResolvedValue({ id: 'p-1', userId: mockUser.id, status: 'draft' }),
+        getProjectApiIds: vi.fn().mockResolvedValue([VALID_API_ID]),
+      } as never);
+      // 개인 키 조회 실패(레포 throw) → 플랫폼 키로 폴백.
+      // 인가(프로젝트 조회)는 성공해야 한다 — 인가 조회 실패는 폴백이 아니라 차단이다.
+      vi.mocked(createUserApiKeyRepository).mockReturnValue({
+        findByUserAndApi: vi.fn().mockRejectedValue(new Error('DB 오류')),
       } as never);
 
       const url = new URL('http://localhost/api/v1/proxy');
@@ -484,7 +488,8 @@ describe('GET /api/v1/proxy', () => {
         findById: vi.fn().mockResolvedValue(apiWithKey),
       } as never);
       vi.mocked(createProjectRepository).mockReturnValue({
-        findById: vi.fn().mockResolvedValue({ id: 'p-1', userId: 'owner-user-id' }),
+        findById: vi.fn().mockResolvedValue({ id: 'p-1', userId: mockUser.id, status: 'draft' }),
+        getProjectApiIds: vi.fn().mockResolvedValue([VALID_API_ID]),
       } as never);
       vi.mocked(createUserApiKeyRepository).mockReturnValue({
         findByUserAndApi: vi.fn().mockResolvedValue({ encryptedKey: 'corrupted-cipher' }),
@@ -522,7 +527,8 @@ describe('GET /api/v1/proxy', () => {
         findById: vi.fn().mockResolvedValue(apiWithKey),
       } as never);
       vi.mocked(createProjectRepository).mockReturnValue({
-        findById: vi.fn().mockResolvedValue({ id: 'p-1', userId: 'owner-user-id' }),
+        findById: vi.fn().mockResolvedValue({ id: 'p-1', userId: mockUser.id, status: 'draft' }),
+        getProjectApiIds: vi.fn().mockResolvedValue([VALID_API_ID]),
       } as never);
       const findByUserAndApi = vi.fn().mockResolvedValue({ encryptedKey: 'enc-personal' });
       vi.mocked(createUserApiKeyRepository).mockReturnValue({ findByUserAndApi } as never);
@@ -540,7 +546,7 @@ describe('GET /api/v1/proxy', () => {
       const res = await GET(req);
 
       // 개인 키가 레포 경로로 조회되어(raw .from 아님) 복호화에 사용됨
-      expect(findByUserAndApi).toHaveBeenCalledWith('owner-user-id', VALID_API_ID);
+      expect(findByUserAndApi).toHaveBeenCalledWith(mockUser.id, VALID_API_ID);
       expect(decryptApiKey).toHaveBeenCalledWith('enc-personal');
       expect(mockFetch).toHaveBeenCalled();
       expect([200, 502]).toContain(res.status);
@@ -816,5 +822,147 @@ describe('GET /api/v1/proxy', () => {
         }),
       );
     });
+  });
+});
+
+describe('프록시 인가 — site/app 모드 (C-2·H-1)', () => {
+  const ORIG_ENV = { ...process.env };
+  const PROJECT = { id: 'proj-1', userId: 'owner-1', status: 'published', slug: 'weather' };
+  const ATTACKER = { id: 'attacker', email: 'a@x.com', name: null, avatarUrl: null };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    const { __resetSiteRateLimit } = await import('@/lib/proxy/siteRateLimit');
+    __resetSiteRateLimit();
+    process.env.NEXT_PUBLIC_ROOT_DOMAIN = 'xzawed.xyz';
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(() => Promise.resolve(makeSuccessResponse())));
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIG_ENV };
+  });
+
+  function siteReq(host: string, extra = ''): Request {
+    return new Request(
+      `https://${host}/api/v1/proxy?apiId=${VALID_API_ID}&proxyPath=/data${extra}`,
+      { headers: { host } },
+    );
+  }
+
+  async function invokeProxy(opts: {
+    request: Request;
+    user?: typeof ATTACKER | null;
+    projectBySlug?: Record<string, unknown> | null;
+    projectById?: Record<string, unknown> | null;
+    linkedApiIds?: string[];
+    personalKey?: string;
+    api?: Record<string, unknown>;
+    times?: number;
+  }): Promise<{ res: Response; userApiKeyRepo: { findByUserAndApi: ReturnType<typeof vi.fn> } }> {
+    const { getAuthUser } = await import('@/lib/auth/index');
+    const factory = await import('@/repositories/factory');
+    const { decryptApiKey } = await import('@/lib/encryption');
+
+    vi.mocked(getAuthUser).mockResolvedValue(opts.user ?? null);
+
+    const userApiKeyRepo = {
+      findByUserAndApi: vi
+        .fn()
+        .mockResolvedValue(opts.personalKey ? { encryptedKey: 'enc' } : null),
+    };
+    vi.mocked(factory.createUserApiKeyRepository).mockReturnValue(userApiKeyRepo as never);
+    if (opts.personalKey) vi.mocked(decryptApiKey).mockReturnValue(opts.personalKey);
+
+    vi.mocked(factory.createProjectRepository).mockReturnValue({
+      findBySlug: vi.fn().mockResolvedValue(opts.projectBySlug ?? null),
+      findById: vi.fn().mockResolvedValue(opts.projectById ?? null),
+      getProjectApiIds: vi.fn().mockResolvedValue(opts.linkedApiIds ?? [VALID_API_ID]),
+    } as never);
+
+    vi.mocked(factory.createCatalogRepository).mockReturnValue({
+      findById: vi.fn().mockResolvedValue(opts.api ?? mockPublicApi),
+    } as never);
+
+    const { GET } = await import('@/app/api/v1/proxy/route');
+    let res!: Response;
+    for (let i = 0; i < (opts.times ?? 1); i++) {
+      res = await GET(opts.request);
+    }
+    return { res, userApiKeyRepo };
+  }
+
+  it('published 서브도메인의 익명 요청을 허용한다 (C-2)', async () => {
+    const { res } = await invokeProxy({
+      request: siteReq('weather.xzawed.xyz'),
+      user: null,
+      projectBySlug: PROJECT,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('미게시 프로젝트의 서브도메인 요청은 404 (존재 여부 미노출)', async () => {
+    const { res } = await invokeProxy({
+      request: siteReq('weather.xzawed.xyz'),
+      user: null,
+      projectBySlug: { ...PROJECT, status: 'draft' },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('세션 사용자가 타인 projectId로 개인 키를 쓰려 하면 403 (H-1)', async () => {
+    const { res } = await invokeProxy({
+      request: siteReq('xzawed.xyz', '&projectId=proj-1'),
+      user: ATTACKER,
+      projectById: { ...PROJECT, userId: 'victim' },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('타인 projectId 요청에서는 개인 키 조회 자체가 일어나지 않는다 (H-1)', async () => {
+    const { userApiKeyRepo } = await invokeProxy({
+      request: siteReq('xzawed.xyz', '&projectId=proj-1'),
+      user: ATTACKER,
+      projectById: { ...PROJECT, userId: 'victim' },
+    });
+    expect(userApiKeyRepo.findByUserAndApi).not.toHaveBeenCalled();
+  });
+
+  it('프로젝트에 연결되지 않은 apiId는 403', async () => {
+    const { res } = await invokeProxy({
+      request: siteReq('weather.xzawed.xyz'),
+      user: null,
+      projectBySlug: PROJECT,
+      linkedApiIds: [],
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('site 모드 레이트리밋 초과 시 429 + Retry-After', async () => {
+    const { res } = await invokeProxy({
+      request: siteReq('weather.xzawed.xyz'),
+      user: null,
+      projectBySlug: PROJECT,
+      times: 25,
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBeTruthy();
+  });
+
+  it('개인 키가 주입된 응답은 캐시하지 않는다 (M-4 가드레일)', async () => {
+    const { res } = await invokeProxy({
+      request: siteReq('weather.xzawed.xyz'),
+      user: null,
+      projectBySlug: PROJECT,
+      personalKey: 'secret-key',
+      api: {
+        ...mockPublicApi,
+        authType: 'api_key',
+        cacheTtlSeconds: 300,
+        authConfig: { param_name: 'X-API-Key', param_in: 'header' },
+      },
+    });
+    expect(res.headers.get('X-Cache')).toBeNull();
+    expect(res.headers.get('Cache-Control')).toContain('no-store');
   });
 });

--- a/src/app/api/v1/generate/regenerate/route.ts
+++ b/src/app/api/v1/generate/regenerate/route.ts
@@ -98,6 +98,7 @@ export async function POST(request: Request): Promise<Response> {
       { html: previousCode.codeHtml, css: previousCode.codeCss, js: previousCode.codeJs },
       feedback,
       projectApis,
+      projectId,
     );
     const stage2SystemPrompt = buildStage2SystemPrompt();
 

--- a/src/app/api/v1/proxy/route.ts
+++ b/src/app/api/v1/proxy/route.ts
@@ -6,6 +6,9 @@ import {
 } from '@/repositories/factory';
 import { decryptApiKey } from '@/lib/encryption';
 import { getAuthUser } from '@/lib/auth/index';
+import { getClientIp } from '@/lib/auth/rateLimit';
+import { resolveProxyContext, isProxyContextError } from '@/lib/proxy/resolveProxyContext';
+import { checkSiteRateLimit } from '@/lib/proxy/siteRateLimit';
 import { LRUMap } from '@/lib/utils/lruMap';
 import { proxyCache, buildCacheKey } from '@/lib/cache/proxyCache';
 import {
@@ -81,23 +84,11 @@ interface ValidatedRequest {
   searchParams: URLSearchParams;
 }
 
-async function validateRequest(request: Request): Promise<ValidatedRequest | Response> {
-  const user = await getAuthUser();
-  if (!user) {
-    return errorResponse(401, 'AUTH_REQUIRED', '로그인이 필요합니다.');
-  }
-
-  // user.id 가드 — 타입상 string(non-nullable)이지만 런타임에서 인증 정보 손상 시
-  // null/undefined가 들어올 수 있다. rate limit Map에 잘못된 키('null', 'undefined')가
-  // 등록되거나 RLS 우회 시도가 가능해지므로 401로 즉시 차단.
-  if (!user.id || typeof user.id !== 'string') {
-    return errorResponse(401, 'AUTH_REQUIRED', '로그인이 필요합니다.');
-  }
-
-  if (!checkProxyRateLimit(user.id)) {
-    return errorResponse(429, 'RATE_LIMITED', '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.');
-  }
-
+/**
+ * 파라미터 형식만 검증한다.
+ * 인증·인가는 resolveProxyContext가, 레이트리밋은 모드 판정 후 handleProxy가 담당한다.
+ */
+function validateParams(request: Request): ValidatedRequest | Response {
   const { searchParams } = new URL(request.url);
   const apiId = searchParams.get('apiId');
   const proxyPath = searchParams.get('proxyPath');
@@ -200,28 +191,25 @@ async function resolveApiKey(
     prefix?: string;
     header_prefix?: string;
   },
-  searchParams: URLSearchParams,
+  keyOwnerId: string | null,
   headers: Record<string, string>,
   targetUrl: URL,
-): Promise<void> {
+): Promise<{ usedPersonalKey: boolean }> {
   let resolvedKey: string | undefined;
+  let usedPersonalKey = false;
 
-  // 1) 프로젝트 오너의 개인 API 키 조회 (projectId가 있을 때)
-  //    raw DB 접근 대신 레포(SQLite)를 사용한다.
-  const projectId = searchParams.get('projectId');
-  if (projectId && UUID_RE.test(projectId)) {
+  // 1) 키 소유자의 개인 API 키 조회.
+  //    소유자는 resolveProxyContext가 결정한다 — site 모드는 Host로 확정된 게시
+  //    프로젝트의 오너, app 모드는 소유권이 검증된 호출자 본인. 이전에는 클라이언트가
+  //    보낸 projectId로 아무 사용자의 키나 복호화할 수 있었다(H-1).
+  if (keyOwnerId) {
     try {
-      // NOTE: 공개 사이트 런타임이 자기 프로젝트의 API 키를 해결하는 경로 — 소유권은
-      // 게시 사이트 서빙 의미상 적용하지 않는다(다중 사용자 격리는 '관리/편집'에만 적용).
-      const project = await createProjectRepository().findById(projectId);
-      if (project?.userId) {
-        const userKey = await createUserApiKeyRepository().findByUserAndApi(
-          project.userId,
-          apiId,
-        );
-        if (userKey?.encryptedKey) {
-          try { resolvedKey = decryptApiKey(userKey.encryptedKey); } catch { /* skip */ }
-        }
+      const userKey = await createUserApiKeyRepository().findByUserAndApi(keyOwnerId, apiId);
+      if (userKey?.encryptedKey) {
+        try {
+          resolvedKey = decryptApiKey(userKey.encryptedKey);
+          usedPersonalKey = true;
+        } catch { /* skip */ }
       }
     } catch { /* 조회 실패 시 플랫폼 키로 폴백 */ }
   }
@@ -258,6 +246,8 @@ async function resolveApiKey(
       targetUrl.searchParams.set(cfg.param_name, injectedValue);
     }
   }
+
+  return { usedPersonalKey };
 }
 
 function resolveContentType(rawContentType: string): string {
@@ -268,10 +258,38 @@ function resolveContentType(rawContentType: string): string {
 }
 
 async function handleProxy(request: Request, method: 'GET' | 'POST'): Promise<Response> {
-  // 인증·레이트리밋·파라미터 검증
-  const validated = await validateRequest(request);
+  const validated = validateParams(request);
   if (validated instanceof Response) return validated;
   const { apiId, proxyPath, searchParams } = validated;
+
+  // 인가 판정 — site(익명·Host 바인딩) / app(세션·소유권 강제) 단일 진입점.
+  const projectRepo = createProjectRepository();
+  const ctx = await resolveProxyContext(request, apiId, {
+    getAuthUser,
+    findProjectBySlug: (slug) => projectRepo.findBySlug(slug),
+    findProjectById: (id) => projectRepo.findById(id),
+    getProjectApiIds: (id) => projectRepo.getProjectApiIds(id),
+    rootDomain: process.env.NEXT_PUBLIC_ROOT_DOMAIN,
+  });
+  if (isProxyContextError(ctx)) {
+    return errorResponse(ctx.error.status, ctx.error.code, ctx.error.message);
+  }
+
+  // 모드별 레이트리밋 — 익명 site는 IP+projectId, 세션 app은 기존 userId 버킷.
+  if (ctx.mode === 'site') {
+    const limit = checkSiteRateLimit(getClientIp(request), ctx.project.id);
+    if (!limit.allowed) {
+      return Response.json(
+        {
+          success: false,
+          error: { code: 'RATE_LIMITED', message: '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.' },
+        },
+        { status: 429, headers: { 'Retry-After': String(limit.retryAfterSec) } },
+      );
+    }
+  } else if (!checkProxyRateLimit(ctx.user.id)) {
+    return errorResponse(429, 'RATE_LIMITED', '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.');
+  }
 
   // Look up API using service role (bypasses RLS — read-only, catalog is semi-public)
   const catalogRepo = createCatalogRepository();
@@ -302,9 +320,32 @@ async function handleProxy(request: Request, method: 'GET' | 'POST'): Promise<Re
     }
   }
 
-  // Cache check — GET 요청 + API에 cacheTtlSeconds 설정된 경우만 적용
+  // Inject API key — 키 소유자는 인가 컨텍스트가 결정한다(클라이언트 입력 아님).
+  // 캐시 판정이 usedPersonalKey에 의존하므로 캐시 조회보다 먼저 수행한다.
+  const headers: Record<string, string> = {
+    'User-Agent': 'CustomWebService-Proxy/1.0',
+    Accept: 'application/json',
+  };
+
+  let usedPersonalKey = false;
+  if (api.authType === 'api_key') {
+    const cfg = api.authConfig as {
+      param_name?: string;
+      param_in?: string;
+      env_var?: string;
+      prefix?: string;
+      header_prefix?: string;
+    };
+    ({ usedPersonalKey } = await resolveApiKey(apiId, cfg, ctx.project?.userId ?? null, headers, targetUrl));
+  }
+
+  // Cache 사용 여부 — GET + cacheTtlSeconds 설정 + **개인 키 미사용**인 경우만.
+  //
+  // buildCacheKey는 apiId:proxyPath:params뿐이라 키 신원이 들어가지 않는다. 익명 사이트
+  // 모드에서 오너의 개인 키로 받은 응답을 캐시하면 같은 항목이 다른 테넌트에게 서빙된다.
+  // 캐시 키에 소유자를 넣는 대신 개인 키 경로는 캐시를 건너뛴다(가장 단순하고 안전).
   const cacheTtlMs =
-    method === 'GET' && api.cacheTtlSeconds != null && api.cacheTtlSeconds > 0
+    method === 'GET' && !usedPersonalKey && api.cacheTtlSeconds != null && api.cacheTtlSeconds > 0
       ? api.cacheTtlSeconds * 1000
       : null;
 
@@ -322,23 +363,6 @@ async function handleProxy(request: Request, method: 'GET' | 'POST'): Promise<Re
         },
       });
     }
-  }
-
-  // Inject API key — 우선순위: 사용자 키 > 프로젝트 오너 키 > 플랫폼 키
-  const headers: Record<string, string> = {
-    'User-Agent': 'CustomWebService-Proxy/1.0',
-    Accept: 'application/json',
-  };
-
-  if (api.authType === 'api_key') {
-    const cfg = api.authConfig as {
-      param_name?: string;
-      param_in?: string;
-      env_var?: string;
-      prefix?: string;
-      header_prefix?: string;
-    };
-    await resolveApiKey(apiId, cfg, searchParams, headers, targetUrl);
   }
 
   // Forward the request

--- a/src/lib/ai/promptBuilder.ts
+++ b/src/lib/ai/promptBuilder.ts
@@ -939,12 +939,17 @@ ${designSection}
 export function buildStage1RegenerationUserPrompt(
   previousCode: { html: string; css: string; js: string },
   feedback: string,
-  apis: ApiCatalogItem[] = []
+  apis: ApiCatalogItem[] = [],
+  projectId?: string
 ): string {
   const apiSection = apis.length > 0
     ? `## 프로젝트에 연결된 API (반드시 활용)
 ${apis.map((api) => {
-  const callMethod = `서버 프록시 (인증 방식 무관): /api/v1/proxy?apiId=${api.id}&proxyPath=<경로>`;
+  // 최초 생성 프롬프트와 동일하게 projectId를 포함한다. 서브도메인은 Host로 프로젝트를
+  // 확정하지만, apex의 직접 게시 URL(/site/{slug})에서는 이 파라미터가 있어야
+  // 프록시가 익명 요청을 게시 사이트로 인식한다.
+  const projectParam = projectId ? `&projectId=${projectId}` : '';
+  const callMethod = `서버 프록시 (인증 방식 무관): /api/v1/proxy?apiId=${api.id}${projectParam}&proxyPath=<경로>`;
   return `### ${api.name} (ID: ${api.id})
 - 호출 방법: ${callMethod}
 - 인증: ${api.authType}`;

--- a/src/lib/auth/tokens.test.ts
+++ b/src/lib/auth/tokens.test.ts
@@ -9,13 +9,18 @@ function fakeRepo(): IAuthTokenRepository & { rows: Array<Record<string, unknown
     create: vi.fn(async (userId, tokenHash, type, expiresAt) => {
       rows.push({ id: `t${rows.length}`, userId, tokenHash, type, expiresAt, consumed: false });
     }),
-    findValidByHash: vi.fn(async (tokenHash, type) => {
-      const r = rows.find((x) => x.tokenHash === tokenHash && x.type === type && !x.consumed);
-      return r ? { id: r.id as string, userId: r.userId as string } : null;
-    }),
-    consume: vi.fn(async (id) => {
-      const r = rows.find((x) => x.id === id);
-      if (r) r.consumed = true;
+    // 원자적 소비: 조건 검사와 상태 변경이 같은 동기 블록에서 일어난다.
+    consumeValid: vi.fn(async (tokenHash, type, now) => {
+      const r = rows.find(
+        (x) =>
+          x.tokenHash === tokenHash &&
+          x.type === type &&
+          !x.consumed &&
+          (x.expiresAt as string) > now,
+      );
+      if (!r) return null;
+      r.consumed = true;
+      return r.userId as string;
     }),
     invalidateByUserAndType: vi.fn(async () => {}),
   };
@@ -32,6 +37,29 @@ describe('tokens', () => {
     expect(userId).toBe('user-1');
     // 재사용 불가(소비됨)
     expect(await verifyAndConsumeToken(repo, raw, 'email_verify')).toBeNull();
+  });
+
+  it('조회·소비를 나누지 않고 consumeValid를 한 번만 호출한다', async () => {
+    // 2단계로 되돌아가면(조회 → await → 소비) 그 사이에 다른 요청이 끼어들어
+    // 같은 토큰이 두 번 소비될 수 있다. 원자성의 실체는 SQL의
+    // `WHERE consumed_at IS NULL`이고, 이 테스트는 호출부가 그 원자 연산을
+    // 우회하지 않는다는 계약을 고정한다(실 SQLite 검증은 레포 테스트에 있다).
+    const repo = fakeRepo();
+    const raw = await issueToken(repo, 'user-1', 'email_verify', EMAIL_VERIFY_TTL_MS);
+    await verifyAndConsumeToken(repo, raw, 'email_verify');
+    expect(repo.consumeValid).toHaveBeenCalledTimes(1);
+  });
+
+  it('만료된 토큰은 소비되지 않는다', async () => {
+    const repo = fakeRepo();
+    const raw = await issueToken(repo, 'user-1', 'email_verify', -1000);
+    expect(await verifyAndConsumeToken(repo, raw, 'email_verify')).toBeNull();
+  });
+
+  it('타입이 다르면 소비되지 않는다', async () => {
+    const repo = fakeRepo();
+    const raw = await issueToken(repo, 'user-1', 'email_verify', EMAIL_VERIFY_TTL_MS);
+    expect(await verifyAndConsumeToken(repo, raw, 'password_reset')).toBeNull();
   });
 
   it('잘못된 토큰은 null', async () => {

--- a/src/lib/auth/tokens.ts
+++ b/src/lib/auth/tokens.ts
@@ -28,9 +28,7 @@ export async function verifyAndConsumeToken(
   raw: string,
   type: AuthTokenType,
 ): Promise<string | null> {
-  const now = new Date().toISOString();
-  const found = await repo.findValidByHash(hashToken(raw), type, now);
-  if (!found) return null;
-  await repo.consume(found.id, now);
-  return found.userId;
+  // 조회와 소비를 분리하지 말 것 — 두 await 사이에 다른 요청이 같은 토큰을
+  // 소비할 수 있다(재설정 링크 재사용). 원자성은 repo.consumeValid의 단일 SQL이 보장한다.
+  return repo.consumeValid(hashToken(raw), type, new Date().toISOString());
 }

--- a/src/lib/config/rateLimit.ts
+++ b/src/lib/config/rateLimit.ts
@@ -24,3 +24,18 @@ export const RATE_LIMIT_WINDOW_MS = 60_000;
 
 /** 동시 활성 사용자 한도 (LRU evict 임계값). 기본 1000명. */
 export const MAX_CONCURRENT_RATE_LIMIT_USERS = envInt('MAX_CONCURRENT_RATE_LIMIT_USERS', 1000);
+
+/**
+ * 익명 게시 사이트 프록시 한도 — IP+projectId 단위. 기본 20회/분.
+ *
+ * 게시 사이트는 오너의 개인 API 키로 업스트림을 호출하므로, 이 리미터가 타인 키 소진을
+ * 막는 유일한 경계다. 게시 사이트 실사용 데이터가 없어 보수적으로 시작하고 운영 로그를
+ * 보고 환경변수로 조정한다(코드 변경 불필요).
+ */
+export const SITE_PROXY_RATE_LIMIT_PER_MIN = envInt('SITE_PROXY_RATE_LIMIT_PER_MIN', 20);
+
+/** 프로젝트 전역 한도. 분산 IP로 한 오너의 키를 소진시키는 것을 상한. 기본 120회/분. */
+export const SITE_PROXY_PROJECT_LIMIT_PER_MIN = envInt('SITE_PROXY_PROJECT_LIMIT_PER_MIN', 120);
+
+/** site 리미터가 동시에 추적하는 최대 버킷 수. 초과 시 만료 항목만 정리한다. */
+export const MAX_SITE_RATE_LIMIT_BUCKETS = envInt('MAX_SITE_RATE_LIMIT_BUCKETS', 5000);

--- a/src/lib/proxy/resolveProxyContext.test.ts
+++ b/src/lib/proxy/resolveProxyContext.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveProxyContext, extractSiteSlug, type ProxyContextDeps } from './resolveProxyContext';
+import type { Project } from '@/types/project';
+
+const API_ID = 'aaaabbbb-cccc-dddd-eeee-ffffffffffff';
+const OTHER_API_ID = '11112222-3333-4444-5555-666677778888';
+
+function makeProject(over: Partial<Project> = {}): Project {
+  return {
+    id: 'proj-1',
+    userId: 'owner-1',
+    organizationId: null,
+    name: 'p',
+    context: 'c',
+    status: 'published',
+    deployUrl: null,
+    deployPlatform: null,
+    repoUrl: null,
+    previewUrl: null,
+    metadata: {},
+    currentVersion: 1,
+    apis: [],
+    slug: 'weather',
+    publishedAt: '2026-01-01T00:00:00.000Z',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  } as Project;
+}
+
+/** 각 의존성을 vi.fn으로 노출해 호출 여부까지 단언할 수 있게 한다. */
+type MockedDeps = {
+  getAuthUser: ReturnType<typeof vi.fn>;
+  findProjectBySlug: ReturnType<typeof vi.fn>;
+  findProjectById: ReturnType<typeof vi.fn>;
+  getProjectApiIds: ReturnType<typeof vi.fn>;
+  rootDomain: string | undefined;
+};
+
+function makeDeps(over: Partial<MockedDeps> = {}): MockedDeps {
+  return {
+    getAuthUser: vi.fn(async () => null),
+    findProjectBySlug: vi.fn(async () => makeProject()),
+    findProjectById: vi.fn(async () => makeProject()),
+    getProjectApiIds: vi.fn(async () => [API_ID]),
+    rootDomain: 'xzawed.xyz',
+    ...over,
+  };
+}
+
+function call(deps: MockedDeps, url: string, host: string, apiId = API_ID) {
+  return resolveProxyContext(
+    new Request(url, { headers: { host } }),
+    apiId,
+    deps as unknown as ProxyContextDeps,
+  );
+}
+
+describe('extractSiteSlug', () => {
+  it('서브도메인에서 slug를 뽑는다', () => {
+    expect(extractSiteSlug('weather.xzawed.xyz', 'xzawed.xyz')).toBe('weather');
+  });
+
+  it('대문자 호스트도 정규화해 처리한다', () => {
+    expect(extractSiteSlug('Weather.XZAWED.xyz', 'xzawed.xyz')).toBe('weather');
+  });
+
+  it('포트가 붙어도 처리한다', () => {
+    expect(extractSiteSlug('weather.xzawed.xyz:3000', 'xzawed.xyz')).toBe('weather');
+  });
+
+  it('apex는 null', () => {
+    expect(extractSiteSlug('xzawed.xyz', 'xzawed.xyz')).toBeNull();
+  });
+
+  it('예약 slug(www)는 null', () => {
+    expect(extractSiteSlug('www.xzawed.xyz', 'xzawed.xyz')).toBeNull();
+  });
+
+  it('localhost는 null (개발 환경)', () => {
+    expect(extractSiteSlug('weather.localhost', 'localhost')).toBeNull();
+  });
+
+  it('rootDomain 미설정이면 null', () => {
+    expect(extractSiteSlug('weather.xzawed.xyz', undefined)).toBeNull();
+  });
+});
+
+describe('resolveProxyContext — site 모드 (익명)', () => {
+  it('published 서브도메인 → site 모드, 프로젝트는 Host에서 확정', async () => {
+    const deps = makeDeps();
+    const ctx = await call(deps, 'https://weather.xzawed.xyz/api/v1/proxy', 'weather.xzawed.xyz');
+    expect(ctx).toMatchObject({ mode: 'site' });
+    expect((ctx as { project: Project }).project.userId).toBe('owner-1');
+  });
+
+  it('Host가 있으면 클라이언트 projectId는 무시된다', async () => {
+    const deps = makeDeps();
+    await call(
+      deps,
+      'https://weather.xzawed.xyz/api/v1/proxy?projectId=attacker-proj',
+      'weather.xzawed.xyz',
+    );
+    expect(deps.findProjectBySlug).toHaveBeenCalledWith('weather');
+    expect(deps.findProjectById).not.toHaveBeenCalled();
+  });
+
+  it('미게시 프로젝트의 서브도메인 → 404', async () => {
+    const deps = makeDeps({
+      findProjectBySlug: vi.fn(async () => makeProject({ status: 'draft' })),
+    });
+    const ctx = await call(deps, 'https://weather.xzawed.xyz/api/v1/proxy', 'weather.xzawed.xyz');
+    expect(ctx).toMatchObject({ error: { status: 404 } });
+  });
+
+  it('존재하지 않는 slug → 404 (부재와 미게시를 구분해 노출하지 않음)', async () => {
+    const deps = makeDeps({ findProjectBySlug: vi.fn(async () => null) });
+    const ctx = await call(deps, 'https://nope.xzawed.xyz/api/v1/proxy', 'nope.xzawed.xyz');
+    expect(ctx).toMatchObject({ error: { status: 404 } });
+  });
+
+  it('apex + 세션 없음 + published projectId → site 모드 (직접 게시 URL 경로)', async () => {
+    const deps = makeDeps();
+    const ctx = await call(deps, 'https://xzawed.xyz/api/v1/proxy?projectId=proj-1', 'xzawed.xyz');
+    expect(ctx).toMatchObject({ mode: 'site' });
+  });
+
+  it('apex + 세션 없음 + 미게시 projectId → 404', async () => {
+    const deps = makeDeps({
+      findProjectById: vi.fn(async () => makeProject({ status: 'draft' })),
+    });
+    const ctx = await call(deps, 'https://xzawed.xyz/api/v1/proxy?projectId=proj-1', 'xzawed.xyz');
+    expect(ctx).toMatchObject({ error: { status: 404 } });
+  });
+
+  it('apex + 세션 없음 + projectId 없음 → 401', async () => {
+    const deps = makeDeps();
+    const ctx = await call(deps, 'https://xzawed.xyz/api/v1/proxy', 'xzawed.xyz');
+    expect(ctx).toMatchObject({ error: { status: 401 } });
+  });
+
+  it('site 모드에서 프로젝트에 연결되지 않은 apiId → 403', async () => {
+    const deps = makeDeps();
+    const ctx = await call(
+      deps,
+      'https://weather.xzawed.xyz/api/v1/proxy',
+      'weather.xzawed.xyz',
+      OTHER_API_ID,
+    );
+    expect(ctx).toMatchObject({ error: { status: 403 } });
+  });
+
+  it('예약 slug(www)는 서브도메인 사이트로 보지 않는다', async () => {
+    const deps = makeDeps();
+    const ctx = await call(deps, 'https://www.xzawed.xyz/api/v1/proxy', 'www.xzawed.xyz');
+    expect(ctx).toMatchObject({ error: { status: 401 } });
+    expect(deps.findProjectBySlug).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveProxyContext — app 모드 (세션)', () => {
+  const user = { id: 'owner-1', email: 'o@x.com', name: null, avatarUrl: null };
+
+  it('세션 + 자기 projectId → app 모드', async () => {
+    const deps = makeDeps({ getAuthUser: vi.fn(async () => user) });
+    const ctx = await call(deps, 'https://xzawed.xyz/api/v1/proxy?projectId=proj-1', 'xzawed.xyz');
+    expect(ctx).toMatchObject({ mode: 'app' });
+  });
+
+  it('세션 + 타인 projectId → 403 (H-1 회귀 방지)', async () => {
+    const deps = makeDeps({
+      getAuthUser: vi.fn(async () => ({ ...user, id: 'attacker' })),
+      findProjectById: vi.fn(async () => makeProject({ userId: 'victim' })),
+    });
+    const ctx = await call(deps, 'https://xzawed.xyz/api/v1/proxy?projectId=proj-1', 'xzawed.xyz');
+    expect(ctx).toMatchObject({ error: { status: 403 } });
+  });
+
+  it('타인 projectId면 연결 API 조회조차 하지 않는다 (소유권이 먼저)', async () => {
+    const deps = makeDeps({
+      getAuthUser: vi.fn(async () => ({ ...user, id: 'attacker' })),
+      findProjectById: vi.fn(async () => makeProject({ userId: 'victim' })),
+    });
+    await call(deps, 'https://xzawed.xyz/api/v1/proxy?projectId=proj-1', 'xzawed.xyz');
+    expect(deps.getProjectApiIds).not.toHaveBeenCalled();
+  });
+
+  it('세션 + projectId 없음 → app 모드, project는 null (플랫폼 키만 사용)', async () => {
+    const deps = makeDeps({ getAuthUser: vi.fn(async () => user) });
+    const ctx = await call(deps, 'https://xzawed.xyz/api/v1/proxy', 'xzawed.xyz');
+    expect(ctx).toMatchObject({ mode: 'app', project: null });
+  });
+
+  it('세션 + 자기 프로젝트지만 연결되지 않은 apiId → 403', async () => {
+    const deps = makeDeps({ getAuthUser: vi.fn(async () => user) });
+    const ctx = await call(
+      deps,
+      'https://xzawed.xyz/api/v1/proxy?projectId=proj-1',
+      'xzawed.xyz',
+      OTHER_API_ID,
+    );
+    expect(ctx).toMatchObject({ error: { status: 403 } });
+  });
+
+  it('세션 + 존재하지 않는 projectId → 404', async () => {
+    const deps = makeDeps({
+      getAuthUser: vi.fn(async () => user),
+      findProjectById: vi.fn(async () => null),
+    });
+    const ctx = await call(deps, 'https://xzawed.xyz/api/v1/proxy?projectId=nope', 'xzawed.xyz');
+    expect(ctx).toMatchObject({ error: { status: 404 } });
+  });
+});

--- a/src/lib/proxy/resolveProxyContext.ts
+++ b/src/lib/proxy/resolveProxyContext.ts
@@ -1,0 +1,125 @@
+import type { Project } from '@/types/project';
+import type { AuthUser } from '@/lib/auth/types';
+import { isValidSlug } from '@/lib/utils/slugify';
+import { assertOwner } from '@/lib/auth/authorize';
+
+/**
+ * 프록시 요청의 인가 컨텍스트.
+ *
+ * 인증·인가 판단이 라우트 여러 곳에 흩어져 있으면 한쪽만 고쳐 구멍이 남는다 —
+ * 개인 API 키 해석부가 소유권을 확인하지 않아 로그인한 아무나 남의 키를 쓸 수 있던 것이
+ * 그 사례다(H-1). 판단을 이 모듈 하나로 모으고 라우트는 결과만 소비한다.
+ */
+export type ProxyContext =
+  | { mode: 'site'; project: Project; linkedApiIds: string[] }
+  | { mode: 'app'; user: AuthUser; project: Project | null; linkedApiIds: string[] };
+
+export interface ProxyContextError {
+  error: { status: 401 | 403 | 404; code: string; message: string };
+}
+
+export interface ProxyContextDeps {
+  getAuthUser: () => Promise<AuthUser | null>;
+  findProjectBySlug: (slug: string) => Promise<Project | null>;
+  findProjectById: (id: string) => Promise<Project | null>;
+  getProjectApiIds: (projectId: string) => Promise<string[]>;
+  rootDomain: string | undefined;
+}
+
+const NOT_FOUND: ProxyContextError = {
+  error: { status: 404, code: 'NOT_FOUND', message: '사이트를 찾을 수 없습니다.' },
+};
+const AUTH_REQUIRED: ProxyContextError = {
+  error: { status: 401, code: 'AUTH_REQUIRED', message: '로그인이 필요합니다.' },
+};
+const API_NOT_LINKED: ProxyContextError = {
+  error: { status: 403, code: 'API_NOT_LINKED', message: '이 사이트에 연결되지 않은 API입니다.' },
+};
+const FORBIDDEN: ProxyContextError = {
+  error: { status: 403, code: 'FORBIDDEN', message: '권한이 없습니다.' },
+};
+
+/** 판정 결과가 오류인지 좁힌다. */
+export function isProxyContextError(
+  value: ProxyContext | ProxyContextError,
+): value is ProxyContextError {
+  return 'error' in value;
+}
+
+/**
+ * Host 헤더에서 게시 사이트 slug를 추출한다. 서브도메인이 아니면 null.
+ *
+ * 호스트명은 대소문자를 구분하지 않으므로(RFC 4343) 비교 전에 소문자로 정규화한다.
+ * 정규화하지 않으면 `Weather.xzawed.xyz` 같은 요청이 endsWith·isValidSlug에서
+ * 조용히 탈락해 간헐적으로만 실패한다.
+ */
+export function extractSiteSlug(host: string, rootDomain: string | undefined): string | null {
+  if (!rootDomain) return null;
+  const hostname = host.toLowerCase().split(':')[0];
+  if (hostname.includes('localhost') || hostname.includes('127.0.0.1')) return null;
+  const root = rootDomain.toLowerCase();
+  if (!hostname.endsWith(`.${root}`)) return null;
+  const slug = hostname.slice(0, -(root.length + 1));
+  // isValidSlug가 예약어(www·api·admin 등)와 형식을 함께 검사한다.
+  return isValidSlug(slug) ? slug : null;
+}
+
+export async function resolveProxyContext(
+  request: Request,
+  apiId: string,
+  deps: ProxyContextDeps,
+): Promise<ProxyContext | ProxyContextError> {
+  const url = new URL(request.url);
+  const host = request.headers.get('host') ?? url.host;
+  const slug = extractSiteSlug(host, deps.rootDomain);
+
+  // 1) Host가 게시 사이트를 가리키면 그것이 권위 — 클라이언트 projectId는 보지 않는다.
+  //    사용자 입력이 인가 근거가 되지 않게 하는 것이 핵심이다.
+  if (slug) {
+    const project = await deps.findProjectBySlug(slug);
+    if (!project || project.status !== 'published') return NOT_FOUND;
+    return buildSiteContext(project, apiId, deps);
+  }
+
+  const user = await deps.getAuthUser();
+  const projectId = url.searchParams.get('projectId');
+
+  // 2) apex + 세션 → app 모드(소유권 강제)
+  if (user?.id) {
+    if (!projectId) return { mode: 'app', user, project: null, linkedApiIds: [] };
+    const project = await deps.findProjectById(projectId);
+    if (!project) return NOT_FOUND;
+    // 소유권 규약은 assertOwner 한 곳에만 둔다 — 프록시 전용 비교식을 새로 만들면
+    // 규약이 갈라지고, 개인 키 해석부가 소유권을 확인하지 않던 H-1이 재발한다.
+    try {
+      assertOwner(project, user.id);
+    } catch {
+      return FORBIDDEN;
+    }
+    const linkedApiIds = await deps.getProjectApiIds(project.id);
+    if (!linkedApiIds.includes(apiId)) return API_NOT_LINKED;
+    return { mode: 'app', user, project, linkedApiIds };
+  }
+
+  // 3) apex + 세션 없음 + published projectId → site 모드
+  //    apex의 /site/{slug} 직접 서빙 경로를 위해 필요하다. 이게 없으면
+  //    "서브도메인에선 되고 직접 게시 URL에선 안 되는" 경로별 분기가 생긴다.
+  if (projectId) {
+    const project = await deps.findProjectById(projectId);
+    if (!project || project.status !== 'published') return NOT_FOUND;
+    return buildSiteContext(project, apiId, deps);
+  }
+
+  return AUTH_REQUIRED;
+}
+
+async function buildSiteContext(
+  project: Project,
+  apiId: string,
+  deps: ProxyContextDeps,
+): Promise<ProxyContext | ProxyContextError> {
+  const linkedApiIds = await deps.getProjectApiIds(project.id);
+  // 게시 사이트가 자신과 무관한 카탈로그 API를 오너 키로 호출하는 것을 막는다.
+  if (!linkedApiIds.includes(apiId)) return API_NOT_LINKED;
+  return { mode: 'site', project, linkedApiIds };
+}

--- a/src/lib/proxy/resolveProxyContext.ts
+++ b/src/lib/proxy/resolveProxyContext.ts
@@ -69,6 +69,21 @@ export async function resolveProxyContext(
   apiId: string,
   deps: ProxyContextDeps,
 ): Promise<ProxyContext | ProxyContextError> {
+  // 인가 판단에 필요한 조회가 실패하면 **fail closed** 한다. 폴백해서 진행하면
+  // 소유권을 확인하지 못한 채 키를 쓰게 된다(H-1의 실패 양상). 통제되지 않은 예외로
+  // 500을 내는 대신 명시적 404로 막는다.
+  try {
+    return await resolve(request, apiId, deps);
+  } catch {
+    return NOT_FOUND;
+  }
+}
+
+async function resolve(
+  request: Request,
+  apiId: string,
+  deps: ProxyContextDeps,
+): Promise<ProxyContext | ProxyContextError> {
   const url = new URL(request.url);
   const host = request.headers.get('host') ?? url.host;
   const slug = extractSiteSlug(host, deps.rootDomain);
@@ -85,7 +100,10 @@ export async function resolveProxyContext(
   const projectId = url.searchParams.get('projectId');
 
   // 2) apex + 세션 → app 모드(소유권 강제)
-  if (user?.id) {
+  //    user.id 타입 가드 — 타입상 string(non-nullable)이지만 인증 정보가 손상되면
+  //    런타임에 다른 타입이 들어올 수 있다. 레이트리밋 Map에 잘못된 키가 등록되거나
+  //    소유권 비교가 예상과 다르게 동작하므로 세션 없음으로 취급한다.
+  if (user?.id && typeof user.id === 'string') {
     if (!projectId) return { mode: 'app', user, project: null, linkedApiIds: [] };
     const project = await deps.findProjectById(projectId);
     if (!project) return NOT_FOUND;

--- a/src/lib/proxy/siteRateLimit.test.ts
+++ b/src/lib/proxy/siteRateLimit.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { checkSiteRateLimit, __resetSiteRateLimit } from './siteRateLimit';
+import {
+  SITE_PROXY_RATE_LIMIT_PER_MIN,
+  SITE_PROXY_PROJECT_LIMIT_PER_MIN,
+  MAX_SITE_RATE_LIMIT_BUCKETS,
+} from '@/lib/config/rateLimit';
+
+describe('checkSiteRateLimit', () => {
+  beforeEach(() => {
+    __resetSiteRateLimit();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    __resetSiteRateLimit();
+  });
+
+  it('한도 내에서는 허용한다', () => {
+    for (let i = 0; i < SITE_PROXY_RATE_LIMIT_PER_MIN; i++) {
+      expect(checkSiteRateLimit('1.1.1.1', 'p1').allowed).toBe(true);
+    }
+  });
+
+  it('IP+projectId 한도 초과 시 차단하고 retryAfter를 준다', () => {
+    for (let i = 0; i < SITE_PROXY_RATE_LIMIT_PER_MIN; i++) checkSiteRateLimit('1.1.1.1', 'p1');
+    const res = checkSiteRateLimit('1.1.1.1', 'p1');
+    expect(res.allowed).toBe(false);
+    expect(res.retryAfterSec).toBeGreaterThan(0);
+  });
+
+  it('다른 IP는 서로 영향을 주지 않는다', () => {
+    for (let i = 0; i < SITE_PROXY_RATE_LIMIT_PER_MIN; i++) checkSiteRateLimit('1.1.1.1', 'p1');
+    expect(checkSiteRateLimit('2.2.2.2', 'p1').allowed).toBe(true);
+  });
+
+  it('같은 IP라도 프로젝트가 다르면 버킷이 분리된다', () => {
+    for (let i = 0; i < SITE_PROXY_RATE_LIMIT_PER_MIN; i++) checkSiteRateLimit('1.1.1.1', 'p1');
+    expect(checkSiteRateLimit('1.1.1.1', 'p2').allowed).toBe(true);
+  });
+
+  it('윈도가 지나면 리셋된다', () => {
+    for (let i = 0; i < SITE_PROXY_RATE_LIMIT_PER_MIN; i++) checkSiteRateLimit('1.1.1.1', 'p1');
+    expect(checkSiteRateLimit('1.1.1.1', 'p1').allowed).toBe(false);
+    vi.advanceTimersByTime(60_001);
+    expect(checkSiteRateLimit('1.1.1.1', 'p1').allowed).toBe(true);
+  });
+
+  it('분산 IP여도 프로젝트 전역 한도에서 차단된다', () => {
+    let allowed = 0;
+    // IP를 매번 바꿔 IP 버킷은 항상 여유가 있게 한다.
+    for (let i = 0; i < SITE_PROXY_PROJECT_LIMIT_PER_MIN + 10; i++) {
+      if (checkSiteRateLimit(`10.0.${Math.floor(i / 250)}.${i % 250}`, 'p1').allowed) allowed++;
+    }
+    expect(allowed).toBe(SITE_PROXY_PROJECT_LIMIT_PER_MIN);
+  });
+
+  it('용량 압박이 있어도 활성 윈도의 카운터를 리셋하지 않는다', () => {
+    // 기존 프록시 리미터(LRUMap)는 eviction 시 활성 카운터가 사라져 한도를 우회할 수 있다.
+    // 이 리미터는 만료 항목만 정리하므로 살아 있는 카운터가 유지되어야 한다.
+    for (let i = 0; i < SITE_PROXY_RATE_LIMIT_PER_MIN; i++) checkSiteRateLimit('1.1.1.1', 'p1');
+    // 다른 버킷을 대량 생성해 용량을 압박한다.
+    const flood = MAX_SITE_RATE_LIMIT_BUCKETS + 500;
+    for (let i = 0; i < flood; i++) {
+      checkSiteRateLimit(`9.9.${Math.floor(i / 250) % 250}.${i % 250}`, `pX${i}`);
+    }
+    expect(checkSiteRateLimit('1.1.1.1', 'p1').allowed).toBe(false);
+  });
+
+  it('retryAfterSec은 최소 1초 이상이다', () => {
+    for (let i = 0; i < SITE_PROXY_RATE_LIMIT_PER_MIN; i++) checkSiteRateLimit('1.1.1.1', 'p1');
+    // 윈도 끝자락으로 이동해도 0초가 반환되면 클라이언트가 즉시 재시도한다.
+    vi.advanceTimersByTime(59_999);
+    expect(checkSiteRateLimit('1.1.1.1', 'p1').retryAfterSec).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/lib/proxy/siteRateLimit.ts
+++ b/src/lib/proxy/siteRateLimit.ts
@@ -1,0 +1,90 @@
+import {
+  RATE_LIMIT_WINDOW_MS,
+  SITE_PROXY_RATE_LIMIT_PER_MIN,
+  SITE_PROXY_PROJECT_LIMIT_PER_MIN,
+  MAX_SITE_RATE_LIMIT_BUCKETS,
+} from '@/lib/config/rateLimit';
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+/**
+ * 익명 게시 사이트 프록시 레이트리밋.
+ *
+ * 기존 프록시 리미터(`/api/v1/proxy`의 LRUMap)는 용량 초과 시 **활성 윈도의 카운터가
+ * 통째로 evict된다** — 다음 요청이 count:1로 다시 시작해 한도를 우회할 수 있다.
+ * 이 리미터는 타인 API 키 소진을 막는 유일한 경계이므로 그 패턴을 쓰지 않는다:
+ * 만료된 버킷만 정리하고, 자리가 부족하면 살아 있는 카운터를 버리는 대신
+ * 새 버킷 생성을 거부(=차단)한다. 우회보다 과차단이 안전하다.
+ *
+ * Railway 단일 인스턴스 전제. 멀티 인스턴스 전환 시 Redis 등으로 교체 필요.
+ */
+const ipBuckets = new Map<string, Bucket>();
+const projectBuckets = new Map<string, Bucket>();
+
+function sweepExpired(map: Map<string, Bucket>, now: number): void {
+  for (const [key, bucket] of map) {
+    if (now >= bucket.resetAt) map.delete(key);
+  }
+}
+
+/**
+ * 버킷을 하나 소비한다.
+ * 한도 초과이거나 용량 부족으로 새 버킷을 만들 수 없으면 allowed=false.
+ */
+function consume(
+  map: Map<string, Bucket>,
+  key: string,
+  limit: number,
+  now: number,
+): { allowed: boolean; resetAt: number } {
+  const existing = map.get(key);
+  if (existing && now < existing.resetAt) {
+    if (existing.count >= limit) return { allowed: false, resetAt: existing.resetAt };
+    existing.count++;
+    return { allowed: true, resetAt: existing.resetAt };
+  }
+
+  // 신규 또는 만료된 버킷 — 자리가 없으면 먼저 만료분만 정리한다.
+  if (!existing && map.size >= MAX_SITE_RATE_LIMIT_BUCKETS) {
+    sweepExpired(map, now);
+    if (map.size >= MAX_SITE_RATE_LIMIT_BUCKETS) {
+      // 활성 카운터를 버리느니 차단한다(한도 우회 방지).
+      return { allowed: false, resetAt: now + RATE_LIMIT_WINDOW_MS };
+    }
+  }
+
+  const resetAt = now + RATE_LIMIT_WINDOW_MS;
+  map.set(key, { count: 1, resetAt });
+  return { allowed: true, resetAt };
+}
+
+export function checkSiteRateLimit(
+  clientIp: string,
+  projectId: string,
+): { allowed: boolean; retryAfterSec: number } {
+  const now = Date.now();
+
+  const perIp = consume(ipBuckets, `${clientIp}:${projectId}`, SITE_PROXY_RATE_LIMIT_PER_MIN, now);
+  if (!perIp.allowed) {
+    return { allowed: false, retryAfterSec: Math.max(1, Math.ceil((perIp.resetAt - now) / 1000)) };
+  }
+
+  const perProject = consume(projectBuckets, projectId, SITE_PROXY_PROJECT_LIMIT_PER_MIN, now);
+  if (!perProject.allowed) {
+    return {
+      allowed: false,
+      retryAfterSec: Math.max(1, Math.ceil((perProject.resetAt - now) / 1000)),
+    };
+  }
+
+  return { allowed: true, retryAfterSec: 0 };
+}
+
+/** 테스트 전용 — 모듈 레벨 상태를 초기화한다. */
+export function __resetSiteRateLimit(): void {
+  ipBuckets.clear();
+  projectBuckets.clear();
+}

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -77,3 +77,47 @@ describe('middleware — local-only 인증 게이트', () => {
     expect(res.headers.get('X-Frame-Options')).toBe('DENY');
   });
 });
+
+describe('middleware — 서브도메인 프록시 패스스루 (C-1)', () => {
+  const ORIG = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_ROOT_DOMAIN = 'xzawed.xyz';
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIG };
+  });
+
+  function subdomainReq(path: string): NextRequest {
+    return new NextRequest(new URL(`http://weather.xzawed.xyz${path}`), {
+      headers: { host: 'weather.xzawed.xyz' },
+    });
+  }
+
+  it('서브도메인의 하위 페이지 경로는 /site/{slug} 아래로 rewrite된다', async () => {
+    const res = await middleware(subdomainReq('/about'));
+    expect(res.headers.get('x-middleware-rewrite')).toContain('/site/weather/about');
+  });
+
+  it('서브도메인의 /api/v1/proxy는 rewrite되지 않는다 (게시 사이트가 상대경로로 호출)', async () => {
+    const res = await middleware(subdomainReq('/api/v1/proxy?apiId=x&proxyPath=/y'));
+    expect(res.headers.get('x-middleware-rewrite')).toBeNull();
+  });
+
+  it('패스스루 응답에도 보안 헤더가 적용된다', async () => {
+    const res = await middleware(subdomainReq('/api/v1/proxy'));
+    expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
+  });
+
+  it('패스스루(API)에는 CSP를 붙이지 않는다 (이중 적용 방지)', async () => {
+    const res = await middleware(subdomainReq('/api/v1/proxy'));
+    expect(res.headers.get('Content-Security-Policy')).toBeNull();
+  });
+
+  it('프록시가 아닌 /api 경로는 여전히 rewrite된다 (최소 노출)', async () => {
+    const res = await middleware(subdomainReq('/api/v1/projects'));
+    expect(res.headers.get('x-middleware-rewrite')).toContain('/site/weather');
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,26 @@ import { getCorrelationId, CORRELATION_ID_HEADER } from '@/lib/utils/correlation
 const PROTECTED_ROUTES = ['/builder', '/dashboard', '/preview'];
 
 /**
+ * 서브도메인에서 `/site/{slug}` rewrite를 건너뛸 경로.
+ *
+ * 게시 사이트의 생성 JS는 상대경로 `/api/v1/proxy?...`로 API를 호출한다
+ * (promptBuilder가 CORS 때문에 직접 외부 URL 호출을 금지하므로 프록시 경유가 유일한 경로).
+ * rewrite되면 `/site/{slug}/api/v1/proxy`가 되는데 `/site/[slug]`는 단일 동적 세그먼트라
+ * 매칭되지 않아 404가 된다 — API를 쓰는 게시 사이트가 전부 데이터 로딩에 실패했다.
+ *
+ * `/api/*` 전체가 아니라 프록시 경로만 여는 이유: 세션 쿠키가 `__Host-` 프리픽스라
+ * 호스트 전용이므로 생성 사이트가 방문자 세션을 탈취할 수는 없지만, 불필요한
+ * 엔드포인트를 서브도메인에 노출할 이유가 없다(최소 노출).
+ */
+const SUBDOMAIN_PASSTHROUGH_PREFIXES = ['/api/v1/proxy'];
+
+function isSubdomainPassthrough(pathname: string): boolean {
+  return SUBDOMAIN_PASSTHROUGH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+/**
  * Auth.js(JWT, local) 보호 경로 게이팅.
  * 보호 경로가 아니거나 인증된 경우 null, 미인증이면 /login 리다이렉트 응답을 반환한다.
  *
@@ -37,7 +57,9 @@ export async function middleware(request: NextRequest) {
 
     if (!isLocalhost && host.endsWith(`.${rootDomain}`)) {
       const slug = host.slice(0, -(rootDomain.length + 1));
-      if (slug && slug !== 'www') {
+      // 패스스루 경로는 rewrite하지 않고 아래 일반 응답 경로로 흘려보낸다 —
+      // 그래야 correlation id·보안 헤더가 적용되고 isApi 판정으로 CSP를 건너뛴다.
+      if (slug && slug !== 'www' && !isSubdomainPassthrough(request.nextUrl.pathname)) {
         const url = request.nextUrl.clone();
         url.pathname = `/site/${slug}${url.pathname === '/' ? '' : url.pathname}`;
         // 서브도메인 사이트는 인증 세션 업데이트 불필요 — 직접 rewrite

--- a/src/repositories/interfaces/IAuthTokenRepository.ts
+++ b/src/repositories/interfaces/IAuthTokenRepository.ts
@@ -2,11 +2,13 @@ export type AuthTokenType = 'email_verify' | 'password_reset';
 
 export interface IAuthTokenRepository {
   create(userId: string, tokenHash: string, type: AuthTokenType, expiresAt: string): Promise<void>;
-  findValidByHash(
-    tokenHash: string,
-    type: AuthTokenType,
-    now: string,
-  ): Promise<{ id: string; userId: string } | null>;
-  consume(id: string, now: string): Promise<void>;
+  /**
+   * 유효(미소비·미만료)한 토큰을 **원자적으로** 소비하고 userId를 반환한다.
+   * 조건에 맞는 행이 없으면 null.
+   *
+   * 조회 → 소비 2단계로 나누면 두 await 사이에 다른 요청이 끼어들어 같은 토큰이
+   * 두 번 소비될 수 있다(비밀번호 재설정 링크 재사용). 단일 문으로 유지할 것.
+   */
+  consumeValid(tokenHash: string, type: AuthTokenType, now: string): Promise<string | null>;
   invalidateByUserAndType(userId: string, type: AuthTokenType, now: string): Promise<void>;
 }

--- a/src/repositories/sqlite/SqliteAuthTokenRepository.test.ts
+++ b/src/repositories/sqlite/SqliteAuthTokenRepository.test.ts
@@ -28,34 +28,34 @@ describe('SqliteAuthTokenRepository', () => {
   const past = new Date(Date.now() - 1000).toISOString();
   const now = new Date().toISOString();
 
-  it('유효한 토큰을 찾는다', async () => {
+  it('유효한 토큰을 소비하면 userId를 반환한다', async () => {
     await repo.create(userId, 'hash-a', 'email_verify', future);
-    const found = await repo.findValidByHash('hash-a', 'email_verify', now);
-    expect(found?.userId).toBe(userId);
+    expect(await repo.consumeValid('hash-a', 'email_verify', now)).toBe(userId);
   });
 
-  it('만료된 토큰은 못 찾는다', async () => {
+  it('만료된 토큰은 소비되지 않는다', async () => {
     await repo.create(userId, 'hash-b', 'email_verify', past);
-    expect(await repo.findValidByHash('hash-b', 'email_verify', now)).toBeNull();
+    expect(await repo.consumeValid('hash-b', 'email_verify', now)).toBeNull();
   });
 
-  it('소비된 토큰은 못 찾는다', async () => {
+  // 원자성의 실체는 UPDATE ... WHERE consumed_at IS NULL 한 문장이다.
+  // 인메모리 fake가 아니라 실 SQLite에 대해 이중 소비가 막히는지 확인한다.
+  it('같은 토큰을 두 번 소비하면 두 번째는 null (실 SQLite 원자성)', async () => {
     await repo.create(userId, 'hash-c', 'password_reset', future);
-    const found = await repo.findValidByHash('hash-c', 'password_reset', now);
-    await repo.consume(found!.id, now);
-    expect(await repo.findValidByHash('hash-c', 'password_reset', now)).toBeNull();
+    expect(await repo.consumeValid('hash-c', 'password_reset', now)).toBe(userId);
+    expect(await repo.consumeValid('hash-c', 'password_reset', now)).toBeNull();
   });
 
-  it('타입이 다르면 못 찾는다', async () => {
+  it('타입이 다르면 소비되지 않는다', async () => {
     await repo.create(userId, 'hash-d', 'email_verify', future);
-    expect(await repo.findValidByHash('hash-d', 'password_reset', now)).toBeNull();
+    expect(await repo.consumeValid('hash-d', 'password_reset', now)).toBeNull();
   });
 
-  it('invalidateByUserAndType은 해당 타입 미소비 토큰을 모두 소비 처리', async () => {
+  it('invalidateByUserAndType 이후에는 소비되지 않는다', async () => {
     await repo.create(userId, 'hash-e', 'password_reset', future);
     await repo.create(userId, 'hash-f', 'password_reset', future);
     await repo.invalidateByUserAndType(userId, 'password_reset', now);
-    expect(await repo.findValidByHash('hash-e', 'password_reset', now)).toBeNull();
-    expect(await repo.findValidByHash('hash-f', 'password_reset', now)).toBeNull();
+    expect(await repo.consumeValid('hash-e', 'password_reset', now)).toBeNull();
+    expect(await repo.consumeValid('hash-f', 'password_reset', now)).toBeNull();
   });
 });

--- a/src/repositories/sqlite/SqliteAuthTokenRepository.ts
+++ b/src/repositories/sqlite/SqliteAuthTokenRepository.ts
@@ -14,14 +14,16 @@ export class SqliteAuthTokenRepository implements IAuthTokenRepository {
       .run();
   }
 
-  async findValidByHash(
+  async consumeValid(
     tokenHash: string,
     type: AuthTokenType,
     now: string,
-  ): Promise<{ id: string; userId: string } | null> {
+  ): Promise<string | null> {
+    // 조건 검사와 갱신이 단일 UPDATE ... RETURNING으로 원자 실행된다.
+    // 조회와 소비를 분리하면 그 사이에 다른 요청이 같은 토큰을 소비할 수 있다.
     const row = this.db
-      .select({ id: schema.authTokens.id, userId: schema.authTokens.user_id })
-      .from(schema.authTokens)
+      .update(schema.authTokens)
+      .set({ consumed_at: now })
       .where(
         and(
           eq(schema.authTokens.token_hash, tokenHash),
@@ -30,17 +32,9 @@ export class SqliteAuthTokenRepository implements IAuthTokenRepository {
           gt(schema.authTokens.expires_at, now),
         ),
       )
-      .limit(1)
+      .returning({ userId: schema.authTokens.user_id })
       .get();
-    return row ?? null;
-  }
-
-  async consume(id: string, now: string): Promise<void> {
-    this.db
-      .update(schema.authTokens)
-      .set({ consumed_at: now })
-      .where(eq(schema.authTokens.id, id))
-      .run();
+    return row?.userId ?? null;
   }
 
   async invalidateByUserAndType(userId: string, type: AuthTokenType, now: string): Promise<void> {

--- a/src/services/authService.test.ts
+++ b/src/services/authService.test.ts
@@ -29,8 +29,7 @@ function makeDeps() {
   };
   const tokenRepo = {
     create: vi.fn(async () => {}),
-    findValidByHash: vi.fn(async (): Promise<{ id: string; userId: string } | null> => null),
-    consume: vi.fn(async () => {}),
+    consumeValid: vi.fn(async (): Promise<string | null> => null),
     invalidateByUserAndType: vi.fn(async () => {}),
   };
   const email = {
@@ -74,17 +73,17 @@ describe('AuthService.verifyEmail', () => {
   });
 
   it('유효하지 않은 토큰은 ValidationError', async () => {
-    deps.tokenRepo.findValidByHash.mockResolvedValue(null);
+    deps.tokenRepo.consumeValid.mockResolvedValue(null);
     await expect(svc.verifyEmail('bad-token')).rejects.toMatchObject({ code: 'INVALID_INPUT' });
   });
 
   it('유효한 토큰이면 사용자 emailVerified 업데이트', async () => {
     const { userId } = await svc.signup('user@example.com', 'pw12345678', 'https://app');
-    deps.tokenRepo.findValidByHash.mockResolvedValue({ id: 'tok1', userId });
+    deps.tokenRepo.consumeValid.mockResolvedValue(userId);
     await svc.verifyEmail('valid-token');
     const user = deps.users.get(userId)!;
     expect(user.emailVerified).not.toBeNull();
-    expect(deps.tokenRepo.consume).toHaveBeenCalled();
+    expect(deps.tokenRepo.consumeValid).toHaveBeenCalled();
   });
 });
 
@@ -153,13 +152,13 @@ describe('AuthService.resetPassword', () => {
   });
 
   it('유효하지 않은 토큰은 ValidationError', async () => {
-    deps.tokenRepo.findValidByHash.mockResolvedValue(null);
+    deps.tokenRepo.consumeValid.mockResolvedValue(null);
     await expect(svc.resetPassword('bad-token', 'newPw12345678')).rejects.toMatchObject({ code: 'INVALID_INPUT' });
   });
 
   it('유효한 토큰이면 비밀번호 업데이트 + 리셋 토큰 전체 무효화', async () => {
     const { userId } = await svc.signup('user@example.com', 'pw12345678', 'https://app');
-    deps.tokenRepo.findValidByHash.mockResolvedValue({ id: 'tok2', userId });
+    deps.tokenRepo.consumeValid.mockResolvedValue(userId);
     await svc.resetPassword('valid-token', 'newPw12345678');
     const user = deps.users.get(userId)!;
     expect(user.passwordHash).toMatch(/^[0-9a-f]+:[0-9a-f]+$/);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,9 @@ export default defineConfig({
         'src/app/**/callback/route.ts',
         'src/app/**/login/page.tsx',
         'src/app/layout.tsx',
+        // 2026-07-28: 서브도메인 패스스루(C-1) 수정과 함께 집계 대상에 편입.
+        // 미포함 시 변경 라인이 SonarCloud new_coverage·codecov/patch에서 0%로 계산된다.
+        'src/middleware.ts',
         'src/app/api/v1/admin/**/route.ts',
         'src/app/api/v1/auth/**/route.ts',
         'src/app/api/v1/countries/**/route.ts',


### PR DESCRIPTION
전체 검수(Claude 독립 검증 + Grok 독립 감사 + 상호 반박 라운드)로 확정한 13건 중 **CRITICAL 2건·HIGH 2건**을 수정합니다.

## 🔴 C-1 — 게시 사이트가 실제로는 동작하지 않았습니다

미들웨어가 서브도메인의 **모든** 경로를 `/site/{slug}`로 rewrite해, `/api/v1/proxy`가 단일 세그먼트 라우트에 미매칭되어 404였습니다.

**프로덕션 실측:**
```
GET https://xzawed.xyz/api/v1/proxy?…            → 401  (라우트 도달)
GET https://testprobe.xzawed.xyz/api/v1/proxy?…  → 404  (rewrite되어 미매칭)
```

생성 프롬프트는 CORS 때문에 직접 외부 URL 호출을 금지하고 상대경로 프록시만 허용하므로, **API를 쓰는 게시 사이트는 전부 데이터 로딩에 실패**했습니다. 미리보기는 apex 도메인이라 정상 동작해 드러나지 않았습니다.

→ `SUBDOMAIN_PASSTHROUGH_PREFIXES`에 프록시 경로 **하나만** rewrite 예외로 둡니다. `/api/*` 전체를 열지 않은 것은 최소 노출 원칙입니다 — 세션 쿠키가 `__Host-` 프리픽스라 호스트 전용인 것을 실측 확인했지만, 불필요한 엔드포인트를 노출할 이유가 없습니다.

## 🔴 C-2 — 익명 방문자가 401

프록시가 항상 세션을 요구해, C-1을 고쳐도 게시 사이트 방문자는 데이터를 볼 수 없었습니다. 같은 표면에 독립적인 두 번째 차단막이었습니다.

## 🟠 H-1 — 타인의 개인 API 키를 쓸 수 있었습니다

`resolveApiKey`가 클라이언트가 보낸 `projectId`로 **그 프로젝트 오너의 개인 API 키를 복호화**하면서 호출자 소유 여부를 확인하지 않았습니다. 로그인한 아무나 남의 키 할당량을 소진시킬 수 있었고, 레이트리밋은 피해자가 아닌 호출자에게 걸렸습니다.

## 🟠 H-2 — 재설정 링크 재사용 가능

`findValidByHash` → `await` → `consume(id)` 2단계였고 `consume`은 `WHERE id`만 검사했습니다. 두 await 사이에 다른 요청이 끼어들면 동시 요청이 모두 성공합니다.

→ 단일 `UPDATE ... WHERE consumed_at IS NULL AND expires_at > ? RETURNING user_id`로 대체하고, 2단계로 되돌아갈 여지를 없애기 위해 기존 두 메서드를 인터페이스에서 제거했습니다.

## 설계 — `resolveProxyContext()` 단일 진입점

인증·인가 판단이 `validateRequest`와 `resolveApiKey` 두 곳에 흩어져 H-1이 발생했습니다. 한 모듈로 모읍니다.

| # | 조건 | 결과 |
|---|------|------|
| 1 | Host가 `{slug}.{ROOT_DOMAIN}` | slug로 프로젝트 확정 → published면 **site**, 아니면 404 |
| 2 | apex + 세션 | **app** (소유권 강제) |
| 3 | apex + 세션 없음 + published `projectId` | **site** |
| 4 | 그 외 | 401 |

| 모드 | apiId 검사 | 키 출처 | 레이트리밋 |
|---|---|---|---|
| site | `apiId ∈ project_apis` 강제 | 플랫폼 키 또는 **그 프로젝트 오너** 키 | IP + projectId |
| app | 동일 강제 | 플랫폼 키 또는 **호출자 본인** 키 | userId (기존) |

**Host 우선** — Host로 프로젝트가 확정되면 클라이언트 `projectId`는 무시합니다. 사용자 입력이 인가 근거가 되지 않게 합니다. 소유권은 프록시 전용 비교식 대신 **기존 `assertOwner` 재사용** — 규약이 갈라지면 H-1이 재발합니다.

**인가 조회 실패는 fail-closed** — 폴백하면 소유권을 확인하지 못한 채 키를 쓰게 됩니다(H-1의 실패 양상).

## 추가로 닫은 것

**M-4 가드레일** — `buildCacheKey`에 키 신원이 없어, 익명 호출자가 오너 키로 받은 응답이 다른 테넌트에게 서빙될 수 있습니다. 지금까지는 공개 API만 캐시돼 잠복이었지만 **이번 변경이 위험을 실재화**하므로 여기서 닫습니다 — 개인 키 주입 시 캐시를 건너뜁니다.

**M-6 패턴 회피** — 신규 익명 리미터가 타인 키 소진을 막는 유일한 경계라, 기존 프록시 리미터의 LRUMap eviction 패턴(용량 초과 시 활성 카운터 소실 → 한도 우회)을 의도적으로 피했습니다. 만료 버킷만 정리하고 자리가 없으면 차단합니다.

**재생성 프롬프트** — `projectId`가 누락돼 있어 apex 직접 게시 경로가 동작하지 않았습니다.

## ⚠️ 명시적 트레이드오프

site 모드는 **published `projectId`를 아는 사람은 누구나 그 오너의 키로 업스트림 호출을 트리거할 수 있다**는 뜻입니다. 게시 사이트 자체가 공개이므로 노출 수준은 같지만 **레이트리밋이 유일한 방어선**입니다. Origin 바인딩이 없어 봇이 서버에서 직접 호출할 수 있으므로 실질 상한은 프로젝트 전역 버킷(기본 120/분)이며, **운영 모니터링 대상**입니다.

사용자 승인 정책("허용 + 강한 레이트리밋")이며 Host 바인딩으로 방어 심도를 더했습니다.

## 검증

| 항목 | 결과 |
|------|------|
| `pnpm lint` | 0 errors (warning 2건 — 기존) |
| `pnpm type-check` | 통과 |
| `pnpm test` | **168 파일 / 2067건 통과** (기존 2022 + 신규 45) |
| `pnpm build` | 통과 |
| standalone 부팅 + `/api/v1/health` | **200** |

신규 테스트는 `resolveProxyContext` 진리표, Host 정규화(대문자·포트·예약 slug), **키 선택 격리**(타인 `projectId`면 개인 키 조회 자체가 일어나지 않음), 레이트리밋 우회 방지(용량 압박 시 활성 카운터 유지), **실 SQLite 토큰 이중 소비 차단**을 고정합니다.

### 검수 과정에서 교정된 것

- Grok의 "check→start TOCTOU로 중복 파이프라인" 주장은 해당 구간에 `await`이 없어 **오탐**으로 판정, 상호 검증에서 철회됐습니다. 실제 결함은 `generationTracker` LRU/TTL 락 소실(M-5, 범위 밖)이었습니다.
- Grok의 계획 검토가 **CI 파손 2건**을 잡았습니다 — `SqliteAuthTokenRepository.test.ts`가 제거 대상 메서드를 호출 중이었고, `src/middleware.ts`가 `coverage.include`에 없었습니다.
- 모드 판정으로 옮기면서 `user.id` 타입 가드를 누락했는데 **기존 테스트가 잡아냈습니다.**

## 배포 후 확인

게시된 사이트가 없어 실환경 확인은 배포 후 테스트 프로젝트 게시로 수행합니다(절차는 ADR에 기재).

## 범위 밖 (다음 라운드)

M-1 Quality Loop AbortSignal · M-2 stale `validation` 저장 · M-3 레이트리밋 fail-open 환불 · M-5 `generationTracker` 락 소실 · M-6 기존 리미터 eviction · M-7 IPv4-mapped IPv6 SSRF · M-8 `x-real-ip` 신뢰 · `AUTH_URL` 미설정(`callback-url=https://0.0.0.0:8080`)

## 문서

- [ADR](docs/decisions/2026-07-28-published-site-proxy-authz.md) · [설계 spec](docs/superpowers/specs/2026-07-28-published-site-proxy-authz-design.md) · [구현 계획](docs/superpowers/plans/2026-07-28-published-site-proxy-authz.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
