### PR TITLE
fix: 생성물의 Alpine 이중 init 차단 — 프롬프트 금지 + 정적 검출 (#204)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,12 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 - **전이 의존성 오버라이드는 스코프를 좁힐 것**: `"brace-expansion@^5": "^5.0.8"`처럼 버전 범위를 명시한다. 전역 오버라이드는 메이저가 다른 소비자를 런타임에 깨뜨린다(v5 CJS는 named export라 `minimatch@3`의 `require(...)(pattern)` 호출이 깨짐 — 실증됨)
 - `sharp`는 `next`의 optionalDependency(`^0.34.5`)라 상위 상향으로 패치 버전에 도달하지 못한다 → `pnpm.overrides`로 상향. 변경 시 **Alpine musl 프리빌트(`@img/sharp-linuxmusl-x64`) 존재 여부와 lockfile 등재를 반드시 확인**(Dockerfile이 `node:22-alpine`)
 
+### 생성물의 Alpine.js 이중 init 금지
+- Alpine은 마운트 시 `x-data` 객체의 **`init()`을 자동 호출**한다. 같은 요소에 `x-init="init()"`을 쓰면 **두 번 실행**되어 같은 API 요청이 동시에 두 번 나간다 — 업스트림 리밋이 빡빡한 API(예: OpenTDB 1req/5초)에서 두 번째가 429가 되고 사용자에게 오류 화면이 보인다(2026-07-29 프로덕션 실측)
+- 2중 방어: ① `promptBuilder.ts`의 Alpine 절에 ❌/✅ 예시와 함께 명시 금지 ② `detectAlpineDoubleInit()`(`codeValidator.ts`)가 정적 검출해 `validateFunctionality` **경고**로 올린다. 보안 문제가 아니므로 `errors`가 아니라 `warnings` — 게시를 막지 않는다
+- 검출 규칙은 **JS 본문을 보지 않는다**. `x-init`이 `init`이라는 이름의 메서드를 부르면 정의돼 있으면 이중 실행, 없으면 ReferenceError라 어느 쪽이든 버그이기 때문. 단어 경계를 쓰므로 `initialize()`·`initChart()`·`myInit()`은 잡지 않는다
+- **프롬프트에 `x-init` 예시를 추가할 때 로더 이름을 `init`으로 짓지 말 것.** 원인은 프롬프트가 나쁜 예시를 준 게 아니라(당시 프롬프트엔 없었다) 모델이 로더를 자연스럽게 `init`으로 명명한 것이었다 — 좋은 예시만으로는 못 막고 명시 금지가 필요하다. 배경: [#204](https://github.com/xzawed/CustomWebService/issues/204)
+
 ### QC 프로세스 (생성/재생성 공통)
 - **상세 절차**: [docs/guides/qc-process.md](docs/guides/qc-process.md) 참조 (8단계 표준 프로세스)
 - **파이프라인 설계**: [docs/architecture/ai-pipeline.md](docs/architecture/ai-pipeline.md) 참조 (3단계 Stage + Quality Loop)

--- a/src/lib/ai/codeValidator.test.ts
+++ b/src/lib/ai/codeValidator.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   validateSecurity, validateFunctionality, evaluateQuality, validateAll,
   evaluateDataBinding, evaluateStructure, evaluateInteractivity, evaluateMobileResponsiveness,
+  detectAlpineDoubleInit,
 } from './codeValidator';
 
 describe('validateSecurity', () => {
@@ -85,6 +86,130 @@ describe('validateFunctionality', () => {
     const result = validateFunctionality(html, '', '');
     expect(result.passed).toBe(true);
     expect(result.errors).toHaveLength(0);
+  });
+
+  it('Alpine 이중 init 경고가 validateFunctionality 경고로 표면화되고 passed는 true를 유지한다', () => {
+    const html =
+      '<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width"></head>' +
+      '<body><div x-data="app()" x-init="init()"></div></body></html>';
+    const result = validateFunctionality(html, '', '');
+    expect(result.passed).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.warnings.some((w) => w.includes('Alpine') && w.includes('init()'))).toBe(true);
+  });
+});
+
+describe('detectAlpineDoubleInit', () => {
+  describe('감지해야 하는 경우', () => {
+    it('x-data와 x-init="init()" 조합을 감지한다', () => {
+      const result = detectAlpineDoubleInit('<div x-data="app()" x-init="init()">');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toContain('init()');
+    });
+
+    it('속성 순서가 바뀐 x-init + x-data도 감지한다', () => {
+      const result = detectAlpineDoubleInit('<div x-init="init()" x-data="app()">');
+      expect(result).toHaveLength(1);
+    });
+
+    it('x-init 값의 앞뒤 공백이 있어도 감지한다', () => {
+      const result = detectAlpineDoubleInit('<div x-data="app()"   x-init=" init() ">');
+      expect(result).toHaveLength(1);
+    });
+
+    it('홑따옴표 속성도 감지한다', () => {
+      const result = detectAlpineDoubleInit("<div x-data='app()' x-init='init()'>");
+      expect(result).toHaveLength(1);
+    });
+
+    it('await init() 형태를 감지한다', () => {
+      const result = detectAlpineDoubleInit('<div x-data="app()" x-init="await init()">');
+      expect(result).toHaveLength(1);
+    });
+
+    it('$nextTick 콜백 안의 init() 호출을 감지한다', () => {
+      const result = detectAlpineDoubleInit(
+        '<div x-data="app()" x-init="$nextTick(() => init())">',
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('init(); other()처럼 연쇄 호출도 감지한다', () => {
+      const result = detectAlpineDoubleInit('<div x-data="app()" x-init="init(); other()">');
+      expect(result).toHaveLength(1);
+    });
+
+    it('위반 요소가 여러 개면 요소마다 경고를 하나씩 반환한다', () => {
+      const html =
+        '<div x-data="a()" x-init="init()"></div><section x-data="b()" x-init="init()"></section>';
+      const result = detectAlpineDoubleInit(html);
+      expect(result).toHaveLength(2);
+    });
+
+    it('값 없는 x-data도 감지한다 — Alpine은 이를 빈 객체로 보므로 init()이 ReferenceError로 죽는다', () => {
+      const result = detectAlpineDoubleInit('<div x-data x-init="init()">');
+      expect(result).toHaveLength(1);
+    });
+
+    it('경고에 문제의 x-init 식을 포함해 어느 요소인지 짚을 수 있게 한다', () => {
+      // 위반이 여러 개일 때 메시지가 전부 같으면 어디를 고쳐야 할지 알 수 없다.
+      const html =
+        '<div x-data="a()" x-init="init()"></div>' +
+        '<section x-data="b()" x-init="$nextTick(() => init())"></section>';
+      const [first, second] = detectAlpineDoubleInit(html);
+      expect(first).toContain('x-init="init()"');
+      expect(second).toContain('$nextTick(() => init())');
+      expect(first).not.toBe(second);
+    });
+
+    it('여러 줄에 걸쳐 속성이 있어도 감지한다', () => {
+      const html = `<div
+  class="card"
+  x-data="app()"
+  id="root"
+  x-init="init()"
+>`;
+      const result = detectAlpineDoubleInit(html);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('감지하지 않아야 하는 경우', () => {
+    it('다른 메서드명 loadData()는 감지하지 않는다', () => {
+      expect(detectAlpineDoubleInit('<div x-data="app()" x-init="loadData()">')).toEqual([]);
+    });
+
+    it('initialize()는 단어 경계로 구분되어 감지하지 않는다', () => {
+      expect(detectAlpineDoubleInit('<div x-data="app()" x-init="initialize()">')).toEqual([]);
+    });
+
+    it('initChart()는 단어 경계로 구분되어 감지하지 않는다', () => {
+      expect(detectAlpineDoubleInit('<div x-data="app()" x-init="initChart()">')).toEqual([]);
+    });
+
+    it('myInit()는 단어 경계로 구분되어 감지하지 않는다', () => {
+      expect(detectAlpineDoubleInit('<div x-data="app()" x-init="myInit()">')).toEqual([]);
+    });
+
+    it('this.initialize()는 감지하지 않는다', () => {
+      expect(detectAlpineDoubleInit('<div x-data="app()" x-init="this.initialize()">')).toEqual([]);
+    });
+
+    it('x-init 없이 x-data만 있으면 감지하지 않는다', () => {
+      expect(detectAlpineDoubleInit('<div x-data="app()">')).toEqual([]);
+    });
+
+    it('x-data 없이 x-init="init()"만 있으면 감지하지 않는다', () => {
+      expect(detectAlpineDoubleInit('<div x-init="init()">')).toEqual([]);
+    });
+
+    it('빈 문자열은 경고 없이 빈 배열을 반환한다', () => {
+      expect(detectAlpineDoubleInit('')).toEqual([]);
+    });
+
+    it('Alpine 속성이 없는 HTML은 경고 없이 빈 배열을 반환한다', () => {
+      expect(detectAlpineDoubleInit('<div class="app"><p>hello</p></div>')).toEqual([]);
+    });
   });
 });
 

--- a/src/lib/ai/codeValidator.ts
+++ b/src/lib/ai/codeValidator.ts
@@ -70,6 +70,91 @@ export function validateSecurity(code: string): ValidationResult {
   };
 }
 
+/**
+ * 따옴표 안의 `>`(예: x-init="$nextTick(() => init())")를 보존하며 여는 태그를 순회한다.
+ * 단순 `[^>]*` 스캔은 화살표 함수의 `>`에서 태그가 잘려 오탐·미탐이 난다.
+ *
+ * 정식 HTML 파서가 아니다 — `<script>` 본문의 `a<b` 같은 표현을 태그 시작으로 오인할 수
+ * 있다. 그 경우에도 잘라낸 조각에 `x-data`와 `x-init`이 동시에 들어 있어야 경고가 나므로
+ * 실질 오탐 가능성은 낮고, 결과는 경고(비차단)라 영향이 제한적이다. 정확도가 더 필요해지면
+ * 파서로 교체할 것.
+ */
+function forEachHtmlOpenTag(html: string, onTag: (tag: string) => void): void {
+  const len = html.length;
+  let i = 0;
+  while (i < len) {
+    if (html[i] === '<' && i + 1 < len && /[a-zA-Z]/i.test(html[i + 1]!)) {
+      const start = i;
+      i += 2;
+      let quote: '"' | "'" | null = null;
+      while (i < len) {
+        const c = html[i]!;
+        if (quote !== null) {
+          if (c === quote) {
+            quote = null;
+          }
+        } else if (c === '"' || c === "'") {
+          quote = c;
+        } else if (c === '>') {
+          onTag(html.slice(start, i + 1));
+          i += 1;
+          break;
+        }
+        i += 1;
+      }
+      continue;
+    }
+    i += 1;
+  }
+}
+
+/**
+ * Alpine.js 이중 init() 호출 패턴을 정적 검출한다.
+ *
+ * Alpine은 x-data 컴포넌트 마운트 시 데이터 객체의 init()을 자동 호출한다.
+ * 같은 요소에 x-init="init()"을 쓰면 init()이 두 번 실행되어 API 중복 요청·레이트리밋
+ * 오류 등이 발생할 수 있다. 데이터 객체에 init이 없으면 ReferenceError가 난다.
+ * 어느 쪽이든 버그이므로 JS 본문 검사 없이 HTML 속성만으로 판정한다.
+ *
+ * @returns 위반 요소당 한국어 경고 메시지 1개 (없으면 빈 배열)
+ */
+export function detectAlpineDoubleInit(html: string): string[] {
+  if (!html) {
+    return [];
+  }
+
+  const warnings: string[] = [];
+  // 메서드명이 정확히 init 인 호출만 — initialize/initChart/myInit 등은 제외
+  const initCallRegex = /\binit\s*\(/;
+
+  forEachHtmlOpenTag(html, (tag) => {
+    // x-data 존재 여부. **값이 없는 `x-data`도 포함한다** — Alpine은 이를 빈 객체로 취급하므로
+    // x-init의 init() 호출이 ReferenceError로 죽는다(값 있는 경우의 이중 실행과 마찬가지로 버그).
+    if (!/\bx-data\b/i.test(tag)) {
+      return;
+    }
+
+    // x-init 값 추출 (쌍/홑따옴표)
+    const xInitMatch = /\bx-init\s*=\s*(?:"([^"]*)"|'([^']*)')/i.exec(tag);
+    if (!xInitMatch) {
+      return;
+    }
+
+    const expression = xInitMatch[1] ?? xInitMatch[2] ?? '';
+    if (initCallRegex.test(expression)) {
+      // 위반이 여러 개일 때 메시지가 전부 같으면 어느 요소를 고쳐야 할지 알 수 없다 —
+      // 문제의 식을 그대로 실어 지목 가능하게 한다.
+      warnings.push(
+        `Alpine.js 컴포넌트에 x-init="${expression}" 이 감지되었습니다. ` +
+          'Alpine은 마운트 시 데이터 객체의 init()을 자동 호출하므로 x-init에서 다시 부르면 이중 실행됩니다 ' +
+          '(API 중복 요청·레이트리밋 오류 등). x-init에서 init() 호출을 제거하고 본문만 데이터 객체에 두세요.',
+      );
+    }
+  });
+
+  return warnings;
+}
+
 export function validateFunctionality(html: string, _css: string, js: string): ValidationResult {
   const errors: string[] = [];
   const warnings: string[] = [];
@@ -89,6 +174,9 @@ export function validateFunctionality(html: string, _css: string, js: string): V
       warnings.push('JavaScript 코드의 중괄호 수가 불일치합니다.');
     }
   }
+
+  // Alpine 이중 init — 품질 신호(경고)만; 게시를 막지 않음
+  warnings.push(...detectAlpineDoubleInit(html));
 
   return {
     passed: errors.length === 0,

--- a/src/lib/ai/promptBuilder.ts
+++ b/src/lib/ai/promptBuilder.ts
@@ -524,7 +524,7 @@ function showError(container, message) {
 
 ### 핵심 Alpine.js 규칙
 1. \`x-data\` — 컴포넌트 최상위에서 상태 선언. \`{ items: [], loading: true, error: null }\`
-2. \`x-init="loadData()"\` — 마운트 시 API 호출 자동 실행
+2. \`x-init="loadData()"\` — 마운트 시 API 호출 자동 실행. **로더 함수 이름을 \`init\`으로 짓지 말 것** (아래 참조)
 3. \`x-show\` — 조건부 표시 (DOM 유지, CSS display 토글)
 4. \`x-if\` — 조건부 렌더링 (DOM 추가/제거 — 성능 주의)
 5. \`x-for\` — 리스트 렌더링, 반드시 \`:key\` 설정
@@ -539,10 +539,36 @@ function showError(container, message) {
 // x-data="{ items: [], filter: '', get filteredItems() { return this.filter ? this.items.filter(i => i.title.includes(this.filter)) : this.items; } }"
 \`\`\`
 
+### ⛔ x-init에서 init() 호출 금지 (이중 실행)
+
+Alpine은 마운트 시 데이터 객체의 \`init()\`을 **자동으로 호출한다.** 같은 요소에
+\`x-init="init()"\`을 쓰면 \`init()\`이 **두 번 실행**되어 같은 API 요청이 동시에 두 번 나간다.
+업스트림 레이트리밋이 빡빡한 API(예: 1req/5초)에서는 두 번째가 429가 되어 사용자에게
+오류 화면이 그대로 보인다.
+
+\`\`\`html
+<!-- ❌ 잘못됨: init()이 두 번 실행된다 -->
+<div x-data="quizApp()" x-init="init()">
+<script>
+  function quizApp() {
+    return { async init() { await this.loadQuiz(); } };  // Alpine이 자동 호출
+  }
+</script>
+
+<!-- ✅ 방법 1: x-init을 지운다 (init은 자동 실행되므로 필요 없다) -->
+<div x-data="quizApp()">
+
+<!-- ✅ 방법 2: 로더 이름을 init이 아닌 것으로 짓고 x-init으로 부른다 -->
+<div x-data="quizApp()" x-init="loadData()">
+\`\`\`
+
+둘 중 하나만 쓴다. **\`init\`이라는 이름과 \`x-init\` 호출을 동시에 쓰지 않는다.**
+
 ### 금지 패턴
 - \`document.getElementById()\` — Alpine.js가 있으면 불필요
 - \`element.innerHTML = ...\` — x-html 또는 x-text 사용
 - 전역 변수로 상태 관리 — x-data로 캡슐화
+- \`x-init="init()"\` — 위 참조. 이중 실행으로 API 중복 요청 발생
 
 ## ★ 코드 반환 전 자가검증 5단계 (절대 필수 — 순서대로 실행)
 


### PR DESCRIPTION
Closes #204

## 문제

Alpine은 마운트 시 `x-data` 객체의 **`init()`을 자동 호출**한다. 같은 요소에 `x-init="init()"`을 쓰면 **두 번 실행**된다.

[#197](https://github.com/xzawed/CustomWebService/issues/197) 실환경 검증에서 게시 사이트가 정확히 이 패턴이었고, 같은 퀴즈 요청이 동시에 두 번 나가 OpenTDB(1req/5초)의 두 번째 호출이 `429` → 사용자에게 **"문제를 불러오지 못했습니다" 오류 화면**이 보였다.

```html
<div x-data="quizApp()" x-init="init()">   <!-- quizApp()이 init()을 정의 → 2회 실행 -->
```

## 원인 — 프롬프트가 나쁜 예시를 준 게 아니었다

확인 결과 당시 `promptBuilder.ts`에는 `x-init="init()"`이 **없었다**(`x-init="loadData()"`만 있었다). 모델이 로더를 자연스럽게 `init`으로 명명해 Alpine 관례와 충돌한 것이다.

→ **좋은 예시만으로는 못 막는다. 명시적 금지가 필요하다.**

## 2중 방어

### 1. 예방 — 프롬프트 명시 금지
Alpine 절에 ❌/✅ 예시와 함께 "`init`이라는 이름과 `x-init` 호출을 동시에 쓰지 않는다"를 넣고, `x-init` 설명 항목에도 "로더 이름을 `init`으로 짓지 말 것"을 붙였다.

### 2. 탐지 — `detectAlpineDoubleInit()` (`codeValidator.ts`)
`validateFunctionality`의 **`warnings`** 로 올린다. 보안이 아니라 품질 신호이므로 `errors`가 아니다 — **게시를 막지 않는다.**

**JS 본문을 보지 않는다**: `x-init`이 `init`이라는 이름의 메서드를 부르면 정의돼 있으면 이중 실행, 없으면 ReferenceError라 **어느 쪽이든 버그**이기 때문.

| 처리 | 예 |
|------|-----|
| 잡는다 | `init()` · ` init() ` · `await init()` · `$nextTick(() => init())` · `init(); other()` · 속성 순서 반대 · 홑따옴표 · 여러 줄 · 값 없는 `x-data` |
| 안 잡는다 | `loadData()` · `initialize()` · `initChart()` · `myInit()` · `this.initialize()` · `x-init` 없음 · `x-data` 없음 |

`initialize`/`initChart`/`myInit`은 **단어 경계**로 구분한다(순진한 `includes('init(')`은 전부 오탐). `x-init="$nextTick(() => init())"`의 화살표 `>`에 태그가 잘리지 않도록 따옴표 인식 스캐너를 쓴다.

## 실제 산출물로 검증

#197 검증 프로젝트의 **실제 프로덕션 생성 HTML**(29KB)에 검출기를 돌려 **해당 요소 1건을 정확히 지목**하는 것을 확인했다. 합성 테스트만으로 끝내지 않았다.

## Claude ↔ Grok 협업

검출기 초안을 **Grok Build**에 위임하고(LOW 위험·좁은 범위로 라우팅 판정), diff 리뷰에서 **2건을 보강**했다:

1. **값 없는 `x-data` 미검출** — `<div x-data x-init="init()">`. Alpine이 빈 객체로 취급해 `init()`이 ReferenceError로 죽는 **실제 누락**이었다
2. **위반이 여러 개일 때 메시지가 전부 동일** — 어느 요소를 고쳐야 할지 알 수 없었다. 문제의 `x-init` 식을 메시지에 실어 지목 가능하게 했다

추가로 태그 스캐너가 정식 파서가 아니라는 한계(`<script>` 본문의 `a<b` 오인 가능)를 주석에 명시했다 — 경고 비차단 경로라 영향은 제한적이다.

두 보강 모두 **실패하는 테스트를 먼저 쓰고** 확인한 뒤 구현했다.

## 검증

| 항목 | 결과 |
|------|------|
| `pnpm test` | **172 파일 / 2164 통과** |
| `pnpm type-check` | 통과 |
| `pnpm lint` | 0 errors (기존 warning 2건) |
| `pnpm build` | 통과 |
| 실제 생성물 검출 | 1건 정확 지목 |

## 후속 여지

지금은 **경고**까지다. 재발이 관측되면 Quality Loop 재시도 트리거(점수 반영)로 승격하는 것이 다음 단계다 — 지금 점수에 넣으면 기존 스코어링 의미가 넓게 바뀌어 과한 변경이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)