### PR TITLE
docs: pollGenerationStatus 헤더를 실제 동작에 맞게 정정 (#215)

### DIFF
--- a/src/lib/generation/pollGenerationStatus.ts
+++ b/src/lib/generation/pollGenerationStatus.ts
@@ -2,13 +2,15 @@
  * 생성 상태 폴링 — SSE 스트림이 'complete' 없이 끊기거나(모바일 백그라운드 전환 등)
  * visibilitychange로 전환될 때 `/api/v1/generate/status/:projectId`를 주기적으로 조회한다.
  *
- * 원래 `builder/page.tsx`의 `handleGenerate` 클로저 내부에 있던 로직을 그대로 추출한 것이다.
- * 동작을 byte-for-byte 보존했으며(아래 주의 참고), 의존성을 주입받아 단위 테스트가 가능하다.
+ * 원래 `builder/page.tsx`의 `handleGenerate` 클로저 내부에 있던 로직을 추출한 것이며,
+ * 의존성을 주입받아 단위 테스트가 가능하다. 추출 당시에는 동작을 그대로 보존했으나
+ * 이후 두 가지를 개선했다(아래).
  *
- * **주의(기존 동작 보존)**:
- * - `status: 'failed'`는 즉시 실패시키지 않고 `throw` → catch에서 마지막 시도일 때만
- *   `failGeneration`. 즉 'failed'가 계속 반환되면 `maxAttempts`까지 재시도 후 실패한다.
- *   (개선 여지가 있으나 이번 추출은 동작 변경 없이 보존만 한다.)
+ * **현재 동작에서 헷갈리기 쉬운 지점**:
+ * - `status: 'failed'`는 **즉시 terminal 실패**다. 추출 시점에는 `throw` 후 마지막
+ *   시도에서만 실패시켜 `maxAttempts`까지 무의미하게 폴링했고, 이를 개선했다.
+ * - `status: 'not_found'`는 전용 메시지로 처리한다. 추출 시점에는 union에 없어
+ *   'unknown'으로 흘러 "연결 복구 안됨"이라는 잘못된 메시지가 나갔다.
  * - 응답이 `!res.ok`이면 루프를 `break`하여 "생성 시간이 초과되었습니다" 경로로 떨어진다.
  * - `status: 'completed'`인데 `result`가 없으면 'unknown'과 동일하게 처리된다.
  */


### PR DESCRIPTION
Closes #215

## 문제

파일 헤더가 코드와 **정반대**를 서술하고 있었다.

| | 서술 |
|---|---|
| 헤더 (8~11행) | `` `failed`는 즉시 실패시키지 않고 throw → maxAttempts까지 재시도 `` |
| 코드 (59~64행) | `failed`면 **즉시** `failGeneration` 후 `stop` |
| CLAUDE.md | `` `failed`→**즉시 terminal 실패** `` |

헤더만 옛 동작에 남아 있었다. `**주의(기존 동작 보존)**`이라는 강한 표현이라, 폴링 실패 경로를 손보려는 사람이 **있지도 않은 재시도를 전제로** 판단하게 된다.

## 수정

- `failed` 항목을 현재 동작으로 정정하고, 옛 동작은 "무엇을 개선했는지"의 맥락으로만 남김
- `not_found` 전용 처리 추가 — 이 역시 추출 이후 개선분인데 헤더에 없었다
- `byte-for-byte 보존` 표현 정리 — 추출 당시의 의도였을 뿐 현재 상태가 아니다(그 뒤 두 번 개선됐다)
- 나머지 두 항목(`!res.ok` → `break`, `result` 없는 `completed` → unknown 취급)은 **코드와 대조해 여전히 유효함을 확인**하고 유지

주석만 변경. 로직 변경 없음 — `pnpm vitest run src/lib/generation/` 13건 통과, `type-check` 통과.

## 발견 경위

세션 마무리 점검에서 Grok에 위임한 `src/` 스캔이 후보로 올렸고, 코드·CLAUDE.md와 대조해 확정했다. (같은 스캔의 TODO 마커 30건은 전부 오탐 — `autoFix.ts`가 생성물의 TODO 주석을 *제거하는* 모듈이라 자기 코드에 TODO 문자열이 들어 있다.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)