### PR TITLE
fix: 생성 락을 인메모리 tracker에서 SQLite로 분리 (#198)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,14 +35,14 @@ src/
 ├── components/      # UI 컴포넌트 (builder/, catalog/, dashboard/, layout/, settings/, ui/)
 ├── hooks/           # 커스텀 React hooks
 ├── lib/             # 유틸리티
-│   ├── ai/          # AI 파이프라인 — generationPipeline(오케스트레이터), stageRunner, generationSaver, qualityLoop, generationTracker
+│   ├── ai/          # AI 파이프라인 — generationPipeline(오케스트레이터), stageRunner, generationSaver, qualityLoop, generationTracker(진행률 전용), generationLock(중복 생성 차단 — DB 락)
 │   ├── auth/        # 인증 — getAuthUser, local-auth*(Credentials+JWT, edge-safe 분할 base/edge), password(scrypt hashPassword/verifyPassword), tokens(auth_tokens 발급/검증), rateLimit(per-IP 스로틀), verifiedGuard(assertEmailVerified), authorize(assertOwner)
 │   ├── cache/       # proxyCache.ts — LRU+TTL 인메모리 캐시 (프록시 응답 서버사이드 캐시)
 │   ├── config/      # 환경변수 기반 설정 (features, rateLimit, qc, limits 등)
 │   ├── catalog/     # API 카탈로그 — healthCheck.ts(DB기반 라이브 검증 분류), verifyRunner.ts(라이브 검증 오케스트레이터·verification_status 갱신, admin 트리거), keyCheck.ts(플랫폼 키 검증), activeApiCount.ts(활성 개수 동적 카운트 — 랜딩/카탈로그 마케팅 카피, 하드코딩 금지)
 │   ├── constants/   # 공용 상수 — cdn.ts (CSP CDN 화이트리스트, buildSiteCsp)
 │   ├── countries/   # 자체 호스팅 국가 데이터 API 로직 — transform(mledoze 변환), query(region/search 필터·코드 조회), types
-│   ├── db/          # 임베디드 SQLite — sqlite/(connection WAL/FK, schema 10테이블, migrator, bootstrap, seedCatalog, ensureCatalog, backup 주기 .backup 덤프+보관정책, retention 무한증가 테이블 정리), errors(UNIQUE 위반 감지)
+│   ├── db/          # 임베디드 SQLite — sqlite/(connection WAL/FK, schema 11테이블, migrator, bootstrap, seedCatalog, ensureCatalog, backup 주기 .backup 덤프+보관정책, retention 무한증가 테이블 정리), errors(UNIQUE 위반 감지)
 │   ├── email/       # 이메일 발송 — emailService(sendVerificationEmail/sendPasswordResetEmail), Resend provider, no-op console fallback(RESEND_API_KEY 미설정 시)
 │   ├── deploy/      # 배포 관련
 │   ├── events/      # EventBus (pub/sub) + eventPersister (전체 이벤트 자동 DB 기록)
@@ -55,7 +55,7 @@ src/
 │   └── utils/       # 공통 유틸리티, 에러 클래스
 ├── middleware.ts     # 서브도메인 라우팅, 보안 헤더 (CSP, HSTS)
 ├── providers/       # AI Provider (IAiProvider → ClaudeProvider)
-├── repositories/    # 데이터 접근 계층 — sqlite/(8 IRepository 구현 — SqliteAuthTokenRepository 추가), interfaces, utils, factory(무인자 SQLite 생성)
+├── repositories/    # 데이터 접근 계층 — sqlite/(9 IRepository 구현 — SqliteGenerationLockRepository 추가), interfaces, utils, factory(무인자 SQLite 생성)
 ├── services/        # 비즈니스 로직 계층
 ├── stores/          # Zustand 스토어
 ├── templates/       # 코드 생성 템플릿
@@ -147,6 +147,7 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 - `PIPELINE_MAX_DURATION_MS` — 파이프라인 총 허용 시간 (기본: 290000ms = 290초). Quality Loop 시작 시 `경과 시간 + iterationTimeout > 이 값`이면 반복을 건너뜀. Railway 300초 한도를 고려한 안전 마진 확보용
 - `QC_QUALITY_THRESHOLD`, `QC_MOBILE_THRESHOLD` — Quality Loop 재시도 트리거 점수 임계값 (각 기본: 60)
 - `RATE_LIMIT_BYPASS_USER_IDS` — 쉼표 구분 userId 목록. 포함된 계정은 일일 생성 한도 검사 스킵 (관리자/개발자 우회용)
+- `GENERATION_LOCK_HEARTBEAT_MS` / `GENERATION_LOCK_STALE_MS` — 생성 락 생존 신호 주기(기본 30초) / 죽은 락 판정 시간(기본 5분). **stale은 heartbeat보다 커야 하며** 아니면 `heartbeat × 2`로 교정하고 경고를 남긴다. 로직: `src/lib/config/generation.ts`
 - 전체 환경변수 목록은 [docs/reference/env-vars.md](docs/reference/env-vars.md) 참조
 
 ## 문서 참조
@@ -166,6 +167,7 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 | **게시 사이트 프록시 복구·인가 모델 정비 ADR (C-1·C-2·H-1·H-2, 2026-07-28)** | [docs/decisions/2026-07-28-published-site-proxy-authz.md](docs/decisions/2026-07-28-published-site-proxy-authz.md) |
 | 게시 사이트 프록시 설계 spec | [docs/superpowers/specs/2026-07-28-published-site-proxy-authz-design.md](docs/superpowers/specs/2026-07-28-published-site-proxy-authz-design.md) |
 | 검수 MEDIUM 발견 항목 수정 ADR (M-1·2·3·5·6·7·8, 2026-07-29) | [docs/decisions/2026-07-29-medium-audit-findings.md](docs/decisions/2026-07-29-medium-audit-findings.md) |
+| **생성 락을 인메모리 tracker에서 SQLite로 분리 ADR (M-5 근본 해결, 2026-07-29)** | [docs/decisions/2026-07-29-durable-generation-lock.md](docs/decisions/2026-07-29-durable-generation-lock.md) |
 | better-sqlite3 v13 N-API 프리빌트 전환·빌드 툴체인 제거 ADR (2026-07-28) | [docs/decisions/2026-07-28-better-sqlite3-v13-napi-prebuilds.md](docs/decisions/2026-07-28-better-sqlite3-v13-napi-prebuilds.md) |
 | 환경변수 목록 | [docs/reference/env-vars.md](docs/reference/env-vars.md) |
 | 에러 클래스 참조 | [docs/reference/error-codes.md](docs/reference/error-codes.md) |
@@ -290,7 +292,7 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 - **Playwright 병렬 체크 주의**: 단일 `page` 인스턴스에서 `Promise.allSettled` 사용 시 viewport를 변경하는 체크는 반드시 다른 체크 완료 후 순차 실행 (`renderingQc.ts` 참고)
 - **playwright-core executablePath 주의**: `playwright-core`는 `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` 환경변수를 자동으로 읽지 않음. `const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH; chromium.launch({ ...(executablePath && { executablePath }) })` 형태로 명시적 전달 필요 (미설정 시 executablePath를 전달하지 않아 playwright-core 기본 탐색 로직이 유지됨). `playwright`(풀 패키지)와 달리 `playwright-core`는 브라우저 다운로드·자동 경로 탐색을 수행하지 않음 (`browserPool.ts` 참고)
 - **slug 충돌 처리**: `assignUniqueSlug()` in `projectService.ts` — base → base-2 → … → base-10 → timestamp fallback; UNIQUE 위반 시 1회 재시도. SQLite UNIQUE 위반은 `isUniqueViolation()`(`@/lib/db/errors`)가 `SQLITE_CONSTRAINT_UNIQUE`/`SQLITE_CONSTRAINT_PRIMARYKEY`/"UNIQUE constraint failed" 메시지로 감지(레거시 23505도 폴백 인식)
-- **generationTracker 단일 인스턴스**: `src/lib/ai/generationTracker.ts`의 `generationTracker`는 모듈 레벨 싱글톤. TTL 차등: `generating` 30분, `completed`/`failed` 10분. Railway 단일 인스턴스 환경에서만 동작 — 멀티 인스턴스 배포 시 Redis 등 외부 저장소로 교체 필요
+- **generationTracker는 진행률 전용 — 중복 생성 게이트로 쓰지 말 것**: `src/lib/ai/generationTracker.ts`의 `generationTracker`는 모듈 레벨 싱글톤이고 TTL 차등(`generating` 30분, `completed`/`failed` 10분)이라 **엔트리가 사라지면 락도 사라진다**. 여기에 게이트를 두면 같은 projectId로 두 번째 파이프라인이 시작돼 Opus/ET 토큰이 이중 청구되고 같은 version으로 UNIQUE 위반이 난다. `isGenerating()`은 그래서 제거됐고 `generationTracker.test.ts`가 부재를 단언한다. 중복 차단은 **`@/lib/ai/generationLock`(DB `generation_locks`)** 담당: 라우트가 `acquireGenerationLock`으로 획득(실패 시 409), `runGenerationPipeline`이 heartbeat를 돌리고 `finally`에서 **중지 → 해제 순서로** 정리한다. 크래시 시 `GENERATION_LOCK_STALE_MS`(기본 5분) 후 자동 탈취. 배경: [ADR](docs/decisions/2026-07-29-durable-generation-lock.md)
 - **생성 상태 폴링 추출**: `builder/page.tsx`의 SSE 폴백 폴링은 `src/lib/generation/pollGenerationStatus.ts`로 추출됨(주입형 `fetchFn`·`delay`·콜백, 단위 테스트 대상). `page.tsx`는 thin 래퍼. 상태 처리: `generating`→진행률 갱신, `completed`+result→완료, **`failed`→즉시 terminal 실패**(이전엔 maxAttempts까지 재시도하던 quirk를 교차검증 후 개선), `not_found`→프로젝트 미존재 메시지, 그 외(`unknown`)→연결 복구 실패 메시지. 테스트는 DI-delay(즉시 resolve)로 결정적 검증, 기본 `setTimeout` 경로만 `vi.useFakeTimers()`+`runAllTimersAsync()`로 커버
 - **모듈 레벨 상태가 있는 파일 테스트**: `let registered = false` 같은 모듈 레벨 플래그가 있는 파일은 테스트 간 상태 누출이 발생한다. `vi.resetModules()` + 매 테스트마다 `await import(...)` 동적 임포트로 격리한다 (`eventPersister.ts` 참고)
 - **api 라우트 테스트 — providers/supabase 모킹 더 이상 불필요**: SQLite 컷오버(P8.2) 후 `@/lib/db/failover`·`@/lib/db/connection`(→pg/drizzle-pg native cold-init)이 제거됐고, 상수만 반환하던 `@/lib/config/providers`도 2026-07-10 죽은 코드 정리로 **삭제됨**. 과거 cold-init 차단용 `vi.mock('@/lib/config/providers', ...)`·`vi.mock('@/lib/supabase/server', ...)`는 전부 제거됨(잔존 시 존재하지 않는 모듈 모킹). `vitest.config.ts`의 `testTimeout`/`hookTimeout` 15000ms 상향은 경합 마진으로 유지 — 배경: [docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md](docs/decisions/2026-06-09-test-flaky-timeout-contention-fix.md)
@@ -323,7 +325,7 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 | Issue | 내용 | 성격 |
 |-------|------|------|
 | ~~[#197](https://github.com/xzawed/CustomWebService/issues/197)~~ | C-1·C-2 실환경 검증 | **완료(2026-07-29)** — [ADR 검증 절](docs/decisions/2026-07-28-published-site-proxy-authz.md) |
-| [#198](https://github.com/xzawed/CustomWebService/issues/198) | M-5 generationTracker durable lock (SQLite 락 권장) | **부분 대응** — 관측만 추가됨 |
+| ~~[#198](https://github.com/xzawed/CustomWebService/issues/198)~~ | M-5 generationTracker durable lock | **완료(2026-07-29)** — [ADR](docs/decisions/2026-07-29-durable-generation-lock.md) |
 | [#199](https://github.com/xzawed/CustomWebService/issues/199) | M-4 잔여 — 캐시 키에 키 신원 추가해 캐시 이득 회복 | 안전하나 비효율 |
 | [#200](https://github.com/xzawed/CustomWebService/issues/200) | site 프록시 오남용 모니터링 (프로젝트 전역 한도가 유일 경계) | 운영 가시성 |
 | [#201](https://github.com/xzawed/CustomWebService/issues/201) | Railway Wait for CI + env 단독 변경 시 재배포 FAILED | 원인 미확정 |

--- a/docs/decisions/2026-07-29-durable-generation-lock.md
+++ b/docs/decisions/2026-07-29-durable-generation-lock.md
@@ -1,0 +1,145 @@
+# 생성 락을 인메모리 tracker에서 SQLite로 분리 (2026-07-29)
+
+## 상태
+
+승인됨 — 구현 완료 ([#198](https://github.com/xzawed/CustomWebService/issues/198))
+
+## 배경
+
+`generationTracker`는 진행률 표시와 **중복 생성 차단**을 겸하고 있었다. 저장소는 모듈 레벨
+`LRUMap(10_000)`이고 TTL은 `generating` 30분 / terminal 10분이다.
+
+엔트리가 TTL 또는 size cap으로 사라지면 `isGenerating()`이 `false`를 돌려준다. 즉
+**락의 실체가 사라지면 락이 열린다.** 결과:
+
+1. 같은 `projectId`로 두 번째 파이프라인이 시작될 수 있다 — Opus/ET 호출이 중복되어
+   **토큰이 이중 청구**되고, 두 파이프라인이 같은 `getNextVersion()`을 받아
+   한쪽이 `UNIQUE(project_id, version)` 위반으로 실패한다
+2. 프로세스가 재시작되면 진행 중이던 락이 통째로 사라진다
+
+PR #196은 `complete()` 유실 시 `logger.warn`을 남겨 **관측만** 가능하게 했다. 근본 원인은
+그대로였다 — 같은 구조 안에서는 고칠 수 없다. TTL을 늘리면 크래시된 파이프라인이 프로젝트를
+영구히 잠그고, 없애면 메모리가 무한 증가한다.
+
+> 검수 이력: Grok이 최초에 "`isGenerating` 체크와 `start()` 사이 TOCTOU"로 보고했으나 해당
+> 구간에 `await`이 없어 **오탐으로 철회**됐다. 실제 메커니즘은 이 eviction/TTL 경로다.
+
+## 결정
+
+**락 책임만 DB로 분리한다.** tracker는 진행률 표시 전용으로 남긴다(이슈의 방안 A).
+
+### 1. `generation_locks` 테이블
+
+```sql
+CREATE TABLE generation_locks (
+  project_id   TEXT PRIMARY KEY,
+  user_id      TEXT NOT NULL,
+  acquired_at  TEXT NOT NULL,
+  heartbeat_at TEXT NOT NULL
+);
+```
+
+**FK를 두지 않았다.** 수명이 짧은 운영 상태이고, `project_id` FK가 있으면 스테일 락이 남은
+프로젝트의 삭제가 FK 위반으로 실패한다(`admin/test-generation`의 cleanup 경로가 실제로 그렇다).
+무결성은 stale 만료와 release가 담당한다.
+
+시각은 다른 테이블과 같은 ISO8601 UTC 문자열이다 — 고정 폭이라 `heartbeat_at < ?` 사전식
+비교가 곧 시간 비교다.
+
+### 2. 원자적 획득 — 단일 문 test-and-set
+
+```sql
+INSERT INTO generation_locks (project_id, user_id, acquired_at, heartbeat_at)
+VALUES (?, ?, ?, ?)
+ON CONFLICT(project_id) DO UPDATE SET ...
+  WHERE generation_locks.heartbeat_at < ?   -- stale한 락만 탈취
+RETURNING project_id
+```
+
+better-sqlite3는 동기 API이고 SQLite는 한 시점에 writer가 1개다. 단일 문이므로 조회와 획득
+사이에 끼어들 틈이 없다 — `SqliteRateLimitRepository`의
+`UPDATE ... WHERE count < limit RETURNING`과 **같은 검증된 패턴**이다.
+
+획득 실패는 "0행 반환"으로 나타난다: 유효한 락이 있으면 `DO UPDATE`의 `WHERE`가 거짓이 되어
+아무 행도 갱신되지 않고 `RETURNING`도 비어 있다.
+
+### 3. heartbeat — 크래시가 프로젝트를 영구히 잠그지 않게
+
+파이프라인이 도는 동안 `GENERATION_LOCK_HEARTBEAT_MS`(기본 30초)마다 `heartbeat_at`을 갱신한다.
+프로세스가 죽으면 신호가 멈추고 `GENERATION_LOCK_STALE_MS`(기본 5분) 후 다른 요청이 탈취한다.
+
+**진행률 갱신 지점에 얹지 않고 독립 타이머를 쓴다** — 파이프라인은 Stage 사이에 수십 초씩 AI
+응답을 기다리므로 간격이 들쭉날쭉해진다. 타이머는 `.unref()`되어 종료를 막지 않는다
+(backup/retention 스케줄러와 동일 원칙).
+
+**`stale > heartbeat`는 강제한다.** 작거나 같으면 살아 있는 파이프라인이 다음 신호 전에 스스로
+만료되어 중복 파이프라인이 다시 열린다. 잘못된 조합은 `heartbeat × 2`로 교정하고 경고를 남긴다 —
+조용히 폴백하면 운영자가 값을 바꿨는데 적용되지 않은 이유를 알 수 없다.
+
+### 4. 수명주기 배치
+
+| 단계 | 위치 | 이유 |
+|------|------|------|
+| 획득 | 라우트 (`generate` · `regenerate` · `admin/test-generation`) | 409를 **스트림 시작 전에** 반환해야 한다 |
+| heartbeat 시작·중지 | `runGenerationPipeline` | 파이프라인 수명과 정확히 일치 |
+| 해제 | `runGenerationPipeline`의 `finally` | 성공·실패 무관하게 반드시 해제 |
+
+`finally`에서 **heartbeat를 먼저 멈추고 해제한다.** 순서가 뒤집히면 방금 해제한 락에 대해
+heartbeat가 한 번 더 돌아 무의미한 경고 로그가 남는다.
+
+해제는 **던지지 않는다** — `finally`에서 예외가 나면 파이프라인의 원래 오류를 덮어버린다.
+해제에 실패해도 stale 만료가 백스톱이다.
+
+### 5. `isGenerating()` 제거
+
+tracker에서 아예 없앴다. 남겨두면 누군가 다시 게이트로 쓴다. 자리에 이유를 적은 주석을 남기고,
+`generationTracker.test.ts`가 **이 메서드가 존재하지 않음을 단언**해 회귀를 고정한다.
+
+## 트레이드오프
+
+**획득 실패는 fail-closed다.** DB 조회가 실패하면 던져서 500을 낸다 — 폴백해서 진행하면
+중복 파이프라인을 막지 못한다. 생성을 시작하지 못하는 쪽이 토큰을 이중으로 태우는 것보다 낫다.
+
+**라우트가 획득하고 파이프라인이 해제한다.** 수명주기가 두 모듈에 걸친다. 라우트가 락을 잡은 뒤
+파이프라인 진입 전에 죽으면(스트림 생성 실패·클라이언트 조기 절단) 락이 stale까지 남는다.
+기존 tracker의 30분 TTL보다 6배 짧으므로 순 개선이며, 이 창을 없애려면 SSE 스트림 구조 자체를
+바꿔야 해서 비용이 이득을 넘는다.
+
+**`retention.ts` 정리 대상에 넣지 않았다.** 행은 `project_id`로 유일하고 정상 경로에서
+해제되므로 상한이 **프로젝트 수**다. 트래픽에 선형 비례하는 `platform_events`와 성격이 다르다.
+(생성 도중 프로젝트가 삭제되면 행 1개가 고아로 남지만 같은 `project_id`가 다시 나오면 덮어쓴다.)
+
+**멀티 인스턴스**로 가면 이 락은 그대로 유효하다 — 단일 writer SQLite가 공유 볼륨을 전제로
+하므로 이 부분은 Redis 전환 시에도 인터페이스(`IGenerationLockRepository`)만 바꾸면 된다.
+
+## 범위 밖
+
+상태 폴링의 `not_found` 오보(이슈의 방안 C)는 **이미 해소되어 있었다** —
+`/api/v1/generate/status/[projectId]`가 tracker 미스 시 DB의 최신 코드로 완료를 판정한다.
+이번 변경은 중복 파이프라인(문제 2)만 다룬다.
+
+## 검증
+
+| 항목 | 결과 |
+|------|------|
+| `pnpm type-check` | 통과 |
+| `pnpm test` | **171 파일 / 2114 테스트 통과** (기존 2073 + 신규 41) |
+
+TDD로 작성했고 모든 신규 테스트가 구현 전에 실패하는 것을 확인했다.
+
+신규 테스트가 고정하는 것:
+
+- **원자적 획득** — 유효한 락이 있으면 두 번째 획득 실패(본인 재획득 포함), 프로젝트 간 독립
+- **stale 경계** — 경계 직전엔 탈취 불가, 넘으면 탈취 가능하고 소유자·획득 시각이 교체됨
+- **heartbeat** — 계속 보내면 stale 경계를 넘겨도 유지, 중지하면 만료, 락이 없으면 `false`,
+  `acquired_at`은 갱신하지 않음(총 점유 시간 관측)
+- **내구성** — 레포 인스턴스를 교체해도(프로세스 재시작 대응) 판정이 일관됨
+- **오류 격리** — 해제·heartbeat가 던져도 밖으로 새지 않음(unhandledRejection 방지)
+- **수명주기** — 성공·실패 양쪽에서 해제되고, heartbeat 중지가 해제보다 **먼저** 일어남
+- **회귀 고정** — `generationTracker.isGenerating`이 존재하지 않음
+
+## 관련 문서
+
+- [검수 MEDIUM 발견 항목 수정 ADR](2026-07-29-medium-audit-findings.md) — M-5 절(관측만 추가한 이전 단계)
+- [SQLite 컷오버 ADR](2026-06-23-sqlite-cutover-and-supabase-removal.md)
+- [환경변수 목록](../reference/env-vars.md) — `GENERATION_LOCK_*`

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -174,6 +174,8 @@ DB 어댑터 없는 JWT 무상태 세션. 공개 셀프서비스 회원가입, D
 | `QUALITY_LOOP_MAX_ITERATIONS` | `2` | ✅ **`2` 운영 중** | 품질 루프 최대 반복 횟수. 기본 2회 (최대 3회 상한). **현재 2회 운영 중.** 낮출수록 총 생성 시간 단축 — Railway 300초 타임아웃 초과 방지용 |
 | `QUALITY_LOOP_STRICT_ADOPTION` | `true` | ➖ | 채택 가드: `true`(기본)는 한 점수 향상 + 다른 점수 동등 이상일 때만 retry 채택(시소 진동 방지). `false`로 설정 시 기존 OR 로직(한쪽 향상) 복원 — 운영 데이터 비교용 롤백 스위치 |
 | `PIPELINE_MAX_DURATION_MS` | `290000` | ➖ | 파이프라인 총 허용 시간(ms). Quality Loop 시작 전 `경과 시간 + iterationTimeout > 이 값`이면 반복 스킵. Railway 300초 한도를 고려해 기본값 290초(10초 여유). 미설정 시 290000 자동 사용 |
+| `GENERATION_LOCK_HEARTBEAT_MS` | `30000` | ➖ | 생성 락(`generation_locks`) 생존 신호 주기(ms). 파이프라인이 도는 동안 이 간격으로 `heartbeat_at`을 갱신한다. 0·음수·비정수는 기본값 폴백 |
+| `GENERATION_LOCK_STALE_MS` | `300000` | ➖ | 이 시간 동안 heartbeat가 없으면 죽은 락으로 보고 다른 요청이 탈취한다(ms). 크래시된 파이프라인이 프로젝트를 영구히 잠그지 않게 하는 안전장치. **heartbeat 주기보다 커야 하며**, 작거나 같으면 `heartbeat × 2`로 교정하고 `logger.warn`을 남긴다 |
 | `QC_QUALITY_THRESHOLD` | `60` | ➖ | 정적 QC 구조 점수 재시도 트리거 임계값. 이 값 미만이면 Quality Loop 재시도 수행 |
 | `QC_MOBILE_THRESHOLD` | `60` | ➖ | 정적 QC 모바일 점수 재시도 트리거 임계값. 이 값 미만이면 Quality Loop 재시도 수행 |
 | `QC_FAST_PASS_THRESHOLD` | `60` | ➖ | Fast QC 통과 기준 점수. 이 값 미만이면 Fast QC 실패로 판정 |

--- a/drizzle/sqlite/0002_icy_cassandra_nova.sql
+++ b/drizzle/sqlite/0002_icy_cassandra_nova.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `generation_locks` (
+	`project_id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`acquired_at` text NOT NULL,
+	`heartbeat_at` text NOT NULL
+);

--- a/drizzle/sqlite/meta/0002_snapshot.json
+++ b/drizzle/sqlite/meta/0002_snapshot.json
@@ -1,0 +1,1092 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d600e360-cbc4-420e-93c9-c694f6e6a3ba",
+  "prevId": "0e038279-c70e-4f3b-8668-83f331aec4c2",
+  "tables": {
+    "api_catalog": {
+      "name": "api_catalog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changelog": {
+          "name": "changelog",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "docs_url": {
+          "name": "docs_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoints": {
+          "name": "endpoints",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_version": {
+          "name": "api_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deprecated_at": {
+          "name": "deprecated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "successor_id": {
+          "name": "successor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cors_supported": {
+          "name": "cors_supported",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "requires_proxy": {
+          "name": "requires_proxy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "credit_required": {
+          "name": "credit_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_ttl_seconds": {
+          "name": "cache_ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'unverified'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_verification_note": {
+          "name": "last_verification_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_tokens": {
+      "name": "auth_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_token_hash_idx": {
+          "name": "auth_tokens_token_hash_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feature_flags": {
+      "name": "feature_flags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flag_name": {
+          "name": "flag_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "feature_flags_flag_name_unique": {
+          "name": "feature_flags_flag_name_unique",
+          "columns": [
+            "flag_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "generated_codes": {
+      "name": "generated_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_html": {
+          "name": "code_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code_css": {
+          "name": "code_css",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code_js": {
+          "name": "code_js",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "framework": {
+          "name": "framework",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'vanilla'"
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_prompt_used": {
+          "name": "ai_prompt_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation_time_ms": {
+          "name": "generation_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_usage": {
+          "name": "token_usage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "generated_codes_project_id_version_unique": {
+          "name": "generated_codes_project_id_version_unique",
+          "columns": [
+            "project_id",
+            "version"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "generated_codes_project_id_projects_id_fk": {
+          "name": "generated_codes_project_id_projects_id_fk",
+          "tableFrom": "generated_codes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "generation_locks": {
+      "name": "generation_locks",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "platform_events": {
+      "name": "platform_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "platform_events_user_id_users_id_fk": {
+          "name": "platform_events_user_id_users_id_fk",
+          "tableFrom": "platform_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "platform_events_project_id_projects_id_fk": {
+          "name": "platform_events_project_id_projects_id_fk",
+          "tableFrom": "platform_events",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_apis": {
+      "name": "project_apis",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_id": {
+          "name": "api_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_apis_project_id_api_id_unique": {
+          "name": "project_apis_project_id_api_id_unique",
+          "columns": [
+            "project_id",
+            "api_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_apis_project_id_projects_id_fk": {
+          "name": "project_apis_project_id_projects_id_fk",
+          "tableFrom": "project_apis",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "project_apis_api_id_api_catalog_id_fk": {
+          "name": "project_apis_api_id_api_catalog_id_fk",
+          "tableFrom": "project_apis",
+          "tableTo": "api_catalog",
+          "columnsFrom": [
+            "api_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "deploy_url": {
+          "name": "deploy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deploy_platform": {
+          "name": "deploy_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_url": {
+          "name": "preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suggested_slugs": {
+          "name": "suggested_slugs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_api_keys": {
+      "name": "user_api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_id": {
+          "name": "api_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_api_keys_user_id_api_id_unique": {
+          "name": "user_api_keys_user_id_api_id_unique",
+          "columns": [
+            "user_id",
+            "api_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_api_keys_user_id_users_id_fk": {
+          "name": "user_api_keys_user_id_users_id_fk",
+          "tableFrom": "user_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_api_keys_api_id_api_catalog_id_fk": {
+          "name": "user_api_keys_api_id_api_catalog_id_fk",
+          "tableFrom": "user_api_keys",
+          "tableTo": "api_catalog",
+          "columnsFrom": [
+            "api_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_daily_limits": {
+      "name": "user_daily_limits",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage_date": {
+          "name": "usage_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generation_count": {
+          "name": "generation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deploy_count": {
+          "name": "deploy_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_daily_limits_user_id_users_id_fk": {
+          "name": "user_daily_limits_user_id_users_id_fk",
+          "tableFrom": "user_daily_limits",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_daily_limits_user_id_usage_date_pk": {
+          "columns": [
+            "user_id",
+            "usage_date"
+          ],
+          "name": "user_daily_limits_user_id_usage_date_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/sqlite/meta/_journal.json
+++ b/drizzle/sqlite/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1782265438782,
       "tag": "0001_pink_the_order",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1785323598240,
+      "tag": "0002_icy_cassandra_nova",
+      "breakpoints": true
     }
   ]
 }

--- a/src/__tests__/api/admin-test-generation.test.ts
+++ b/src/__tests__/api/admin-test-generation.test.ts
@@ -52,6 +52,14 @@ vi.mock('@/repositories/factory', () => ({
   createProjectRepository: vi.fn(() => projectRepoMock),
 }));
 
+// 라우트가 락을 획득하고 파이프라인(모킹됨)이 해제한다 — 짝을 맞추지 않으면
+// heartbeat가 없는 락을 갱신하려다 매번 경고가 남는다.
+vi.mock('@/lib/ai/generationLock', () => ({
+  acquireGenerationLock: vi.fn().mockResolvedValue(true),
+  releaseGenerationLock: vi.fn().mockResolvedValue(undefined),
+  startLockHeartbeat: vi.fn().mockReturnValue(() => {}),
+}));
+
 vi.mock('@/lib/ai/promptBuilder', () => ({
   buildStage1SystemPrompt: vi.fn(() => 'sys1'),
   buildStage1UserPrompt: vi.fn(() => 'user1'),

--- a/src/__tests__/api/generate-regenerate.test.ts
+++ b/src/__tests__/api/generate-regenerate.test.ts
@@ -21,6 +21,13 @@ vi.mock('@/repositories/factory', () => ({
   createProjectRepository: vi.fn(),
 }));
 
+// 중복 파이프라인 차단은 DB 락(generation_locks)이 담당한다 — 라우트는 락 모듈만 알면 된다.
+vi.mock('@/lib/ai/generationLock', () => ({
+  acquireGenerationLock: vi.fn().mockResolvedValue(true),
+  releaseGenerationLock: vi.fn().mockResolvedValue(undefined),
+  startLockHeartbeat: vi.fn().mockReturnValue(() => {}),
+}));
+
 vi.mock('@/lib/events/eventPersister', () => ({
   registerEventPersister: vi.fn(),
 }));
@@ -275,7 +282,9 @@ describe('POST /api/v1/generate/regenerate', () => {
 
     const { generationTracker } = await import('@/lib/ai/generationTracker');
     const startSpy = vi.spyOn(generationTracker, 'start');
-    vi.spyOn(generationTracker, 'isGenerating').mockReturnValueOnce(true);
+
+    const { acquireGenerationLock } = await import('@/lib/ai/generationLock');
+    vi.mocked(acquireGenerationLock).mockResolvedValueOnce(false);
 
     const { POST } = await import('@/app/api/v1/generate/regenerate/route');
     const response = await POST(makeRequest({ projectId: PROJECT_ID, feedback: FEEDBACK }));

--- a/src/__tests__/api/generate.test.ts
+++ b/src/__tests__/api/generate.test.ts
@@ -20,6 +20,14 @@ vi.mock('@/repositories/factory', () => ({
   createProjectRepository: vi.fn(),
 }));
 
+// 중복 파이프라인 차단은 DB 락(generation_locks)이 담당한다. 라우트는 락 모듈만 알면 되므로
+// 여기서 seam을 끊는다 — 락 자체의 원자성·stale 동작은 레포·모듈 단위 테스트가 고정한다.
+vi.mock('@/lib/ai/generationLock', () => ({
+  acquireGenerationLock: vi.fn().mockResolvedValue(true),
+  releaseGenerationLock: vi.fn().mockResolvedValue(undefined),
+  startLockHeartbeat: vi.fn().mockReturnValue(() => {}),
+}));
+
 vi.mock('@/lib/events/eventPersister', () => ({
   registerEventPersister: vi.fn(),
 }));
@@ -351,14 +359,44 @@ describe('POST /api/v1/generate', () => {
       decrementDailyLimit: decrementMock,
     } as never);
 
-    const { generationTracker } = await import('@/lib/ai/generationTracker');
-    vi.spyOn(generationTracker, 'isGenerating').mockReturnValueOnce(true);
+    const { acquireGenerationLock } = await import('@/lib/ai/generationLock');
+    vi.mocked(acquireGenerationLock).mockResolvedValueOnce(false);
 
     const { POST } = await import('@/app/api/v1/generate/route');
     const response = await POST(makeRequest({ projectId: '11111111-1111-4111-a111-111111111111' }));
 
     expect(response.status).toBe(409);
     expect(decrementMock).toHaveBeenCalledWith('user-1');
+  });
+
+  it('락 획득 실패는 파이프라인 진입 전에 반환한다 — tracker.start도 호출되지 않는다', async () => {
+    await setupHappyPath();
+
+    const { acquireGenerationLock } = await import('@/lib/ai/generationLock');
+    vi.mocked(acquireGenerationLock).mockResolvedValueOnce(false);
+
+    const { generationTracker } = await import('@/lib/ai/generationTracker');
+    const startSpy = vi.spyOn(generationTracker, 'start');
+
+    const { POST } = await import('@/app/api/v1/generate/route');
+    const response = await POST(makeRequest({ projectId: '11111111-1111-4111-a111-111111111111' }));
+
+    expect(response.status).toBe(409);
+    expect(startSpy).not.toHaveBeenCalled();
+  });
+
+  it('정상 경로에서는 호출자 본인을 소유자로 락을 획득한다', async () => {
+    await setupHappyPath();
+
+    const { acquireGenerationLock } = await import('@/lib/ai/generationLock');
+
+    const { POST } = await import('@/app/api/v1/generate/route');
+    await POST(makeRequest({ projectId: '11111111-1111-4111-a111-111111111111' }));
+
+    expect(acquireGenerationLock).toHaveBeenCalledWith(
+      '11111111-1111-4111-a111-111111111111',
+      'user-1',
+    );
   });
 
   it('AI 생성 실패 시 SSE error 이벤트를 전송하고 레이트리밋을 보상한다', async () => {

--- a/src/app/api/v1/admin/test-generation/route.ts
+++ b/src/app/api/v1/admin/test-generation/route.ts
@@ -15,6 +15,7 @@ import {
   buildStage2FunctionUserPrompt,
 } from '@/lib/ai/promptBuilder';
 import { runGenerationPipeline } from '@/lib/ai/generationPipeline';
+import { acquireGenerationLock } from '@/lib/ai/generationLock';
 import type { SseWriter } from '@/lib/ai/sseWriter';
 import type { Project, ProjectMetadata } from '@/types/project';
 import type { ApiCatalogItem } from '@/types/api';
@@ -72,6 +73,11 @@ export async function POST(request: Request): Promise<Response> {
       } as Omit<Project, 'id' | 'createdAt' | 'updatedAt'>);
       createdProjectId = project.id;
       await projectRepo.insertProjectApis(project.id, apiIds);
+
+      // 파이프라인이 finally에서 락을 해제하므로 여기서 획득해 짝을 맞춘다. 획득하지 않으면
+      // heartbeat가 없는 락을 갱신하려다 매번 "lock disappeared" 경고를 남긴다.
+      // 프로젝트를 방금 만들었으므로 획득은 항상 성공한다.
+      await acquireGenerationLock(project.id, userId);
 
       const events: Array<{ event: string; data: unknown }> = [];
       const writer: SseWriter = {

--- a/src/app/api/v1/generate/regenerate/route.ts
+++ b/src/app/api/v1/generate/regenerate/route.ts
@@ -28,6 +28,7 @@ import { regenerateSchema } from '@/types/schemas';
 import { createSseWriter } from '@/lib/ai/sseWriter';
 import { runGenerationPipeline } from '@/lib/ai/generationPipeline';
 import { generationTracker } from '@/lib/ai/generationTracker';
+import { acquireGenerationLock } from '@/lib/ai/generationLock';
 
 export async function POST(request: Request): Promise<Response> {
   let pendingDecrement: (() => Promise<void>) | undefined;
@@ -85,7 +86,8 @@ export async function POST(request: Request): Promise<Response> {
       throw new NotFoundError('재생성할 기존 코드가 없습니다. 먼저 코드를 생성해주세요.');
     }
 
-    if (generationTracker.isGenerating(projectId)) {
+    // 중복 파이프라인 차단은 DB 락이 담당한다 — generate 라우트와 동일 규약.
+    if (!(await acquireGenerationLock(projectId, user.id))) {
       await pendingDecrement?.().catch(() => {});
       pendingDecrement = undefined;
       return Response.json(
@@ -93,8 +95,7 @@ export async function POST(request: Request): Promise<Response> {
         { status: 409 },
       );
     }
-    // isGenerating 체크와 파이프라인 시작 사이의 TOCTOU 레이스를 닫기 위해
-    // ReadableStream 생성 전에 즉시 tracker 상태를 설정한다.
+    // tracker는 진행률 표시 전용 — 락 책임은 위에서 끝났다.
     generationTracker.start(projectId, user.id);
 
     const stage1SystemPrompt = buildStage1SystemPrompt();

--- a/src/app/api/v1/generate/route.ts
+++ b/src/app/api/v1/generate/route.ts
@@ -23,6 +23,7 @@ import { templateRegistry } from '@/templates/TemplateRegistry';
 import { createSseWriter } from '@/lib/ai/sseWriter';
 import { runGenerationPipeline } from '@/lib/ai/generationPipeline';
 import { generationTracker } from '@/lib/ai/generationTracker';
+import { acquireGenerationLock } from '@/lib/ai/generationLock';
 
 export async function POST(request: Request): Promise<Response> {
   let pendingDecrement: (() => Promise<void>) | undefined;
@@ -79,7 +80,10 @@ export async function POST(request: Request): Promise<Response> {
       }
     }
 
-    if (generationTracker.isGenerating(projectId)) {
+    // 중복 파이프라인 차단은 DB 락이 담당한다(단일 문 test-and-set이라 체크·획득 사이에
+    // 끼어들 틈이 없다). 인메모리 tracker가 락을 겸하던 구조에서는 TTL·size cap으로 엔트리가
+    // 사라지면 락도 사라져 두 번째 파이프라인이 시작될 수 있었다 — Opus/ET 이중 청구.
+    if (!(await acquireGenerationLock(projectId, user.id))) {
       await pendingDecrement?.().catch(() => {});
       pendingDecrement = undefined;
       return Response.json(
@@ -87,8 +91,7 @@ export async function POST(request: Request): Promise<Response> {
         { status: 409 },
       );
     }
-    // isGenerating 체크와 파이프라인 시작 사이의 TOCTOU 레이스를 닫기 위해
-    // ReadableStream 생성 전에 즉시 tracker 상태를 설정한다.
+    // tracker는 진행률 표시 전용 — 락 책임은 위에서 끝났다.
     generationTracker.start(projectId, user.id);
 
     const designPreferences = (project.metadata as Record<string, unknown>)?.designPreferences as DesignPreferences | undefined;

--- a/src/lib/ai/generationLock.test.ts
+++ b/src/lib/ai/generationLock.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type Database from 'better-sqlite3';
+import {
+  createSqliteConnection,
+  runSqliteMigrations,
+  type SqliteDb,
+} from '@/lib/db/sqlite/connection';
+import { SqliteGenerationLockRepository } from '@/repositories/sqlite/SqliteGenerationLockRepository';
+
+const PROJECT_ID = '22222222-2222-2222-2222-222222222222';
+const USER_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_USER = '44444444-4444-4444-4444-444444444444';
+
+// 실제 SQLite 레포를 주입한다 — 락 상태를 mock 호출 횟수가 아니라 DB 사실로 검증하기 위함.
+let db: SqliteDb;
+let raw: Database.Database;
+let repo: SqliteGenerationLockRepository;
+
+vi.mock('@/repositories/factory', () => ({
+  createGenerationLockRepository: () => repo,
+}));
+
+describe('generationLock', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-29T00:00:00.000Z'));
+    const conn = createSqliteConnection(':memory:');
+    db = conn.db;
+    raw = conn.raw;
+    runSqliteMigrations(db);
+    repo = new SqliteGenerationLockRepository(db);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    raw.close();
+  });
+
+  describe('acquireGenerationLock', () => {
+    it('락이 없으면 획득하고 DB에 기록한다', async () => {
+      const { acquireGenerationLock } = await import('./generationLock');
+
+      expect(await acquireGenerationLock(PROJECT_ID, USER_ID)).toBe(true);
+      expect(await repo.find(PROJECT_ID)).toMatchObject({ userId: USER_ID });
+    });
+
+    it('이미 생성 중이면 두 번째 호출은 실패한다', async () => {
+      const { acquireGenerationLock } = await import('./generationLock');
+
+      expect(await acquireGenerationLock(PROJECT_ID, USER_ID)).toBe(true);
+      expect(await acquireGenerationLock(PROJECT_ID, OTHER_USER)).toBe(false);
+    });
+
+    it('설정된 stale 시간이 지나면 탈취할 수 있다', async () => {
+      const { acquireGenerationLock } = await import('./generationLock');
+      const { GENERATION_LOCK_STALE_MS } = await import('@/lib/config/generation');
+
+      await acquireGenerationLock(PROJECT_ID, USER_ID);
+      vi.advanceTimersByTime(GENERATION_LOCK_STALE_MS + 1);
+
+      expect(await acquireGenerationLock(PROJECT_ID, OTHER_USER)).toBe(true);
+    });
+  });
+
+  describe('releaseGenerationLock', () => {
+    it('해제하면 DB에서 사라져 즉시 재획득할 수 있다', async () => {
+      const { acquireGenerationLock, releaseGenerationLock } = await import('./generationLock');
+
+      await acquireGenerationLock(PROJECT_ID, USER_ID);
+      await releaseGenerationLock(PROJECT_ID);
+
+      expect(await repo.find(PROJECT_ID)).toBeNull();
+      expect(await acquireGenerationLock(PROJECT_ID, OTHER_USER)).toBe(true);
+    });
+
+    it('레포가 던져도 예외를 밖으로 내보내지 않는다 — finally 경로에서 원래 오류를 덮으면 안 된다', async () => {
+      const { releaseGenerationLock } = await import('./generationLock');
+      vi.spyOn(repo, 'release').mockRejectedValue(new Error('db down'));
+
+      await expect(releaseGenerationLock(PROJECT_ID)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('startLockHeartbeat', () => {
+    it('heartbeat 간격마다 갱신해 stale 경계를 넘겨도 락이 유지된다', async () => {
+      const { acquireGenerationLock, startLockHeartbeat } = await import('./generationLock');
+      const { GENERATION_LOCK_STALE_MS, GENERATION_LOCK_HEARTBEAT_MS } = await import(
+        '@/lib/config/generation'
+      );
+
+      await acquireGenerationLock(PROJECT_ID, USER_ID);
+      const stop = startLockHeartbeat(PROJECT_ID);
+
+      // stale 경계를 훌쩍 넘도록 진행하되, 그 사이 heartbeat가 계속 돈다.
+      const ticks = Math.ceil((GENERATION_LOCK_STALE_MS * 2) / GENERATION_LOCK_HEARTBEAT_MS);
+      for (let i = 0; i < ticks; i++) {
+        await vi.advanceTimersByTimeAsync(GENERATION_LOCK_HEARTBEAT_MS);
+      }
+
+      expect(await repo.isHeld(PROJECT_ID, GENERATION_LOCK_STALE_MS)).toBe(true);
+      stop();
+    });
+
+    it('stop() 이후에는 더 이상 갱신하지 않아 락이 stale해진다', async () => {
+      const { acquireGenerationLock, startLockHeartbeat } = await import('./generationLock');
+      const { GENERATION_LOCK_STALE_MS, GENERATION_LOCK_HEARTBEAT_MS } = await import(
+        '@/lib/config/generation'
+      );
+
+      await acquireGenerationLock(PROJECT_ID, USER_ID);
+      const stop = startLockHeartbeat(PROJECT_ID);
+      await vi.advanceTimersByTimeAsync(GENERATION_LOCK_HEARTBEAT_MS);
+      stop();
+
+      await vi.advanceTimersByTimeAsync(GENERATION_LOCK_STALE_MS + 1);
+
+      expect(await repo.isHeld(PROJECT_ID, GENERATION_LOCK_STALE_MS)).toBe(false);
+    });
+
+    it('락이 이미 사라졌으면 스스로 멈춘다 — 없는 락을 되살리지 않는다', async () => {
+      const { acquireGenerationLock, releaseGenerationLock, startLockHeartbeat } = await import(
+        './generationLock'
+      );
+      const { GENERATION_LOCK_HEARTBEAT_MS } = await import('@/lib/config/generation');
+
+      await acquireGenerationLock(PROJECT_ID, USER_ID);
+      const stop = startLockHeartbeat(PROJECT_ID);
+      await releaseGenerationLock(PROJECT_ID);
+
+      await vi.advanceTimersByTimeAsync(GENERATION_LOCK_HEARTBEAT_MS * 3);
+
+      // heartbeat가 락을 재생성하지 않아야 한다.
+      expect(await repo.find(PROJECT_ID)).toBeNull();
+      stop();
+    });
+
+    it('heartbeat 중 레포가 던져도 unhandled rejection을 만들지 않는다', async () => {
+      const { acquireGenerationLock, startLockHeartbeat } = await import('./generationLock');
+      const { GENERATION_LOCK_HEARTBEAT_MS } = await import('@/lib/config/generation');
+
+      await acquireGenerationLock(PROJECT_ID, USER_ID);
+      vi.spyOn(repo, 'heartbeat').mockRejectedValue(new Error('db down'));
+
+      const stop = startLockHeartbeat(PROJECT_ID);
+      await expect(
+        vi.advanceTimersByTimeAsync(GENERATION_LOCK_HEARTBEAT_MS * 2),
+      ).resolves.not.toThrow();
+      stop();
+    });
+
+    it('stop()을 두 번 불러도 안전하다', async () => {
+      const { acquireGenerationLock, startLockHeartbeat } = await import('./generationLock');
+
+      await acquireGenerationLock(PROJECT_ID, USER_ID);
+      const stop = startLockHeartbeat(PROJECT_ID);
+
+      stop();
+      expect(() => stop()).not.toThrow();
+    });
+  });
+});

--- a/src/lib/ai/generationLock.ts
+++ b/src/lib/ai/generationLock.ts
@@ -1,0 +1,79 @@
+import { createGenerationLockRepository } from '@/repositories/factory';
+import {
+  GENERATION_LOCK_HEARTBEAT_MS,
+  GENERATION_LOCK_STALE_MS,
+} from '@/lib/config/generation';
+import { logger } from '@/lib/utils/logger';
+
+/**
+ * 프로젝트별 생성 락 — 같은 projectId로 파이프라인이 두 번 도는 것을 막는다.
+ *
+ * `generationTracker`가 락을 겸하던 구조에서는 TTL(생성 중 30분)이나 size cap으로 엔트리가
+ * 사라지면 락도 함께 사라져 두 번째 파이프라인이 시작될 수 있었다 — Opus/ET 호출이 중복되어
+ * 토큰이 이중 청구되고, 두 파이프라인이 같은 `getNextVersion()`을 받아 한쪽이 UNIQUE 위반으로
+ * 실패한다. 락 책임만 DB로 분리하고 tracker는 진행률 표시 전용으로 남긴다.
+ */
+
+/** 획득 실패는 "이미 생성 중"을 뜻한다. 조회 실패는 던져서 fail-closed 한다. */
+export async function acquireGenerationLock(projectId: string, userId: string): Promise<boolean> {
+  return createGenerationLockRepository().acquire(projectId, userId, GENERATION_LOCK_STALE_MS);
+}
+
+/**
+ * 락 해제. **던지지 않는다** — finally 경로에서 호출되므로 여기서 예외가 나면
+ * 파이프라인의 원래 오류를 덮어버린다. 해제에 실패해도 stale 만료가 백스톱이다.
+ */
+export async function releaseGenerationLock(projectId: string): Promise<void> {
+  try {
+    await createGenerationLockRepository().release(projectId);
+  } catch (error) {
+    logger.warn('Failed to release generation lock', {
+      projectId,
+      error: error instanceof Error ? error.message : 'Unknown',
+    });
+  }
+}
+
+/**
+ * 주기적 생존 신호를 시작하고 중지 함수를 반환한다.
+ *
+ * 파이프라인은 Stage 사이에 수십 초씩 AI 응답을 기다리므로 진행률 갱신 지점에 heartbeat를
+ * 얹으면 간격이 들쭉날쭉해진다. 독립 타이머로 일정 주기를 보장한다.
+ */
+export function startLockHeartbeat(projectId: string): () => void {
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const stop = (): void => {
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+
+  const tick = async (): Promise<void> => {
+    try {
+      const alive = await createGenerationLockRepository().heartbeat(projectId);
+      if (!alive) {
+        // 락이 이미 없다 — 다른 요청이 탈취했거나 해제된 상태다. 되살리면 안 된다.
+        logger.warn('Generation lock disappeared while the pipeline was still running', {
+          projectId,
+        });
+        stop();
+      }
+    } catch (error) {
+      // 타이머 콜백의 거부는 아무도 관측하지 않아 unhandledRejection이 된다. 여기서 닫는다.
+      logger.warn('Generation lock heartbeat failed', {
+        projectId,
+        error: error instanceof Error ? error.message : 'Unknown',
+      });
+    }
+  };
+
+  timer = setInterval(() => {
+    void tick();
+  }, GENERATION_LOCK_HEARTBEAT_MS);
+  // 프로세스 종료를 막지 않는다 (backup/retention 스케줄러와 동일 원칙).
+  (timer as { unref?: () => void }).unref?.();
+
+  return stop;
+}

--- a/src/lib/ai/generationPipeline.integration.test.ts
+++ b/src/lib/ai/generationPipeline.integration.test.ts
@@ -51,6 +51,10 @@ vi.mock('@/lib/ai/generationTracker', () => ({
     complete: vi.fn(),
   },
 }));
+vi.mock('@/lib/ai/generationLock', () => ({
+  releaseGenerationLock: vi.fn().mockResolvedValue(undefined),
+  startLockHeartbeat: vi.fn(),
+}));
 vi.mock('@/lib/utils/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
@@ -70,6 +74,7 @@ import { validateAll, evaluateQuality } from '@/lib/ai/codeValidator';
 import { runFastQc, isQcEnabled } from '@/lib/qc';
 import { eventBus } from '@/lib/events/eventBus';
 import { generationTracker } from '@/lib/ai/generationTracker';
+import { releaseGenerationLock, startLockHeartbeat } from '@/lib/ai/generationLock';
 import { assembleHtml } from '@/lib/ai/codeParser';
 import type { ApiCatalogItem } from '@/types/api';
 
@@ -154,6 +159,9 @@ describe('runGenerationPipeline()', () => {
     (assembleHtml as Mock).mockReturnValue('<html><body>assembled</body></html>');
     (validateAll as Mock).mockReturnValue({ errors: [], warnings: [] });
     (evaluateQuality as Mock).mockReturnValue(makeQualityMetrics());
+    // startLockHeartbeat는 항상 중지 함수를 돌려준다 — finally에서 호출되므로 기본값 필수.
+    (startLockHeartbeat as Mock).mockReturnValue(() => {});
+    (releaseGenerationLock as Mock).mockResolvedValue(undefined);
 
     const stageResult = makeStageResult();
     (runStage1 as Mock).mockResolvedValue(stageResult);
@@ -435,6 +443,59 @@ describe('runGenerationPipeline()', () => {
 
       const errorEvents = sse.events.filter(e => e.event === 'error');
       expect(errorEvents.length).toBe(1);
+    });
+  });
+
+  describe('생성 락 수명주기', () => {
+    it('성공적으로 끝나면 락을 해제한다 — 다음 요청이 막히지 않아야 한다', async () => {
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      expect(releaseGenerationLock).toHaveBeenCalledWith('proj-1');
+    });
+
+    it('실패해도 락을 해제한다 — 실패한 생성이 프로젝트를 잠그면 안 된다', async () => {
+      (runStage1 as Mock).mockRejectedValue(new Error('AI 서비스 응답 없음'));
+
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      expect(releaseGenerationLock).toHaveBeenCalledWith('proj-1');
+    });
+
+    it('실행 중 heartbeat를 시작하고 끝나면 반드시 멈춘다 — 타이머가 남으면 해제된 락을 되살린다', async () => {
+      const stop = vi.fn();
+      (startLockHeartbeat as Mock).mockReturnValue(stop);
+
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      expect(startLockHeartbeat).toHaveBeenCalledWith('proj-1');
+      expect(stop).toHaveBeenCalled();
+    });
+
+    it('실패 경로에서도 heartbeat 타이머를 멈춘다', async () => {
+      const stop = vi.fn();
+      (startLockHeartbeat as Mock).mockReturnValue(stop);
+      (runStage1 as Mock).mockRejectedValue(new Error('AI 서비스 응답 없음'));
+
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      expect(stop).toHaveBeenCalled();
+    });
+
+    it('heartbeat를 멈춘 뒤에 락을 해제한다 — 순서가 뒤집히면 이미 지운 락을 되살릴 수 있다', async () => {
+      const order: string[] = [];
+      (startLockHeartbeat as Mock).mockReturnValue(() => order.push('stop'));
+      (releaseGenerationLock as Mock).mockImplementation(async () => {
+        order.push('release');
+      });
+
+      const sse = makeSse();
+      await runGenerationPipeline(makeInput(), sse as never, makeServices());
+
+      expect(order).toEqual(['stop', 'release']);
     });
   });
 

--- a/src/lib/ai/generationPipeline.ts
+++ b/src/lib/ai/generationPipeline.ts
@@ -7,6 +7,7 @@ import { runFastQc, isQcEnabled } from '@/lib/qc';
 import { eventBus } from '@/lib/events/eventBus';
 import { logger } from '@/lib/utils/logger';
 import { generationTracker } from '@/lib/ai/generationTracker';
+import { releaseGenerationLock, startLockHeartbeat } from '@/lib/ai/generationLock';
 import { runStage1, runStage2Function, runStage3 } from '@/lib/ai/stageRunner';
 import { saveGeneratedCode } from '@/lib/ai/generationSaver';
 import { extractFeatures } from '@/lib/ai/featureExtractor';
@@ -356,8 +357,10 @@ export async function runGenerationPipeline(
   );
   const pipelineSignal = pipelineAbortController.signal;
 
-  // route.ts에서 이미 start()를 호출했으므로 여기서는 중복 호출하지 않는다.
-  // (route.ts에서 isGenerating 체크 직후 start()를 호출하여 TOCTOU 레이스 제거)
+  // route.ts에서 이미 락 획득과 tracker.start()를 마쳤다. 여기서는 락이 살아 있음을 알리고
+  // (heartbeat), 끝날 때 반드시 해제하는 것만 담당한다 — 해제하지 않으면 stale 만료
+  // (기본 5분)까지 같은 프로젝트의 재생성이 409로 막힌다.
+  const stopHeartbeat = startLockHeartbeat(projectId);
 
   try {
     sse.send('progress', { step: 'analyzing', progress: 5, message: '분석 중...' });
@@ -474,5 +477,9 @@ export async function runGenerationPipeline(
     );
   } finally {
     clearTimeout(pipelineAbortTimer);
+    // 순서가 중요하다 — 타이머를 먼저 멈춘다. 해제 뒤에 heartbeat가 한 번 더 돌면
+    // 방금 지운 락을 되살릴 수는 없지만(UPDATE라 0행), 무의미한 경고 로그가 남는다.
+    stopHeartbeat();
+    await releaseGenerationLock(projectId);
   }
 }

--- a/src/lib/ai/generationTracker.test.ts
+++ b/src/lib/ai/generationTracker.test.ts
@@ -67,14 +67,11 @@ describe('GenerationTracker', () => {
     stopCleanup();
   });
 
-  it('isGenerating()은 generating 상태에서 true, completed 이후 false를 반환한다', async () => {
+  it('중복 생성 게이트를 노출하지 않는다 — 락은 DB(generation_locks)가 담당한다', async () => {
     const { generationTracker, stopCleanup } = await import('./generationTracker');
-    generationTracker.start('p5', 'user-1');
-    expect(generationTracker.isGenerating('p5')).toBe(true);
-
-    generationTracker.complete('p5', { projectId: 'p5', version: 1, previewUrl: '' });
-    expect(generationTracker.isGenerating('p5')).toBe(false);
-
+    // 인메모리 엔트리는 TTL·size cap으로 사라질 수 있어 락의 근거가 될 수 없다.
+    // 게이트가 여기로 되돌아오면 중복 파이프라인(토큰 이중 청구)이 재발한다.
+    expect((generationTracker as unknown as Record<string, unknown>).isGenerating).toBeUndefined();
     stopCleanup();
   });
 

--- a/src/lib/ai/generationTracker.ts
+++ b/src/lib/ai/generationTracker.ts
@@ -95,10 +95,11 @@ class GenerationTracker {
     return this.entries.get(projectId);
   }
 
-  isGenerating(projectId: string): boolean {
-    const entry = this.entries.get(projectId);
-    return entry !== undefined && entry.status === 'generating';
-  }
+  // `isGenerating`은 제거됐다. 이 tracker는 인메모리 LRU+TTL이라 엔트리가 사라지면
+  // "생성 중 아님"으로 보고했고, 그 틈으로 두 번째 파이프라인이 시작될 수 있었다
+  // (Opus/ET 이중 청구 + 같은 version으로 UNIQUE 위반). 중복 차단은 DB 락
+  // (`generation_locks`, `@/lib/ai/generationLock`)이 담당하고 여기는 진행률만 남긴다.
+  // 게이트를 다시 여기에 두지 말 것.
 
   stopCleanup(): void {
     if (this.cleanupTimer !== null) {

--- a/src/lib/config/generation.test.ts
+++ b/src/lib/config/generation.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe('generation lock 설정', () => {
+  it('env var 미설정 시 기본값을 반환한다', async () => {
+    const mod = await import('./generation');
+    expect(mod.GENERATION_LOCK_HEARTBEAT_MS).toBe(30_000);
+    expect(mod.GENERATION_LOCK_STALE_MS).toBe(300_000);
+  });
+
+  it('유효한 양의 정수이면 파싱된 값을 반환한다', async () => {
+    vi.stubEnv('GENERATION_LOCK_HEARTBEAT_MS', '10000');
+    vi.stubEnv('GENERATION_LOCK_STALE_MS', '60000');
+    vi.resetModules();
+    const mod = await import('./generation');
+    expect(mod.GENERATION_LOCK_HEARTBEAT_MS).toBe(10_000);
+    expect(mod.GENERATION_LOCK_STALE_MS).toBe(60_000);
+  });
+
+  it('숫자가 아니거나 0·음수이면 기본값을 반환한다 — 0은 락을 즉시 만료시켜 중복 파이프라인을 다시 연다', async () => {
+    vi.stubEnv('GENERATION_LOCK_STALE_MS', '0');
+    vi.stubEnv('GENERATION_LOCK_HEARTBEAT_MS', 'abc');
+    vi.resetModules();
+    const mod = await import('./generation');
+    expect(mod.GENERATION_LOCK_STALE_MS).toBe(300_000);
+    expect(mod.GENERATION_LOCK_HEARTBEAT_MS).toBe(30_000);
+  });
+
+  it('stale은 heartbeat보다 반드시 커야 한다 — 아니면 살아 있는 파이프라인이 스스로 만료된다', async () => {
+    vi.stubEnv('GENERATION_LOCK_HEARTBEAT_MS', '90000');
+    vi.stubEnv('GENERATION_LOCK_STALE_MS', '60000');
+    vi.resetModules();
+    const mod = await import('./generation');
+    expect(mod.GENERATION_LOCK_STALE_MS).toBeGreaterThan(mod.GENERATION_LOCK_HEARTBEAT_MS);
+  });
+});

--- a/src/lib/config/generation.ts
+++ b/src/lib/config/generation.ts
@@ -1,0 +1,38 @@
+/**
+ * 코드 생성 락 설정.
+ *
+ * 락은 DB(`generation_locks`)에 있고 살아 있음은 주기적 heartbeat로 증명한다.
+ * 프로세스가 죽으면 heartbeat가 멈추고 `GENERATION_LOCK_STALE_MS` 후 다른 요청이
+ * 락을 탈취한다 — 크래시된 파이프라인이 프로젝트를 영구히 잠그지 않게 하는 장치다.
+ */
+import { logger } from '@/lib/utils/logger';
+
+function envInt(key: string, defaultValue: number): number {
+  const raw = process.env[key];
+  if (!raw) return defaultValue;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+}
+
+/** 생존 신호 주기(ms). 기본 30초. */
+export const GENERATION_LOCK_HEARTBEAT_MS = envInt('GENERATION_LOCK_HEARTBEAT_MS', 30_000);
+
+const rawStaleMs = envInt('GENERATION_LOCK_STALE_MS', 300_000);
+
+/**
+ * 이 시간 동안 heartbeat가 없으면 죽은 락으로 보고 탈취를 허용한다(ms). 기본 5분.
+ *
+ * heartbeat 주기보다 짧거나 같으면 **살아 있는 파이프라인이 다음 신호 전에 스스로
+ * 만료되어** 중복 파이프라인이 다시 열린다. 잘못된 조합은 교정하고 경고를 남긴다 —
+ * 조용히 폴백하면 운영자가 값을 바꿨는데 적용되지 않은 이유를 알 수 없다.
+ */
+export const GENERATION_LOCK_STALE_MS =
+  rawStaleMs > GENERATION_LOCK_HEARTBEAT_MS ? rawStaleMs : GENERATION_LOCK_HEARTBEAT_MS * 2;
+
+if (GENERATION_LOCK_STALE_MS !== rawStaleMs) {
+  logger.warn('GENERATION_LOCK_STALE_MS must exceed the heartbeat interval — using a corrected value', {
+    requestedStaleMs: rawStaleMs,
+    heartbeatMs: GENERATION_LOCK_HEARTBEAT_MS,
+    effectiveStaleMs: GENERATION_LOCK_STALE_MS,
+  });
+}

--- a/src/lib/db/sqlite/schema.ts
+++ b/src/lib/db/sqlite/schema.ts
@@ -203,3 +203,26 @@ export const authTokens = sqliteTable(
   },
   (t) => [index('auth_tokens_token_hash_idx').on(t.token_hash)],
 );
+
+// ── 11. generation_locks (프로젝트별 생성 락 — durable) ───────────────────────
+//
+// `generationTracker`(인메모리 LRU+TTL)가 락을 겸하던 구조에서는 엔트리가 TTL이나
+// size cap으로 사라지면 락도 함께 사라져 같은 projectId로 두 번째 파이프라인이 시작될 수
+// 있었다(Opus/ET 이중 청구 + `getNextVersion()` 충돌). 락 책임만 DB로 분리한다.
+//
+// **FK를 두지 않는다.** 수명이 짧은 운영 상태이고, `project_id` FK가 있으면 스테일 락이
+// 남은 프로젝트의 삭제가 FK 위반으로 실패한다(admin/test-generation의 cleanup 경로가 실제로
+// 그렇다). 무결성은 stale 만료(heartbeat_at)와 release가 담당한다.
+//
+// 시각은 다른 테이블과 동일하게 ISO8601 UTC 문자열로 저장한다 — 고정 폭이라
+// `heartbeat_at < ?` 사전식 비교가 시간 비교와 일치한다.
+//
+// `retention.ts` 정리 대상에 넣지 않았다: 행은 projectId로 유일하고 정상 경로에서 해제되므로
+// 상한이 **프로젝트 수**다. 트래픽에 선형 비례하는 `platform_events`와 성격이 다르다.
+// (생성 도중 프로젝트가 삭제되면 행 1개가 고아로 남지만 다음 동명 projectId가 덮어쓴다.)
+export const generationLocks = sqliteTable('generation_locks', {
+  project_id: text('project_id').primaryKey(),
+  user_id: text('user_id').notNull(),
+  acquired_at: text('acquired_at').notNull(),
+  heartbeat_at: text('heartbeat_at').notNull(),
+});

--- a/src/repositories/factory.ts
+++ b/src/repositories/factory.ts
@@ -8,6 +8,7 @@ import type {
   IRateLimitRepository,
   IUserApiKeyRepository,
   IAuthTokenRepository,
+  IGenerationLockRepository,
 } from '@/repositories/interfaces';
 
 // SQLite implementations — 임베디드 단일 인스턴스(유일한 DB 백엔드)
@@ -20,6 +21,7 @@ import {
   SqliteRateLimitRepository,
   SqliteUserApiKeyRepository,
   SqliteAuthTokenRepository,
+  SqliteGenerationLockRepository,
 } from '@/repositories/sqlite';
 
 export function createProjectRepository(): IProjectRepository {
@@ -52,4 +54,8 @@ export function createUserApiKeyRepository(): IUserApiKeyRepository {
 
 export function createAuthTokenRepository(): IAuthTokenRepository {
   return new SqliteAuthTokenRepository(getSqliteDb());
+}
+
+export function createGenerationLockRepository(): IGenerationLockRepository {
+  return new SqliteGenerationLockRepository(getSqliteDb());
 }

--- a/src/repositories/interfaces/IGenerationLockRepository.ts
+++ b/src/repositories/interfaces/IGenerationLockRepository.ts
@@ -1,0 +1,38 @@
+export interface GenerationLock {
+  projectId: string;
+  userId: string;
+  /** ISO8601 UTC — 최초 획득 시각. heartbeat로 갱신되지 않는다(총 점유 시간 관측용). */
+  acquiredAt: string;
+  /** ISO8601 UTC — 마지막 생존 신호. stale 판정 기준. */
+  heartbeatAt: string;
+}
+
+/**
+ * 프로젝트별 생성 락. 같은 projectId로 파이프라인이 동시에 두 번 도는 것을 막는다.
+ *
+ * 인메모리 tracker가 락을 겸하던 구조에서는 TTL·size cap으로 엔트리가 사라지면 락도 함께
+ * 사라졌다. 저장소를 DB로 옮겨 프로세스 재시작·엔트리 소멸을 넘어 유지되게 한다.
+ *
+ * `staleMs`를 정책으로 내장하지 않고 인자로 받는다 — `IRateLimitRepository`가 `limit`을
+ * 인자로 받는 것과 같은 이유로, 정책은 호출부(config)에 두고 레포는 저장만 담당한다.
+ */
+export interface IGenerationLockRepository {
+  /**
+   * 원자적으로 락을 획득한다. 유효한 락이 이미 있으면 false.
+   * 마지막 heartbeat가 `staleMs`를 넘긴 락은 탈취할 수 있다 — 크래시된 파이프라인이
+   * 프로젝트를 영구히 잠그지 않게 하는 안전장치다.
+   */
+  acquire(projectId: string, userId: string, staleMs: number): Promise<boolean>;
+
+  /** 생존 신호. 락이 없으면 false(유실을 성공으로 위장하지 않는다). */
+  heartbeat(projectId: string): Promise<boolean>;
+
+  /** 해제. 없는 락에도 안전하다(finally 경로에서 호출되므로 멱등해야 한다). */
+  release(projectId: string): Promise<void>;
+
+  /** 유효한(stale이 아닌) 락 보유 여부. */
+  isHeld(projectId: string, staleMs: number): Promise<boolean>;
+
+  /** 진단용 조회 — stale 락도 그대로 반환한다. */
+  find(projectId: string): Promise<GenerationLock | null>;
+}

--- a/src/repositories/interfaces/index.ts
+++ b/src/repositories/interfaces/index.ts
@@ -7,3 +7,4 @@ export type { IEventRepository, PersistEventContext, EventRecord } from './IEven
 export type { IRateLimitRepository } from './IRateLimitRepository';
 export type { IUserApiKeyRepository, UserApiKey } from './IUserApiKeyRepository';
 export type { IAuthTokenRepository, AuthTokenType } from './IAuthTokenRepository';
+export type { IGenerationLockRepository, GenerationLock } from './IGenerationLockRepository';

--- a/src/repositories/sqlite/SqliteGenerationLockRepository.test.ts
+++ b/src/repositories/sqlite/SqliteGenerationLockRepository.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type Database from 'better-sqlite3';
+import {
+  createSqliteConnection,
+  runSqliteMigrations,
+  type SqliteDb,
+} from '@/lib/db/sqlite/connection';
+import { SqliteGenerationLockRepository } from './SqliteGenerationLockRepository';
+
+const PROJECT_A = '22222222-2222-2222-2222-222222222222';
+const PROJECT_B = '33333333-3333-3333-3333-333333333333';
+const USER_1 = '11111111-1111-1111-1111-111111111111';
+const USER_2 = '44444444-4444-4444-4444-444444444444';
+
+const STALE_MS = 5 * 60 * 1000;
+
+describe('SqliteGenerationLockRepository', () => {
+  let db: SqliteDb;
+  let raw: Database.Database;
+  let clock: number;
+  let repo: SqliteGenerationLockRepository;
+
+  beforeEach(() => {
+    const conn = createSqliteConnection(':memory:');
+    db = conn.db;
+    raw = conn.raw;
+    runSqliteMigrations(db);
+    clock = Date.parse('2026-07-29T00:00:00.000Z');
+    // 주입 시계 — stale 판정은 시간 경과가 본질이므로 실시간에 의존하면 검증할 수 없다.
+    repo = new SqliteGenerationLockRepository(db, () => clock);
+  });
+
+  afterEach(() => {
+    raw.close();
+  });
+
+  /** 밀리초 경과. */
+  function advance(ms: number): void {
+    clock += ms;
+  }
+
+  describe('acquire', () => {
+    it('락이 없으면 획득에 성공한다', async () => {
+      expect(await repo.acquire(PROJECT_A, USER_1, STALE_MS)).toBe(true);
+    });
+
+    it('유효한 락이 있으면 두 번째 획득은 실패한다 — 동시 요청 중 하나만 성공', async () => {
+      expect(await repo.acquire(PROJECT_A, USER_1, STALE_MS)).toBe(true);
+      expect(await repo.acquire(PROJECT_A, USER_2, STALE_MS)).toBe(false);
+    });
+
+    it('락 보유자 본인의 재획득도 실패한다 — 같은 프로젝트의 중복 파이프라인을 막는 것이 목적', async () => {
+      expect(await repo.acquire(PROJECT_A, USER_1, STALE_MS)).toBe(true);
+      expect(await repo.acquire(PROJECT_A, USER_1, STALE_MS)).toBe(false);
+    });
+
+    it('프로젝트가 다르면 서로 간섭하지 않는다', async () => {
+      expect(await repo.acquire(PROJECT_A, USER_1, STALE_MS)).toBe(true);
+      expect(await repo.acquire(PROJECT_B, USER_1, STALE_MS)).toBe(true);
+    });
+
+    it('heartbeat가 stale 경계를 넘긴 락은 다른 요청이 탈취한다 — 크래시된 파이프라인이 영구 잠금하지 않는다', async () => {
+      expect(await repo.acquire(PROJECT_A, USER_1, STALE_MS)).toBe(true);
+      advance(STALE_MS + 1);
+      expect(await repo.acquire(PROJECT_A, USER_2, STALE_MS)).toBe(true);
+    });
+
+    it('stale 경계 직전에는 아직 탈취할 수 없다', async () => {
+      expect(await repo.acquire(PROJECT_A, USER_1, STALE_MS)).toBe(true);
+      advance(STALE_MS - 1);
+      expect(await repo.acquire(PROJECT_A, USER_2, STALE_MS)).toBe(false);
+    });
+
+    it('탈취에 성공하면 소유자와 획득 시각이 새 요청으로 교체된다', async () => {
+      await repo.acquire(PROJECT_A, USER_1, STALE_MS);
+      advance(STALE_MS + 1);
+      await repo.acquire(PROJECT_A, USER_2, STALE_MS);
+
+      const lock = await repo.find(PROJECT_A);
+      expect(lock?.userId).toBe(USER_2);
+      expect(lock?.acquiredAt).toBe(new Date(clock).toISOString());
+    });
+  });
+
+  describe('heartbeat', () => {
+    it('heartbeat를 계속 보내면 stale 경계를 넘겨도 탈취되지 않는다', async () => {
+      await repo.acquire(PROJECT_A, USER_1, STALE_MS);
+
+      // 원래라면 만료됐을 시간까지 진행하되, 중간에 살아있음을 알린다.
+      advance(STALE_MS - 1);
+      expect(await repo.heartbeat(PROJECT_A)).toBe(true);
+      advance(STALE_MS - 1);
+
+      expect(await repo.acquire(PROJECT_A, USER_2, STALE_MS)).toBe(false);
+    });
+
+    it('락이 없으면 false를 반환한다 — 유실을 조용히 성공으로 위장하지 않는다', async () => {
+      expect(await repo.heartbeat(PROJECT_A)).toBe(false);
+    });
+
+    it('acquired_at은 갱신하지 않는다 — 총 점유 시간을 관측할 수 있어야 한다', async () => {
+      await repo.acquire(PROJECT_A, USER_1, STALE_MS);
+      const acquiredAt = (await repo.find(PROJECT_A))?.acquiredAt;
+
+      advance(1000);
+      await repo.heartbeat(PROJECT_A);
+
+      const lock = await repo.find(PROJECT_A);
+      expect(lock?.acquiredAt).toBe(acquiredAt);
+      expect(lock?.heartbeatAt).toBe(new Date(clock).toISOString());
+    });
+  });
+
+  describe('release', () => {
+    it('해제 후에는 즉시 재획득할 수 있다', async () => {
+      await repo.acquire(PROJECT_A, USER_1, STALE_MS);
+      await repo.release(PROJECT_A);
+
+      expect(await repo.acquire(PROJECT_A, USER_2, STALE_MS)).toBe(true);
+    });
+
+    it('없는 락을 해제해도 오류가 나지 않는다 — finally 경로에서 안전해야 한다', async () => {
+      await expect(repo.release(PROJECT_A)).resolves.toBeUndefined();
+    });
+
+    it('다른 프로젝트의 락은 건드리지 않는다', async () => {
+      await repo.acquire(PROJECT_A, USER_1, STALE_MS);
+      await repo.acquire(PROJECT_B, USER_1, STALE_MS);
+
+      await repo.release(PROJECT_A);
+
+      expect(await repo.isHeld(PROJECT_B, STALE_MS)).toBe(true);
+    });
+  });
+
+  describe('isHeld', () => {
+    it('유효한 락이 있으면 true', async () => {
+      await repo.acquire(PROJECT_A, USER_1, STALE_MS);
+      expect(await repo.isHeld(PROJECT_A, STALE_MS)).toBe(true);
+    });
+
+    it('락이 없으면 false', async () => {
+      expect(await repo.isHeld(PROJECT_A, STALE_MS)).toBe(false);
+    });
+
+    it('stale 락은 보유로 보지 않는다', async () => {
+      await repo.acquire(PROJECT_A, USER_1, STALE_MS);
+      advance(STALE_MS + 1);
+      expect(await repo.isHeld(PROJECT_A, STALE_MS)).toBe(false);
+    });
+  });
+
+  describe('내구성', () => {
+    it('프로세스 재시작(레포 인스턴스 교체)을 넘어 락 상태가 유지된다', async () => {
+      await repo.acquire(PROJECT_A, USER_1, STALE_MS);
+
+      // 같은 DB 파일을 보는 새 인스턴스 — 인메모리 tracker와 달리 상태가 남아야 한다.
+      const afterRestart = new SqliteGenerationLockRepository(db, () => clock);
+
+      expect(await afterRestart.isHeld(PROJECT_A, STALE_MS)).toBe(true);
+      expect(await afterRestart.acquire(PROJECT_A, USER_2, STALE_MS)).toBe(false);
+    });
+
+    it('재시작 후 stale해진 락은 정상적으로 탈취된다 — 크래시로 잃은 락이 영구화되지 않는다', async () => {
+      await repo.acquire(PROJECT_A, USER_1, STALE_MS);
+      advance(STALE_MS + 1);
+
+      const afterRestart = new SqliteGenerationLockRepository(db, () => clock);
+
+      expect(await afterRestart.acquire(PROJECT_A, USER_2, STALE_MS)).toBe(true);
+    });
+  });
+
+  describe('find', () => {
+    it('락이 없으면 null', async () => {
+      expect(await repo.find(PROJECT_A)).toBeNull();
+    });
+
+    it('stale 락도 반환한다 — 진단용이므로 유효성으로 거르지 않는다', async () => {
+      await repo.acquire(PROJECT_A, USER_1, STALE_MS);
+      advance(STALE_MS + 1);
+
+      expect(await repo.find(PROJECT_A)).not.toBeNull();
+    });
+  });
+});

--- a/src/repositories/sqlite/SqliteGenerationLockRepository.ts
+++ b/src/repositories/sqlite/SqliteGenerationLockRepository.ts
@@ -1,0 +1,112 @@
+import { and, eq, sql } from 'drizzle-orm';
+import type { SqliteDb } from '@/lib/db/sqlite/connection';
+import * as schema from '@/lib/db/sqlite/schema';
+import type {
+  GenerationLock,
+  IGenerationLockRepository,
+} from '@/repositories/interfaces';
+
+/**
+ * SQLite 기반 생성 락 (임베디드 단일 writer).
+ *
+ * 원자성: better-sqlite3는 동기 API이고 SQLite는 한 시점에 writer가 1개뿐이다.
+ * `INSERT ... ON CONFLICT DO UPDATE ... WHERE <stale> RETURNING`은 단일 문이므로
+ * 조회와 획득 사이에 다른 요청이 끼어들 틈이 없다 — `SqliteRateLimitRepository`의
+ * `UPDATE ... WHERE count < limit RETURNING`과 같은 test-and-set 패턴이다.
+ *
+ * 획득 실패는 "0행 반환"으로 나타난다: 유효한 락이 있으면 DO UPDATE의 WHERE가 거짓이 되어
+ * 아무 행도 갱신되지 않고 RETURNING도 비어 있다.
+ *
+ * 시계를 주입받는다 — stale 판정은 시간 경과가 본질이라 실시간에 묶으면 검증할 수 없다.
+ */
+export class SqliteGenerationLockRepository implements IGenerationLockRepository {
+  constructor(
+    private db: SqliteDb,
+    private now: () => number = Date.now,
+  ) {}
+
+  private iso(ms: number): string {
+    return new Date(ms).toISOString();
+  }
+
+  async acquire(projectId: string, userId: string, staleMs: number): Promise<boolean> {
+    const now = this.now();
+    const nowIso = this.iso(now);
+    // 이 시각보다 오래된 heartbeat는 죽은 것으로 본다.
+    const staleBefore = this.iso(now - staleMs);
+
+    const rows = this.db
+      .insert(schema.generationLocks)
+      .values({
+        project_id: projectId,
+        user_id: userId,
+        acquired_at: nowIso,
+        heartbeat_at: nowIso,
+      })
+      .onConflictDoUpdate({
+        target: schema.generationLocks.project_id,
+        set: {
+          user_id: userId,
+          acquired_at: nowIso,
+          heartbeat_at: nowIso,
+        },
+        // stale한 락만 탈취한다. 유효한 락이면 0행 → 획득 실패.
+        setWhere: sql`${schema.generationLocks.heartbeat_at} < ${staleBefore}`,
+      })
+      .returning({ projectId: schema.generationLocks.project_id })
+      .all();
+
+    return rows.length > 0;
+  }
+
+  async heartbeat(projectId: string): Promise<boolean> {
+    const rows = this.db
+      .update(schema.generationLocks)
+      .set({ heartbeat_at: this.iso(this.now()) })
+      .where(eq(schema.generationLocks.project_id, projectId))
+      .returning({ projectId: schema.generationLocks.project_id })
+      .all();
+
+    return rows.length > 0;
+  }
+
+  async release(projectId: string): Promise<void> {
+    this.db
+      .delete(schema.generationLocks)
+      .where(eq(schema.generationLocks.project_id, projectId))
+      .run();
+  }
+
+  async isHeld(projectId: string, staleMs: number): Promise<boolean> {
+    const staleBefore = this.iso(this.now() - staleMs);
+
+    const row = this.db
+      .select({ projectId: schema.generationLocks.project_id })
+      .from(schema.generationLocks)
+      .where(
+        and(
+          eq(schema.generationLocks.project_id, projectId),
+          sql`${schema.generationLocks.heartbeat_at} >= ${staleBefore}`,
+        ),
+      )
+      .get();
+
+    return row !== undefined;
+  }
+
+  async find(projectId: string): Promise<GenerationLock | null> {
+    const row = this.db
+      .select()
+      .from(schema.generationLocks)
+      .where(eq(schema.generationLocks.project_id, projectId))
+      .get();
+
+    if (!row) return null;
+    return {
+      projectId: row.project_id,
+      userId: row.user_id,
+      acquiredAt: row.acquired_at,
+      heartbeatAt: row.heartbeat_at,
+    };
+  }
+}

--- a/src/repositories/sqlite/index.ts
+++ b/src/repositories/sqlite/index.ts
@@ -6,3 +6,4 @@ export { SqliteEventRepository } from './SqliteEventRepository';
 export { SqliteRateLimitRepository } from './SqliteRateLimitRepository';
 export { SqliteUserApiKeyRepository } from './SqliteUserApiKeyRepository';
 export { SqliteAuthTokenRepository } from './SqliteAuthTokenRepository';
+export { SqliteGenerationLockRepository } from './SqliteGenerationLockRepository';


### PR DESCRIPTION
Closes #198

## 문제

`generationTracker`는 진행률 표시와 **중복 생성 차단**을 겸했다. 저장소가 모듈 레벨 `LRUMap`(TTL: `generating` 30분)이라 **엔트리가 사라지면 락도 사라진다** — `isGenerating()`이 `false`를 돌려주고 같은 `projectId`로 두 번째 파이프라인이 시작될 수 있다.

- Opus/ET 호출이 중복되어 **토큰이 이중 청구**
- 두 파이프라인이 같은 `getNextVersion()`을 받아 한쪽이 `UNIQUE(project_id, version)` 위반으로 실패
- 프로세스 재시작이면 진행 중이던 락이 통째로 소실

PR #196은 `logger.warn`으로 **관측만** 가능하게 했다. 같은 구조 안에서는 고칠 수 없다 — TTL을 늘리면 크래시된 파이프라인이 프로젝트를 영구히 잠그고, 없애면 메모리가 무한 증가한다.

## 해결 — 이슈의 방안 A (SQLite 락)

락 책임만 DB로 분리하고 tracker는 진행률 전용으로 남긴다.

### 원자적 획득

```sql
INSERT INTO generation_locks (...) VALUES (...)
ON CONFLICT(project_id) DO UPDATE SET ...
  WHERE generation_locks.heartbeat_at < ?   -- stale한 락만 탈취
RETURNING project_id
```

better-sqlite3는 동기 API이고 SQLite는 writer가 1개다. **단일 문**이라 체크와 획득 사이에 끼어들 틈이 없다 — `SqliteRateLimitRepository`의 `UPDATE ... WHERE count < limit RETURNING`과 같은 검증된 패턴이다. 획득 실패는 "0행 반환"으로 나타난다.

### heartbeat

파이프라인이 도는 동안 30초마다 `heartbeat_at`을 갱신한다. 프로세스가 죽으면 신호가 멈추고 5분 후 다른 요청이 탈취한다. 진행률 갱신 지점에 얹지 않고 **독립 타이머**를 쓴다 — Stage 사이에 수십 초씩 AI 응답을 기다려 간격이 들쭉날쭉해지기 때문. 타이머는 `.unref()`.

`stale <= heartbeat` 조합은 살아 있는 파이프라인이 다음 신호 전에 스스로 만료되게 만든다. `heartbeat × 2`로 교정하고 **경고를 남긴다** — 조용히 폴백하면 운영자가 값을 바꿨는데 적용되지 않은 이유를 알 수 없다.

### 수명주기

| 단계 | 위치 |
|------|------|
| 획득 | 라우트 (`generate` · `regenerate` · `admin/test-generation`) — 409를 스트림 시작 전에 반환해야 함 |
| heartbeat 시작·중지 | `runGenerationPipeline` |
| 해제 | `runGenerationPipeline`의 `finally` — 성공·실패 무관 |

`finally`에서 **heartbeat를 먼저 멈추고 해제한다**(순서가 뒤집히면 무의미한 경고 로그). 해제는 **던지지 않는다** — `finally`에서 예외가 나면 파이프라인의 원래 오류를 덮는다.

### `isGenerating()` 제거

남겨두면 누군가 다시 게이트로 쓴다. `generationTracker.test.ts`가 **메서드 부재를 단언**해 회귀를 고정한다.

## 설계 판단

- **FK 없음** — `project_id` FK가 있으면 스테일 락이 남은 프로젝트 삭제가 FK 위반으로 실패한다(`admin/test-generation` cleanup 경로가 실제로 그렇다)
- **획득 실패는 fail-closed** — DB 조회 실패는 던져서 500. 폴백하면 중복을 못 막는다
- **`retention.ts` 대상 아님** — 행이 `project_id`로 유일하고 정상 경로에서 해제되므로 상한이 프로젝트 수다. 트래픽 비례로 커지는 `platform_events`와 성격이 다르다

## 범위 밖

상태 폴링의 `not_found` 오보(이슈 방안 C)는 **이미 해소되어 있었다** — `/api/v1/generate/status/[projectId]`가 tracker 미스 시 DB 최신 코드로 완료를 판정한다. 이번 변경은 중복 파이프라인만 다룬다.

## 검증

TDD로 작성했고 **신규 41개 테스트 전부 구현 전 실패를 확인**했다.

| 항목 | 결과 |
|------|------|
| `pnpm test` | **171 파일 / 2114 통과** (기존 2073 + 41) |
| `pnpm type-check` | 통과 |
| `pnpm lint` | 0 errors (기존 warning 2건) |
| `pnpm build` | 통과 |

고정한 것: 원자적 획득(본인 재획득 포함 차단) · stale 경계 직전/직후 · heartbeat 연장과 중지 · `acquired_at` 불변 · 레포 인스턴스 교체(프로세스 재시작) 후 판정 일관성 · 해제·heartbeat 오류 격리 · 성공/실패 양쪽 해제 · 중지→해제 순서.

## 배포 시 주의

마이그레이션 `0002_icy_cassandra_nova.sql`이 부팅 시 자동 적용된다(`bootstrapSqlite` → `runSqliteMigrations`). 새 테이블 생성만 하므로 기존 데이터에 영향 없음.

## 관련 문서

- [ADR: 생성 락을 인메모리 tracker에서 SQLite로 분리](docs/decisions/2026-07-29-durable-generation-lock.md)
- [env-vars.md](docs/reference/env-vars.md) — `GENERATION_LOCK_HEARTBEAT_MS` · `GENERATION_LOCK_STALE_MS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)