### PR TITLE
chore: 저장소 위생 — 런타임 락 무시 + Codex 배포 체크리스트 훅 등재

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash(git push*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '--- Railway 배포 체크리스트 ---\n1. Railway 대시보드에서 배포 상태 확인 (빌드 로그 → 헬스체크)\n2. 헬스체크 경로: /api/v1/health\n3. 성공 확인 후 배포 태그: git tag deploy/$(date +%Y-%m-%d-%H%M) && git push origin --tags\n사용자에게 Railway 배포 상태 확인을 요청할 것'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,8 @@ test-results/
 
 # claude — settings.local.json(시크릿)만 제외, settings.json(훅/권한)은 버전 관리
 .claude/settings.local.json
+# 세션별 런타임 락(sessionId·pid) — 머신마다 달라 커밋하면 매번 충돌한다
+.claude/scheduled_tasks.lock
 
 # 임시 검증 산출물
 verification-report.json


### PR DESCRIPTION
GitHub/저장소 정리 중 발견한 작업 트리 오염 2건을 정리한다.

## 변경

| 파일 | 처리 | 근거 |
|------|------|------|
| `.claude/scheduled_tasks.lock` | **무시** | `sessionId`·`pid`가 든 세션별 런타임 락. 머신마다 달라 커밋하면 매번 충돌한다 |
| `.codex/hooks.json` | **등재** | `git push` 후 Railway 배포 체크리스트를 띄우는 훅. 시크릿 없음 |

`.claude/` 전체를 무시하지 않고 **해당 파일만** 지정했다 — `agents/`·`commands/`·`settings.json`은 계속 버전 관리 대상이다(기존 `.gitignore` 주석의 결정 유지).

`.codex/hooks.json`을 무시하지 않고 등재한 이유: 훅·권한 설정을 버전 관리하는 `.claude/settings.json`과 같은 성격이고, 내용이 이 프로젝트의 배포 절차(헬스체크 경로·배포 태그 규칙)를 그대로 담고 있어 저장소에 있는 편이 맞다.

## 함께 수행한 정리 (커밋 불필요)

- 로컬 잔여 브랜치 **11개 삭제** — 전부 MERGED PR(#108·#109·#117·#122·#123·#125·#127·#128·#129·#131·#133)에 대응하는 것을 확인 후 삭제
- stale 원격추적 ref **15개 prune**
- 원격 브랜치는 `main` 하나, 열린 PR·이슈 0건, Dependabot 보안 알림 0건으로 이미 정리된 상태였다

코드 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)