### PR TITLE
fix: 검수 MEDIUM 발견 6건 수정 (M-1·2·3·5·6·7·8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 | 의존성 보안 일괄 상향·감사 게이트 2단계화 ADR (2026-07-28) | [docs/decisions/2026-07-28-dependency-security-updates.md](docs/decisions/2026-07-28-dependency-security-updates.md) |
 | **게시 사이트 프록시 복구·인가 모델 정비 ADR (C-1·C-2·H-1·H-2, 2026-07-28)** | [docs/decisions/2026-07-28-published-site-proxy-authz.md](docs/decisions/2026-07-28-published-site-proxy-authz.md) |
 | 게시 사이트 프록시 설계 spec | [docs/superpowers/specs/2026-07-28-published-site-proxy-authz-design.md](docs/superpowers/specs/2026-07-28-published-site-proxy-authz-design.md) |
+| 검수 MEDIUM 발견 항목 수정 ADR (M-1·2·3·5·6·7·8, 2026-07-29) | [docs/decisions/2026-07-29-medium-audit-findings.md](docs/decisions/2026-07-29-medium-audit-findings.md) |
 | better-sqlite3 v13 N-API 프리빌트 전환·빌드 툴체인 제거 ADR (2026-07-28) | [docs/decisions/2026-07-28-better-sqlite3-v13-napi-prebuilds.md](docs/decisions/2026-07-28-better-sqlite3-v13-napi-prebuilds.md) |
 | 환경변수 목록 | [docs/reference/env-vars.md](docs/reference/env-vars.md) |
 | 에러 클래스 참조 | [docs/reference/error-codes.md](docs/reference/error-codes.md) |
@@ -232,6 +233,15 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 ### 클라이언트 IP 도출 규칙 (레이트리밋)
 - `x-forwarded-for`는 **최우측** 항목만 신뢰한다. 최좌측은 클라이언트가 위조할 수 있어 per-IP 리밋이 무력화된다
 - 단일 출처: `getClientIp()`(`src/lib/auth/rateLimit.ts`) — `adminAuth.verifyAdminKey()`와 동일 규칙. 새 리밋을 추가할 때 XFF를 직접 파싱하지 말 것
+- **`x-real-ip`는 신뢰하지 않는다**(2026-07-29). 신뢰 경계가 붙였다는 보장이 없어 클라이언트가 위조·회전할 수 있고, 폴백을 두면 XFF 없는 경로에서 per-IP 한도가 무력화된다. 식별 불가 시 `'unknown'` 단일 버킷으로 fail-closed
+
+### 인메모리 레이트리밋 구현 규칙
+- **LRU eviction으로 활성 윈도를 버리지 말 것**. 용량 초과 시 살아 있는 카운터가 evict되면 다음 요청이 `count:1`로 시작해 한도가 우회된다(동시 사용자가 많을수록 심해짐 — 2026-07-29 수정)
+- 올바른 패턴: 만료 버킷만 정리하고, 정리 후에도 자리가 없으면 **새 키를 거부(차단)**한다. 우회보다 과차단이 안전하다. 구현 참고: `src/lib/proxy/siteRateLimit.ts`, `checkProxyRateLimit`(`proxy/route.ts`)
+
+### AI 호출 타임아웃 규칙
+- **타임아웃은 `Promise.race`만으로 끝내지 말고 `AbortSignal`을 함께 넘길 것**. race는 즉시 종료돼도 업스트림 호출은 SDK 타임아웃(최대 ~270초)까지 살아 있어, 다음 반복이 겹치면 **Opus/ET 토큰 비용이 이중 청구**된다. `AiPrompt.abortSignal` → `ClaudeProvider`의 `{ signal }`로 이미 배선되어 있다
+- race에서 지는 쪽의 거부는 아무도 관측하지 않으므로 생성 Promise에 no-op `.catch()`를 미리 붙여 `unhandledRejection`을 막을 것 (`qualityLoop.ts` 참고)
 
 ### 의존성 감사 게이트 (`pnpm audit`)
 - CI는 2단계로 실행한다: ① `pnpm audit --prod --audit-level=high`(**프로덕션 트리 하드 게이트**), ② `pnpm audit --audit-level=high`(전체 트리, 검토된 면제 적용)

--- a/docs/decisions/2026-07-29-medium-audit-findings.md
+++ b/docs/decisions/2026-07-29-medium-audit-findings.md
@@ -1,0 +1,107 @@
+# 검수 MEDIUM 발견 항목 수정 (2026-07-29)
+
+## 상태
+
+승인됨 — 구현 완료
+
+## 배경
+
+[2026-07-28 전체 검수](2026-07-28-published-site-proxy-authz.md)에서 확정한 13건 중
+CRITICAL 2건·HIGH 2건은 PR #195에서 처리했다. 이 ADR은 남은 **MEDIUM 6건**을 다룬다
+(M-4는 위험도가 이번 변경으로 상승해 #195에 선반영됨).
+
+## 수정 내역
+
+### M-1 — Quality Loop 타임아웃이 업스트림 호출을 취소하지 않음 (비용 이중청구)
+
+`Promise.race`로 타임아웃만 걸고 `AbortSignal`을 넘기지 않아, race는 즉시 종료돼도
+**Anthropic 호출은 SDK 타임아웃까지 계속 살아 있었다.** 다음 반복이 또 다른 호출을
+시작하므로 Opus/ET 호출이 중첩되어 토큰 비용이 이중 청구됐다. 또한 뒤늦게 거부되는
+고아 Promise에 핸들러가 없어 `unhandledRejection` 위험도 있었다.
+
+`AiPrompt.abortSignal`과 `ClaudeProvider`의 `{ signal }` 전달은 **이미 배선되어 있었고
+qualityLoop만 사용하지 않고 있었다.** 반복마다 `AbortController`를 만들어 타임아웃 시
+`abort()`하고, race에서 지는 쪽의 거부가 관측되지 않는 문제를 막기 위해 생성 Promise에
+no-op catch를 미리 붙인다.
+
+### M-2 — Quality Loop 이후 stale `validation` 저장
+
+루프가 코드를 교체해도 `saveGeneratedCode`에는 **루프 이전** `validation`이 전달돼,
+실제 서빙되는 코드와 다른 코드의 `securityCheckPassed`·`validationErrors`가 DB에 남았다.
+재계산 결과(`finalValidation`)를 저장에도 넘긴다. 오류 검사에만 쓰고 버리던 값이다.
+
+### M-3 — 레이트리밋 fail-open + 무조건 환불로 무료 할당량 증가
+
+`checkAndIncrementDailyLimit`은 우회(bypass)·DB 오류(fail-open) 시 **카운터를 올리지
+않는데**, 실패 경로는 조건 없이 `decrementDailyLimit`을 호출했다. 사용자가 5/10인 상태에서
+fail-open → 파이프라인 실패 → 환불이면 4/10이 된다. DB 오류가 반복될수록 한도가 늘어난다.
+
+반환값을 `{ charged: boolean }`으로 바꾸고, **청구된 경우에만** 환불 경로를 만든다.
+환불 경로가 라우트(`pendingDecrement`)와 파이프라인(`handlePipelineFailure`) 두 곳이므로,
+파이프라인에는 청구되지 않았을 때 no-op 디크리멘터를 주입해 양쪽을 한 번에 막는다.
+
+### M-5 — `generationTracker` 락 소실 (부분 대응)
+
+엔트리가 TTL(생성 중 30분) 또는 size cap으로 사라지면 `complete()`가 조용히 no-op이 되어,
+**코드는 저장됐는데 상태 폴링은 not_found를 보고**한다. `isGenerating()`도 false가 되어
+중복 파이프라인이 시작될 수 있다.
+
+근본 해결은 외부 저장소 기반 durable lock이며 단일 인스턴스 인메모리 구조에서는 불가능하다.
+**관측 가능하게만 만들었다** — 엔트리 없이 완료되면 `logger.warn`을 남긴다. 상태 엔드포인트에
+DB 폴백이 있어 사용자 영향은 이미 일부 완화되어 있다. 멀티 인스턴스 전환 시 Redis 등으로
+교체할 때 함께 해결할 사안으로 남긴다.
+
+### M-6 — 프록시 레이트리밋 LRU eviction이 활성 카운터를 리셋
+
+`LRUMap(1000)`이라 활성 사용자가 상한을 넘으면 **살아 있는 윈도의 카운터가 evict되어**
+그 사용자의 다음 요청이 `count:1`로 다시 시작한다. 동시 사용자가 많을수록 60/분 한도가
+무력화된다.
+
+일반 `Map`으로 바꾸고 만료 버킷만 정리한다. 정리 후에도 자리가 없으면 활성 카운터를
+버리는 대신 **차단**한다(우회보다 과차단이 안전). PR #195에서 신규 site 리미터에 적용한
+원칙을 기존 리미터에도 통일했다.
+
+### M-7 — IPv4-mapped IPv6 SSRF 우회
+
+`isPrivateHost('::ffff:127.0.0.1')`이 **false**였다 — IPv4 패턴에도 IPv6 패턴에도 걸리지
+않는다. Node의 `dns.lookup`이 매핑 형식을 돌려줄 수 있어 실제 도달 가능한 경로다.
+매핑 주소를 IPv4로 정규화한 뒤 검사하고, 16진 표기(`::ffff:7f00:1`)는 대역 자체를 차단한다.
+
+### M-8 — `x-real-ip` 신뢰
+
+XFF가 없으면 `x-real-ip`로 폴백했는데, 이 헤더는 신뢰 경계(Railway 엣지)가 붙였다는 보장이
+없어 클라이언트가 자유롭게 위조·회전할 수 있다. 폴백을 두면 XFF 없는 경로에서 per-IP
+한도(signup·비밀번호 재설정 메일 발송)가 통째로 무력화된다.
+
+폴백을 제거하고 식별 불가일 땐 단일 `'unknown'` 버킷으로 모아 **fail-closed** 한다.
+
+> 트레이드오프: Railway가 항상 XFF를 붙이므로 프로덕션 영향은 없다. XFF가 없는 환경으로
+> 이전하면 모든 요청이 한 버킷을 공유해 과차단될 수 있으므로, 그때는 해당 플랫폼이 붙이는
+> 신뢰 가능한 헤더를 명시적으로 추가해야 한다.
+
+## 검증
+
+| 항목 | 결과 |
+|------|------|
+| `pnpm lint` | 0 errors (warning 2건 — 기존) |
+| `pnpm type-check` | 통과 |
+| `pnpm test` | **168 파일 / 2070건 통과** |
+
+신규 회귀 테스트: IPv4-mapped IPv6 3종(리터럴 2 + DNS 해석 1) SSRF 차단,
+`x-real-ip` 미신뢰, `{ charged }` 반환 계약.
+
+기존 테스트 다수가 옛 동작을 검증하고 있어 함께 갱신했다 — `checkAndIncrementDailyLimit`
+mock 반환값(7개 파일), `x-real-ip` 폴백 단언 2건.
+
+## 미해결 — 운영 조치 필요
+
+`__Secure-authjs.callback-url`이 `https://0.0.0.0:8080`으로 설정된다. `AUTH_URL`이
+코드·문서 어디에도 참조되지 않아 Auth.js가 컨테이너 바인드 주소에서 유도한 값이다.
+
+`AUTH_TRUST_HOST=true`가 설정되어 있어 실제 로그인은 정상 동작하므로 영향은 낮으나,
+**Railway 환경변수에 `AUTH_URL=https://xzawed.xyz`를 추가**하는 것이 정확하다.
+코드 변경이 아니라 운영 설정이므로 이 PR 범위 밖이다.
+
+## 관련 문서
+
+- [게시 사이트 프록시 복구·인가 모델 정비 ADR](2026-07-28-published-site-proxy-authz.md)

--- a/src/__tests__/api/generate-regenerate.test.ts
+++ b/src/__tests__/api/generate-regenerate.test.ts
@@ -146,7 +146,7 @@ async function setupHappyPath(overrides?: {
 
   const decrementMock = vi.fn().mockResolvedValue(undefined);
   vi.mocked(createRateLimitService).mockReturnValue({
-    checkAndIncrementDailyLimit: vi.fn().mockResolvedValue(undefined),
+    checkAndIncrementDailyLimit: vi.fn().mockResolvedValue({ charged: true }),
     decrementDailyLimit: decrementMock,
   } as never);
 

--- a/src/__tests__/api/generate.test.ts
+++ b/src/__tests__/api/generate.test.ts
@@ -202,7 +202,7 @@ async function setupHappyPath() {
     getByIds: vi.fn().mockResolvedValue(mockApis),
   } as never);
   vi.mocked(createRateLimitService).mockReturnValue({
-    checkAndIncrementDailyLimit: vi.fn().mockResolvedValue(undefined),
+    checkAndIncrementDailyLimit: vi.fn().mockResolvedValue({ charged: true }),
     decrementDailyLimit: vi.fn().mockResolvedValue(undefined),
   } as never);
 
@@ -249,7 +249,7 @@ describe('POST /api/v1/generate', () => {
 
     const { createRateLimitService } = await import('@/services/factory');
     vi.mocked(createRateLimitService).mockReturnValue({
-      checkAndIncrementDailyLimit: vi.fn().mockResolvedValue(undefined),
+      checkAndIncrementDailyLimit: vi.fn().mockResolvedValue({ charged: true }),
       decrementDailyLimit: vi.fn().mockResolvedValue(undefined),
     } as never);
 
@@ -347,7 +347,7 @@ describe('POST /api/v1/generate', () => {
     const decrementMock = vi.fn().mockResolvedValue(undefined);
     const { createRateLimitService } = await import('@/services/factory');
     vi.mocked(createRateLimitService).mockReturnValue({
-      checkAndIncrementDailyLimit: vi.fn().mockResolvedValue(undefined),
+      checkAndIncrementDailyLimit: vi.fn().mockResolvedValue({ charged: true }),
       decrementDailyLimit: decrementMock,
     } as never);
 
@@ -373,7 +373,7 @@ describe('POST /api/v1/generate', () => {
     const decrementMock = vi.fn().mockResolvedValue(undefined);
     const { createRateLimitService } = await import('@/services/factory');
     vi.mocked(createRateLimitService).mockReturnValue({
-      checkAndIncrementDailyLimit: vi.fn().mockResolvedValue(undefined),
+      checkAndIncrementDailyLimit: vi.fn().mockResolvedValue({ charged: true }),
       decrementDailyLimit: decrementMock,
     } as never);
 

--- a/src/__tests__/api/ownership-isolation.test.ts
+++ b/src/__tests__/api/ownership-isolation.test.ts
@@ -25,7 +25,7 @@ vi.mock('@/lib/ai/codeParser', () => ({
 
 vi.mock('@/services/factory', () => ({
   createRateLimitService: vi.fn().mockReturnValue({
-    checkAndIncrementDailyLimit: vi.fn().mockResolvedValue(undefined),
+    checkAndIncrementDailyLimit: vi.fn().mockResolvedValue({ charged: true }),
   }),
 }));
 

--- a/src/__tests__/api/proxy.test.ts
+++ b/src/__tests__/api/proxy.test.ts
@@ -200,6 +200,49 @@ describe('GET /api/v1/proxy', () => {
     });
   });
 
+  // 16진 표기 IPv4-mapped IPv6도 대역째 차단한다(M-7).
+  it('16진 표기 IPv4-mapped IPv6 ::ffff:7f00:1 → 403', async () => {
+    const { getAuthUser } = await import('@/lib/auth/index');
+    vi.mocked(getAuthUser).mockResolvedValue(mockUser);
+    const { createCatalogRepository } = await import('@/repositories/factory');
+    vi.mocked(createCatalogRepository).mockReturnValue({
+      findById: vi.fn().mockResolvedValue({ ...mockPublicApi, baseUrl: 'http://[::ffff:7f00:1]/internal' }),
+    } as never);
+
+    const { GET } = await import('@/app/api/v1/proxy/route');
+    const res = await GET(makeRequest(VALID_API_ID, '/data'));
+    expect(res.status).toBe(403);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // 활성 사용자 수가 상한을 넘으면 살아 있는 카운터를 버리는 대신 차단한다(M-6).
+  // LRUMap 시절에는 여기서 evict가 일어나 다음 요청이 count:1로 시작, 한도가 우회됐다.
+  it('활성 사용자 상한 초과 시 활성 카운터를 버리지 않고 새 사용자를 차단한다', async () => {
+    const { getAuthUser } = await import('@/lib/auth/index');
+    const { createCatalogRepository } = await import('@/repositories/factory');
+    vi.mocked(createCatalogRepository).mockReturnValue({
+      findById: vi.fn().mockResolvedValue(mockPublicApi),
+    } as never);
+
+    const { GET } = await import('@/app/api/v1/proxy/route');
+    const { MAX_CONCURRENT_RATE_LIMIT_USERS } = await import('@/lib/config/rateLimit');
+
+    // 상한까지 서로 다른 사용자로 버킷을 채운다.
+    for (let i = 0; i < MAX_CONCURRENT_RATE_LIMIT_USERS; i++) {
+      vi.mocked(getAuthUser).mockResolvedValue({ ...mockUser, id: `filler-${i}` });
+      await GET(makeRequest(VALID_API_ID, '/data'));
+    }
+
+    // 상한을 넘긴 신규 사용자는 차단된다(기존 카운터는 유지).
+    vi.mocked(getAuthUser).mockResolvedValue({ ...mockUser, id: 'overflow-user' });
+    const res = await GET(makeRequest(VALID_API_ID, '/data'));
+    expect(res.status).toBe(429);
+
+    // 이미 버킷을 가진 사용자는 계속 정상 동작한다.
+    vi.mocked(getAuthUser).mockResolvedValue({ ...mockUser, id: 'filler-0' });
+    expect((await GET(makeRequest(VALID_API_ID, '/data'))).status).toBe(200);
+  });
+
   it('rate limit 초과 (분당 60회) → 429', async () => {
     const { getAuthUser } = await import('@/lib/auth/index');
     vi.mocked(getAuthUser).mockResolvedValue(mockUser);

--- a/src/__tests__/api/proxy.test.ts
+++ b/src/__tests__/api/proxy.test.ts
@@ -137,6 +137,36 @@ describe('GET /api/v1/proxy', () => {
     it('AWS/GCP 메타데이터 169.254.169.254 → 403', async () => {
       await expectSsrfBlocked('http://169.254.169.254/latest/meta-data');
     });
+
+    // IPv4-mapped IPv6는 IPv4 패턴에도 IPv6 패턴에도 걸리지 않아 그대로 통과했다(M-7).
+    // dns.lookup이 매핑 형식을 돌려줄 수 있어 실제 도달 가능한 우회 경로다.
+    it('IPv4-mapped IPv6 루프백 ::ffff:127.0.0.1 → 403', async () => {
+      await expectSsrfBlocked('http://[::ffff:127.0.0.1]/internal');
+    });
+
+    it('IPv4-mapped IPv6 메타데이터 ::ffff:169.254.169.254 → 403', async () => {
+      await expectSsrfBlocked('http://[::ffff:169.254.169.254]/latest/meta-data');
+    });
+
+    it('DNS가 IPv4-mapped IPv6로 해석되면 → 403', async () => {
+      const { default: dnsDefault } = await import('dns/promises');
+      vi.mocked(dnsDefault.lookup).mockResolvedValueOnce({
+        address: '::ffff:169.254.169.254',
+        family: 6,
+      } as never);
+
+      const { getAuthUser } = await import('@/lib/auth/index');
+      vi.mocked(getAuthUser).mockResolvedValue(mockUser);
+      const { createCatalogRepository } = await import('@/repositories/factory');
+      vi.mocked(createCatalogRepository).mockReturnValue({
+        findById: vi.fn().mockResolvedValue({ ...mockPublicApi, baseUrl: 'https://legit.example.com' }),
+      } as never);
+
+      const { GET } = await import('@/app/api/v1/proxy/route');
+      const res = await GET(makeRequest(VALID_API_ID, '/data'));
+      expect(res.status).toBe(403);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
   });
 
   describe('입력 검증', () => {

--- a/src/__tests__/api/suggest-apis.test.ts
+++ b/src/__tests__/api/suggest-apis.test.ts
@@ -50,7 +50,7 @@ async function setupAuth() {
 
   const { createRateLimitService } = await import('@/services/factory');
   vi.mocked(createRateLimitService).mockReturnValue({
-    checkAndIncrementDailyLimit: vi.fn().mockResolvedValue(undefined),
+    checkAndIncrementDailyLimit: vi.fn().mockResolvedValue({ charged: true }),
     decrementDailyLimit: vi.fn().mockResolvedValue(undefined),
   } as never);
 }

--- a/src/__tests__/api/suggest-context.test.ts
+++ b/src/__tests__/api/suggest-context.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/lib/utils/logger', () => ({
 
 vi.mock('@/services/factory', () => ({
   createRateLimitService: vi.fn().mockReturnValue({
-    checkAndIncrementDailyLimit: vi.fn().mockResolvedValue(undefined),
+    checkAndIncrementDailyLimit: vi.fn().mockResolvedValue({ charged: true }),
   }),
 }));
 

--- a/src/__tests__/api/suggest-modification.test.ts
+++ b/src/__tests__/api/suggest-modification.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/lib/utils/logger', () => ({
 
 vi.mock('@/services/factory', () => ({
   createRateLimitService: vi.fn().mockReturnValue({
-    checkAndIncrementDailyLimit: vi.fn().mockResolvedValue(undefined),
+    checkAndIncrementDailyLimit: vi.fn().mockResolvedValue({ charged: true }),
   }),
 }));
 

--- a/src/__tests__/api/suggest-preferences.test.ts
+++ b/src/__tests__/api/suggest-preferences.test.ts
@@ -71,7 +71,7 @@ async function setupAuth(user: typeof mockUser | null = mockUser) {
 
   const { createRateLimitService, createCatalogService } = await import('@/services/factory');
   vi.mocked(createRateLimitService).mockReturnValue({
-    checkAndIncrementDailyLimit: vi.fn().mockResolvedValue(undefined),
+    checkAndIncrementDailyLimit: vi.fn().mockResolvedValue({ charged: true }),
     decrementDailyLimit: vi.fn().mockResolvedValue(undefined),
   } as never);
 

--- a/src/__tests__/services/rateLimitService.test.ts
+++ b/src/__tests__/services/rateLimitService.test.ts
@@ -35,7 +35,7 @@ describe('RateLimitService', () => {
   describe('checkAndIncrementDailyLimit', () => {
     it('allowed=true이면 정상 통과한다', async () => {
       const service = new RateLimitService(makeRepo({ allowed: true }));
-      await expect(service.checkAndIncrementDailyLimit('user-1')).resolves.toBeUndefined();
+      await expect(service.checkAndIncrementDailyLimit('user-1')).resolves.toEqual({ charged: true });
     });
 
     it('allowed=false이면 RateLimitError를 던진다', async () => {
@@ -48,7 +48,7 @@ describe('RateLimitService', () => {
     it('DB 오류 발생 시 fail-open — 예외 없이 통과한다', async () => {
       const service = new RateLimitService(makeRepo({ throwOnCheck: true }));
       // Should NOT throw — fail open
-      await expect(service.checkAndIncrementDailyLimit('user-1')).resolves.toBeUndefined();
+      await expect(service.checkAndIncrementDailyLimit('user-1')).resolves.toEqual({ charged: false });
     });
 
     it('올바른 limit 파라미터로 호출한다', async () => {
@@ -69,7 +69,7 @@ describe('RateLimitService', () => {
         const repo = makeRepo({ allowed: true });
         const service = new RateLimitService(repo);
 
-        await expect(service.checkAndIncrementDailyLimit('admin-2')).resolves.toBeUndefined();
+        await expect(service.checkAndIncrementDailyLimit('admin-2')).resolves.toEqual({ charged: false });
 
         // 리밋 검사(증가)는 건너뛴다
         expect(repo.checkAndIncrementDailyLimit).not.toHaveBeenCalled();

--- a/src/app/api/v1/generate/regenerate/route.ts
+++ b/src/app/api/v1/generate/regenerate/route.ts
@@ -52,8 +52,12 @@ export async function POST(request: Request): Promise<Response> {
     const correlationId = getCorrelationId(request);
 
     const rateLimitService = createRateLimitService();
-    await rateLimitService.checkAndIncrementDailyLimit(user.id);
-    pendingDecrement = () => rateLimitService.decrementDailyLimit(user.id);
+    // charged=false(우회·fail-open)면 카운터가 오르지 않았으므로 환불 경로를 만들지 않는다.
+    const { charged } = await rateLimitService.checkAndIncrementDailyLimit(user.id);
+    if (charged) pendingDecrement = () => rateLimitService.decrementDailyLimit(user.id);
+    const pipelineRateLimit = charged
+      ? rateLimitService
+      : { decrementDailyLimit: async (): Promise<void> => {} };
 
     const projectService = createProjectService();
     const [project, apiIds] = await Promise.all([
@@ -126,7 +130,7 @@ export async function POST(request: Request): Promise<Response> {
           {
             codeRepo,
             projectService,
-            rateLimitService,
+            rateLimitService: pipelineRateLimit,
             projectRepo: createProjectRepository(),
           },
         );

--- a/src/app/api/v1/generate/route.ts
+++ b/src/app/api/v1/generate/route.ts
@@ -48,8 +48,13 @@ export async function POST(request: Request): Promise<Response> {
 
     const rateLimitService = createRateLimitService();
     const projectService = createProjectService();
-    await rateLimitService.checkAndIncrementDailyLimit(user.id);
-    pendingDecrement = () => rateLimitService.decrementDailyLimit(user.id);
+    // charged=false(우회·fail-open)면 카운터가 오르지 않았으므로 환불 경로를 만들지 않는다.
+    // 조건 없이 환불하면 DB 오류가 날 때마다 사용자 한도가 늘어난다.
+    const { charged } = await rateLimitService.checkAndIncrementDailyLimit(user.id);
+    if (charged) pendingDecrement = () => rateLimitService.decrementDailyLimit(user.id);
+    const pipelineRateLimit = charged
+      ? rateLimitService
+      : { decrementDailyLimit: async (): Promise<void> => {} };
     const [project, apiIds] = await Promise.all([
       projectService.getById(projectId, user.id),
       projectService.getProjectApiIds(projectId),
@@ -114,7 +119,7 @@ export async function POST(request: Request): Promise<Response> {
           {
             codeRepo: createCodeRepository(),
             projectService,
-            rateLimitService,
+            rateLimitService: pipelineRateLimit,
             projectRepo: createProjectRepository(),
           },
         );

--- a/src/app/api/v1/proxy/route.ts
+++ b/src/app/api/v1/proxy/route.ts
@@ -9,7 +9,6 @@ import { getAuthUser } from '@/lib/auth/index';
 import { getClientIp } from '@/lib/auth/rateLimit';
 import { resolveProxyContext, isProxyContextError } from '@/lib/proxy/resolveProxyContext';
 import { checkSiteRateLimit } from '@/lib/proxy/siteRateLimit';
-import { LRUMap } from '@/lib/utils/lruMap';
 import { proxyCache, buildCacheKey } from '@/lib/cache/proxyCache';
 import {
   RATE_LIMIT_PER_MIN,
@@ -17,20 +16,32 @@ import {
   MAX_CONCURRENT_RATE_LIMIT_USERS,
 } from '@/lib/config/rateLimit';
 
-// 인메모리 Rate Limit: 사용자당 분당 RATE_LIMIT_PER_MIN회 (기본 60회)
-// LRUMap으로 활성 사용자 MAX_CONCURRENT_RATE_LIMIT_USERS 초과 시 가장 오래된
-// 항목 자동 evict (Railway 단일 인스턴스 메모리 누적 방지).
-const proxyRateLimit = new LRUMap<string, { count: number; resetAt: number }>(MAX_CONCURRENT_RATE_LIMIT_USERS);
+// 인메모리 Rate Limit: 사용자당 분당 RATE_LIMIT_PER_MIN회 (기본 60회).
+//
+// LRUMap을 쓰지 않는다 — 활성 사용자 수가 상한을 넘으면 **살아 있는 윈도의 카운터가
+// evict되어** 그 사용자의 다음 요청이 count:1로 다시 시작한다. 즉 동시 사용자가 많을수록
+// 한도가 무력화된다. 만료 버킷만 정리하고, 자리가 없으면 새 키를 거부(=차단)한다.
+// site 리미터(src/lib/proxy/siteRateLimit.ts)와 동일한 원칙.
+const proxyRateLimit = new Map<string, { count: number; resetAt: number }>();
 
 function checkProxyRateLimit(userId: string): boolean {
   const now = Date.now();
   const entry = proxyRateLimit.get(userId);
-  if (!entry || now >= entry.resetAt) {
-    proxyRateLimit.set(userId, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+  if (entry && now < entry.resetAt) {
+    if (entry.count >= RATE_LIMIT_PER_MIN) return false;
+    entry.count++;
     return true;
   }
-  if (entry.count >= RATE_LIMIT_PER_MIN) return false;
-  entry.count++;
+
+  if (!entry && proxyRateLimit.size >= MAX_CONCURRENT_RATE_LIMIT_USERS) {
+    for (const [key, bucket] of proxyRateLimit) {
+      if (now >= bucket.resetAt) proxyRateLimit.delete(key);
+    }
+    // 만료분을 정리해도 자리가 없으면 활성 카운터를 버리는 대신 차단한다.
+    if (proxyRateLimit.size >= MAX_CONCURRENT_RATE_LIMIT_USERS) return false;
+  }
+
+  proxyRateLimit.set(userId, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
   return true;
 }
 
@@ -60,9 +71,19 @@ const PRIVATE_IP_PATTERNS = [
 function isPrivateHost(hostname: string): boolean {
   if (BLOCKED_HOSTS.has(hostname)) return true;
   // URL 표준에서 IPv6는 대괄호로 감싸짐 (e.g. [fe80::1]) — 패턴 검사 전 제거
-  const bare = hostname.startsWith('[') && hostname.endsWith(']')
+  let bare = hostname.startsWith('[') && hostname.endsWith(']')
     ? hostname.slice(1, -1)
     : hostname;
+
+  // IPv4-mapped IPv6(::ffff:127.0.0.1, ::ffff:169.254.169.254)를 IPv4로 정규화한다.
+  // 정규화 없이는 IPv4 패턴에도 IPv6 패턴에도 걸리지 않아 사설/메타데이터 주소가 통과한다.
+  // Node의 dns.lookup이 매핑 형식을 돌려줄 수 있으므로 실제 도달 가능한 우회 경로다.
+  const mapped = /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i.exec(bare);
+  if (mapped) bare = mapped[1];
+  // 16진 표기(::ffff:7f00:1)도 동일하게 취급 — 매핑 대역 자체를 차단한다.
+  if (/^::ffff:[0-9a-f]{1,4}:[0-9a-f]{1,4}$/i.test(bare)) return true;
+
+  if (BLOCKED_HOSTS.has(bare)) return true;
   return PRIVATE_IP_PATTERNS.some((p) => p.test(bare));
 }
 

--- a/src/lib/ai/generationPipeline.ts
+++ b/src/lib/ai/generationPipeline.ts
@@ -439,8 +439,13 @@ export async function runGenerationPipeline(
     );
 
     // Quality Loop가 새 코드를 생성했을 수 있으므로 보안 검증을 재실행한다.
+    //
+    // 재계산 결과를 저장에도 넘긴다 — 이전에는 오류 검사에만 쓰고 저장에는 루프 이전
+    // validation을 그대로 넘겨, 실제 서빙되는 코드와 다른 코드의 securityCheckPassed·
+    // validationErrors가 DB에 남았다(QC 대시보드가 잘못된 코드를 근거로 판단하게 됨).
+    let finalValidation = validation;
     if (qualityLoopUsed) {
-      const finalValidation = validateAll(finalParsed.html, finalParsed.css, finalParsed.js);
+      finalValidation = validateAll(finalParsed.html, finalParsed.css, finalParsed.js);
       if (finalValidation.errors.length > 0) {
         logger.warn('Quality loop output failed security validation', { projectId, errors: finalValidation.errors });
         throw new Error(`생성된 코드에 보안 문제가 감지되었습니다: ${finalValidation.errors.join(', ')}`);
@@ -452,7 +457,7 @@ export async function runGenerationPipeline(
       {
         projectId, userId, correlationId,
         parsed: finalParsed, quality, qcReport, qualityLoopUsed,
-        validation, apis, projectContext, extraMetadata,
+        validation: finalValidation, apis, projectContext, extraMetadata,
         featureSpec,
         stage2Response: { provider: stage3Result.provider, model: stage3Result.model, durationMs: aggregatedDuration, tokensUsed: aggregatedTokens },
         userPromptUsed: stage3Result.userPrompt,

--- a/src/lib/ai/generationTracker.test.ts
+++ b/src/lib/ai/generationTracker.test.ts
@@ -110,3 +110,24 @@ describe('GenerationTracker', () => {
     stopCleanup();
   });
 });
+
+describe('GenerationTracker — 엔트리 유실 관측 (M-5)', () => {
+  it('엔트리가 없는데 complete()가 호출되면 경고 로그를 남긴다', async () => {
+    // TTL(생성 중 30분)이나 size cap으로 엔트리가 사라진 뒤 완료된 경우.
+    // 코드는 저장됐는데 상태 폴링은 not_found를 보고하므로 조용히 넘기면 안 된다.
+    const { logger } = await import('@/lib/utils/logger');
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const { generationTracker, stopCleanup } = await import('./generationTracker');
+    generationTracker.complete('never-started', {
+      projectId: 'never-started', version: 1, previewUrl: '/p',
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Generation completed but tracker entry was already gone',
+      { projectId: 'never-started' },
+    );
+    warnSpy.mockRestore();
+    stopCleanup();
+  });
+});

--- a/src/lib/ai/generationTracker.ts
+++ b/src/lib/ai/generationTracker.ts
@@ -1,4 +1,5 @@
 import { LRUMap } from '@/lib/utils/lruMap';
+import { logger } from '@/lib/utils/logger';
 
 const TTL_GENERATING_MS = 30 * 60 * 1000; // 30분 — 생성 중 상태는 더 오래 유지
 const TTL_TERMINAL_MS = 10 * 60 * 1000;  // 10분 — completed/failed
@@ -62,7 +63,14 @@ class GenerationTracker {
 
   complete(projectId: string, result: TrackerEntry['result']): void {
     const entry = this.entries.get(projectId);
-    if (!entry) return;
+    if (!entry) {
+      // 엔트리가 TTL(생성 중 30분) 또는 size cap으로 사라진 뒤 완료된 경우.
+      // 상태 폴링이 이 프로젝트를 not_found로 보고하게 되므로(코드는 저장됐는데도)
+      // 조용히 넘기지 않고 남긴다. 근본 해결은 외부 저장소 기반 durable lock이며
+      // 단일 인스턴스 인메모리 구조에서는 관측만 가능하다.
+      logger.warn('Generation completed but tracker entry was already gone', { projectId });
+      return;
+    }
 
     entry.status = 'completed';
     entry.progress = 100;

--- a/src/lib/ai/qualityLoop.ts
+++ b/src/lib/ai/qualityLoop.ts
@@ -277,18 +277,35 @@ async function runLlmRetryIteration(
   const { systemPrompt, userFeedback, aiProvider, iterationTimeoutMs, useET, projectId, attempt } = options;
   try {
     const improvementPrompt = buildQualityImprovementPrompt(state.parsed, state.quality, state.qcReport, userFeedback);
+
+    // 타임아웃 시 in-flight Anthropic 호출을 실제로 취소한다.
+    //
+    // 이전에는 Promise.race만 걸어 race는 즉시 종료되지만 업스트림 요청은 SDK 타임아웃까지
+    // 계속 살아 있었다. 다음 반복이 또 다른 호출을 시작하므로 Opus/ET 호출이 중첩되어
+    // **토큰 비용이 이중으로 청구**됐고, 뒤늦게 거부되는 고아 Promise에는 핸들러가 붙어
+    // 있지 않아 unhandledRejection 위험도 있었다.
+    const controller = new AbortController();
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(
-        () => reject(new Error(`Quality loop iteration timed out after ${iterationTimeoutMs}ms`)),
-        iterationTimeoutMs,
-      );
+      timeoutId = setTimeout(() => {
+        controller.abort();
+        reject(new Error(`Quality loop iteration timed out after ${iterationTimeoutMs}ms`));
+      }, iterationTimeoutMs);
     });
+
+    const generation = aiProvider.generateCode({
+      system: systemPrompt,
+      user: improvementPrompt,
+      extendedThinking: useET,
+      abortSignal: controller.signal,
+    });
+    // abort로 인한 뒤늦은 거부가 unhandledRejection이 되지 않도록 핸들러를 미리 붙인다.
+    // (race에서 지는 쪽의 거부는 아무도 관찰하지 않는다.)
+    generation.catch(() => { /* 타임아웃 경로에서 관찰됨 */ });
+
     // race 종료 후 타이머를 정리한다. 성공 시에도 타이머가 만료(최대 200초)까지 살아남던 누수 차단.
-    const retryResponse = await Promise.race([
-      aiProvider.generateCode({ system: systemPrompt, user: improvementPrompt, extendedThinking: useET }),
-      timeoutPromise,
-    ]).finally(() => clearTimeout(timeoutId));
+    const retryResponse = await Promise.race([generation, timeoutPromise])
+      .finally(() => clearTimeout(timeoutId));
     const retryParsed = parseGeneratedCode(retryResponse.content);
 
     if (!retryParsed.html) {

--- a/src/lib/auth/rateLimit.test.ts
+++ b/src/lib/auth/rateLimit.test.ts
@@ -23,13 +23,15 @@ describe('rateLimit', () => {
     const req = new Request('https://x', { headers: { 'x-forwarded-for': '203.0.113.9' } });
     expect(getClientIp(req)).toBe('203.0.113.9');
   });
-  it('getClientIp는 XFF가 없으면 x-real-ip로 폴백한다', () => {
+  // x-real-ip는 신뢰 경계가 붙였다는 보장이 없어 클라이언트가 위조·회전할 수 있다.
+  // 폴백을 두면 XFF 없는 경로에서 per-IP 한도가 통째로 무력화되므로 신뢰하지 않는다.
+  it('getClientIp는 XFF가 없으면 x-real-ip를 신뢰하지 않고 unknown을 반환한다', () => {
     const req = new Request('https://x', { headers: { 'x-real-ip': '198.51.100.7' } });
-    expect(getClientIp(req)).toBe('198.51.100.7');
+    expect(getClientIp(req)).toBe('unknown');
   });
-  it('getClientIp는 XFF가 빈 문자열이면 x-real-ip로 폴백한다', () => {
+  it('getClientIp는 XFF가 빈 문자열이어도 x-real-ip를 신뢰하지 않는다', () => {
     const req = new Request('https://x', { headers: { 'x-forwarded-for': '', 'x-real-ip': '198.51.100.7' } });
-    expect(getClientIp(req)).toBe('198.51.100.7');
+    expect(getClientIp(req)).toBe('unknown');
   });
   it('getClientIp는 어떤 헤더도 없을 시 "unknown" 반환', () => {
     const req = new Request('https://x');

--- a/src/lib/auth/rateLimit.ts
+++ b/src/lib/auth/rateLimit.ts
@@ -29,5 +29,12 @@ export function getClientIp(request: Request): string {
   const xff = request.headers.get('x-forwarded-for');
   const rightmost = xff?.split(',').at(-1)?.trim();
   if (rightmost) return rightmost;
-  return request.headers.get('x-real-ip')?.trim() || 'unknown';
+
+  // XFF가 없으면 x-real-ip로 폴백하지 않는다.
+  //
+  // x-real-ip는 신뢰 경계(Railway 엣지)가 붙였다는 보장이 없어 클라이언트가 자유롭게
+  // 위조·회전할 수 있다. 폴백을 두면 XFF가 없는 경로에서 per-IP 한도(signup·비밀번호
+  // 재설정 메일 발송)가 통째로 무력화된다. 식별 불가일 땐 단일 'unknown' 버킷으로
+  // 모아 fail-closed 한다 — 과차단이 우회보다 안전하다.
+  return 'unknown';
 }

--- a/src/services/rateLimitService.test.ts
+++ b/src/services/rateLimitService.test.ts
@@ -105,7 +105,7 @@ describe('RateLimitService.checkAndIncrementDailyLimit()', () => {
     repo.getCurrentUsage.mockRejectedValue(new Error('usage read fail'));
     const service = new RateLimitService(repo);
 
-    await expect(service.checkAndIncrementDailyLimit('user-1')).resolves.toBeUndefined();
+    await expect(service.checkAndIncrementDailyLimit('user-1')).resolves.toEqual({ charged: true });
     await flush();
     expect(eventBus.emit).not.toHaveBeenCalled();
   });
@@ -123,7 +123,8 @@ describe('RateLimitService.checkAndIncrementDailyLimit()', () => {
     repo.checkAndIncrementDailyLimit.mockRejectedValue(new Error('db down'));
     const service = new RateLimitService(repo);
 
-    await expect(service.checkAndIncrementDailyLimit('user-1')).resolves.toBeUndefined();
+    // fail-open은 카운터를 올리지 않으므로 charged=false — 실패해도 환불하면 안 된다.
+    await expect(service.checkAndIncrementDailyLimit('user-1')).resolves.toEqual({ charged: false });
     expect(logger.error).toHaveBeenCalledWith(
       'Rate limit check failed — failing open',
       expect.objectContaining({ userId: 'user-1', error: 'db down' })
@@ -135,7 +136,7 @@ describe('RateLimitService.checkAndIncrementDailyLimit()', () => {
     repo.checkAndIncrementDailyLimit.mockRejectedValue('raw string failure');
     const service = new RateLimitService(repo);
 
-    await expect(service.checkAndIncrementDailyLimit('user-1')).resolves.toBeUndefined();
+    await expect(service.checkAndIncrementDailyLimit('user-1')).resolves.toEqual({ charged: false });
     expect(logger.error).toHaveBeenCalledWith(
       'Rate limit check failed — failing open',
       expect.objectContaining({ error: 'raw string failure' })

--- a/src/services/rateLimitService.ts
+++ b/src/services/rateLimitService.ts
@@ -31,15 +31,16 @@ export class RateLimitService {
    * On DB error, fails open (allows the request) to avoid blocking
    * legitimate users due to infrastructure issues.
    *
-   * IMPORTANT: Call decrementDailyLimit() in the failure path if this
-   * method returned successfully but the generation subsequently failed.
+   * IMPORTANT: 반환된 `charged`가 true일 때만 실패 경로에서 decrementDailyLimit()을
+   * 호출할 것. 우회(bypass)와 fail-open은 카운터를 올리지 않으므로, 조건 없이 환불하면
+   * 사용자가 호출할 때마다 한도가 늘어난다.
    */
-  async checkAndIncrementDailyLimit(userId: string): Promise<void> {
+  async checkAndIncrementDailyLimit(userId: string): Promise<{ charged: boolean }> {
     const bypassIds = (process.env.RATE_LIMIT_BYPASS_USER_IDS ?? '').split(',').map((s) => s.trim()).filter(Boolean);
     if (bypassIds.includes(userId)) {
       // 무로깅 우회는 운영 가시성 사각지대를 만든다. 우회 적용 시 감사 로그를 남긴다.
       logger.info('Rate limit bypass applied', { userId, source: 'RATE_LIMIT_BYPASS_USER_IDS' });
-      return;
+      return { charged: false };
     }
 
     const limits = getLimits();
@@ -60,13 +61,16 @@ export class RateLimitService {
           });
         }
       }).catch(() => { /* 경고 실패는 무시 */ });
+      return { charged: true };
     } catch (err) {
       if (err instanceof RateLimitError) throw err;
-      // Fail open: DB error — allow the request to proceed
+      // Fail open: DB error — allow the request to proceed.
+      // 카운터는 올라가지 않았으므로 charged=false — 실패해도 환불하면 안 된다.
       logger.error('Rate limit check failed — failing open', {
         userId,
         error: err instanceof Error ? err.message : String(err),
       });
+      return { charged: false };
     }
   }
 


### PR DESCRIPTION
[2026-07-28 전체 검수](docs/decisions/2026-07-28-published-site-proxy-authz.md)에서 확정한 13건 중, CRITICAL·HIGH 4건(#195)에 이어 **남은 MEDIUM**을 처리합니다.

## 💸 M-1 — Quality Loop 타임아웃이 업스트림 호출을 취소하지 않았습니다 (비용 이중청구)

`Promise.race`로 타임아웃만 걸고 `AbortSignal`을 넘기지 않아, **race는 즉시 끝나도 Anthropic 호출은 SDK 타임아웃(~270초)까지 살아 있었습니다.** 다음 반복이 또 다른 호출을 시작하므로 Opus/ET 호출이 중첩되어 토큰 비용이 이중 청구됐습니다. 뒤늦게 거부되는 고아 Promise에 핸들러가 없어 `unhandledRejection` 위험도 있었습니다.

`AiPrompt.abortSignal` → `ClaudeProvider`의 `{ signal }` 배선은 **이미 있었고 qualityLoop만 안 쓰고 있었습니다.** 반복마다 `AbortController`를 만들어 타임아웃 시 `abort()`하고, race에서 지는 쪽의 거부를 관측하도록 no-op catch를 미리 붙입니다.

## M-2 — Quality Loop 이후 stale `validation` 저장

루프가 코드를 교체해도 저장에는 **루프 이전** `validation`이 넘어가, 실제 서빙되는 코드와 다른 `securityCheckPassed`·`validationErrors`가 DB에 남았습니다. QC 대시보드가 잘못된 근거로 판단하게 됩니다. 재계산 결과를 저장에도 넘깁니다 — 오류 검사에만 쓰고 버리던 값입니다.

## M-3 — fail-open + 무조건 환불로 무료 할당량 증가

우회·DB 오류(fail-open)는 **카운터를 올리지 않는데** 실패 경로는 조건 없이 환불했습니다. 5/10에서 fail-open → 파이프라인 실패 → 환불이면 4/10이 됩니다.

`{ charged: boolean }` 반환으로 바꾸고 청구된 경우에만 환불합니다. 환불 경로가 라우트(`pendingDecrement`)와 파이프라인(`handlePipelineFailure`) **두 곳**이라, 파이프라인에는 미청구 시 no-op 디크리멘터를 주입해 양쪽을 한 번에 막습니다.

## M-5 — `generationTracker` 락 소실 ⚠️ 부분 대응

엔트리가 TTL(30분)·size cap으로 사라지면 `complete()`가 조용히 no-op이 되어 **코드는 저장됐는데 폴링은 not_found**를 보고합니다.

**근본 해결은 외부 저장소 기반 durable lock이라 단일 인스턴스 인메모리 구조에서는 불가능합니다.** 관측 가능하게만 만들었습니다(`logger.warn`). 상태 엔드포인트에 DB 폴백이 있어 사용자 영향은 일부 완화되어 있습니다. 멀티 인스턴스 전환 시 Redis 교체와 함께 해결할 사안으로 남깁니다.

## M-6 — 프록시 리미터 LRU eviction이 활성 카운터를 리셋

`LRUMap(1000)`이라 활성 사용자가 상한을 넘으면 **살아 있는 윈도의 카운터가 evict되어** 다음 요청이 `count:1`로 시작합니다. 동시 사용자가 많을수록 60/분 한도가 무력화됩니다.

만료 버킷만 정리하고, 정리 후에도 자리가 없으면 **차단**합니다(우회보다 과차단이 안전). #195에서 신규 site 리미터에 적용한 원칙을 기존 리미터에도 통일했습니다.

## M-7 — IPv4-mapped IPv6 SSRF 우회

`isPrivateHost('::ffff:127.0.0.1')`이 **false**였습니다 — IPv4 패턴에도 IPv6 패턴에도 걸리지 않습니다. Node의 `dns.lookup`이 매핑 형식을 돌려줄 수 있어 실제 도달 가능한 경로입니다. 정규화 후 검사하고 16진 표기(`::ffff:7f00:1`)는 대역째 차단합니다.

## M-8 — `x-real-ip` 신뢰 제거

XFF가 없으면 `x-real-ip`로 폴백했는데, 이 헤더는 신뢰 경계가 붙였다는 보장이 없어 클라이언트가 위조·회전할 수 있습니다. XFF 없는 경로에서 per-IP 한도(signup·재설정 메일)가 무력화됩니다. 폴백을 제거하고 `'unknown'` 단일 버킷으로 **fail-closed** 합니다.

> Railway가 항상 XFF를 붙이므로 프로덕션 영향은 없습니다. XFF 없는 환경으로 이전하면 과차단될 수 있어, 그때는 해당 플랫폼의 신뢰 가능한 헤더를 명시적으로 추가해야 합니다.

## 검증

| 항목 | 결과 |
|------|------|
| `pnpm lint` | 0 errors (warning 2건 — 기존) |
| `pnpm type-check` | 통과 |
| `pnpm test` | **168 파일 / 2070건 통과** |

신규 회귀 테스트: IPv4-mapped IPv6 3종(리터럴 2 + DNS 해석 1) 차단, `x-real-ip` 미신뢰, `{ charged }` 반환 계약.

**기존 테스트 다수가 옛 동작을 검증하고 있어 함께 갱신했습니다** — `checkAndIncrementDailyLimit` mock 반환값(7개 파일), `x-real-ip` 폴백 단언 2건, `resolves.toBeUndefined()` 6건.

## ⚠️ 미해결 — 운영 조치 필요 (코드 밖)

`__Secure-authjs.callback-url`이 `https://0.0.0.0:8080`으로 설정됩니다. `AUTH_URL`이 코드·문서 어디에도 참조되지 않아 Auth.js가 컨테이너 바인드 주소에서 유도한 값입니다.

`AUTH_TRUST_HOST=true`라 실제 로그인은 정상 동작하므로 영향은 낮으나, **Railway 환경변수에 `AUTH_URL=https://xzawed.xyz` 추가**를 권장합니다. 코드 변경이 아니라 이 PR 범위 밖입니다.

## 문서

- [ADR](docs/decisions/2026-07-29-medium-audit-findings.md)
- `CLAUDE.md` — 인메모리 레이트리밋 구현 규칙(LRU eviction 금지), AI 호출 타임아웃 규칙(AbortSignal 필수), `x-real-ip` 미신뢰 3개 항목 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)
