### PR TITLE
test+feat: 스트리밍 thinking 커버리지 보강 · debug에 모델 해석 결과 노출

### DIFF
--- a/src/providers/ai/ClaudeProvider.test.ts
+++ b/src/providers/ai/ClaudeProvider.test.ts
@@ -195,6 +195,32 @@ describe('ClaudeProvider', () => {
       expect(result.provider).toBe('claude');
       expect(result.model).toBe('claude-sonnet-5');
     });
+
+    // 파이프라인이 실제로 쓰는 경로는 스트리밍이다 — thinking 분기를 여기서도 고정한다.
+    it('extendedThinking 미활성 시 thinking을 disabled로 명시한다', async () => {
+      mockStreamOn.mockImplementation(() => {});
+
+      await provider.generateCodeStream({ system: 'sys', user: 'user' }, () => {});
+
+      const callArg = mockStream.mock.calls[0][0] as Record<string, unknown>;
+      expect(callArg).toMatchObject({ thinking: { type: 'disabled' } });
+      expect(callArg).not.toHaveProperty('output_config');
+    });
+
+    it('extendedThinking 활성화 시 adaptive + effort:high를 전달한다', async () => {
+      mockStreamOn.mockImplementation(() => {});
+
+      await provider.generateCodeStream(
+        { system: 'sys', user: 'user', extendedThinking: true },
+        () => {}
+      );
+
+      const callArg = mockStream.mock.calls[0][0] as Record<string, unknown>;
+      expect(callArg).toMatchObject({
+        thinking: { type: 'adaptive' },
+        output_config: { effort: 'high' },
+      });
+    });
   });
 
   describe('withRetry — 재시도 동작', () => {


### PR DESCRIPTION
Opus 5 상향(#211) 후속 2건. #211이 자동 병합되며 커버리지 보강 커밋이 누락됐고, 검증 과정에서 진단 수단 부재가 드러났다.

## 1. 스트리밍 경로의 thinking 분기 커버리지

#211에서 `codecov/patch`가 **diff 커버리지 71.42%** (target 94.23%)로 막았다. 확인해보니 `generateCodeStream`의 thinking 분기에 테스트가 없었다 — **파이프라인이 실제로 쓰는 경로가 스트리밍**이라 공백을 둘 수 없다.

| 추가한 테스트 | 고정하는 것 |
|---|---|
| ET 비활성 → `thinking: disabled` 명시 + `output_config` 미전송 | Opus 5는 `thinking` 생략 시 adaptive가 켜져 `max_tokens`를 생성물과 나눠 쓴다. `disabled`+`effort: xhigh\|max`는 400 |
| ET 활성 → `adaptive` + `effort: high` | 기존 동작 유지 |

`generateCode`(비스트리밍)에는 같은 규약의 테스트가 이미 있었고 스트리밍 쪽만 비어 있었다.

## 2. `GET /api/v1/admin/debug`에 모델 해석 결과 노출

**Opus 5가 실제로 적용됐는지 확인할 방법이 저장소에 없었다.** 허용목록에 없는 `AI_MODEL_*` env는 경고 로그 한 줄만 남기고 **조용히 기본값으로 폴백**하는데, 로그에 접근할 수 없으면 env 값만 보고 "허용목록과 일치하니 맞을 것"이라 추론하는 수밖에 없다.

그 추론이 틀렸던 것이 **2026-07-10 사고**다 — `AI_MODEL_GENERATION`이 `claude-opus-4-8`인데 허용목록에 없어 `opus-4-7`로 돌고 있던 것을 한참 뒤에 발견했다. 같은 벽에 다시 부딪혀서, 이번엔 확인 가능하게 만든다.

```json
"models": {
  "generation": { "env": "claude-opus-5", "resolved": "claude-opus-5", "fellBack": false },
  "suggestion": { "env": "claude-haiku-4-5", "resolved": "claude-haiku-4-5", "fellBack": false }
}
```

| 필드 | 의미 |
|---|---|
| `env` | env 원본 값 (미설정 시 `null`) |
| `resolved` | **실제로 적용되는 모델** |
| `fellBack` | `true`면 env가 무시되고 기본값이 쓰이는 중 — 허용목록을 고쳐야 한다 |

"모델 변경 후 `fellBack: false` 확인" 규칙을 CLAUDE.md와 api-endpoints.md에 남겼다.

## 검증

| 항목 | 결과 |
|------|------|
| `pnpm test` | **2173 통과** |
| `pnpm type-check` · `pnpm lint`(0 errors) · `pnpm build` | 통과 |

TDD — 진단 필드 테스트 3건이 구현 전 실패하는 것을 확인했다(`env`/`resolved` 일치, `fellBack=true` 노출, env 미설정 시 `env=null`이고 폴백 아님).

## 참고

- [ADR: 생성 모델 Opus 4.8 → Opus 5 상향](docs/decisions/2026-07-29-llm-model-upgrade-opus5.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)