### PR TITLE
docs: 프로덕션 SQLite 복구 쓰기 리허설 실측 반영 (#222)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,7 +373,7 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 - **temperature deprecated (Claude 4.x)**: Claude 4.x 모델(`claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-opus-4-7`)은 `temperature` 파라미터를 지원하지 않음. ClaudeProvider에서 완전히 제거됨 (Extended Thinking 포함). `IAiPrompt.temperature` 필드는 legacy 호환용으로 유지하나 실제 API 호출에 사용하지 않음
 - **인메모리 rate limit 한계**: proxy의 Map 기반 리밋은 서버 재시작 시 초기화됨 (분당 카운터라 보안 영향 낮음). Railway 단일 인스턴스 전제 — 멀티 인스턴스 전환 시 Redis 등 외부 저장소 필요 (generationTracker와 동일 제약)
 - **이 서비스의 WAL은 캐시가 아니라 데이터 본체다 (복구 시 치명)**: 장기 실행 프로세스가 거의 체크포인트하지 않아 **`/data/app.db`는 4096B·테이블 0개**이고 실데이터는 전부 `app.db-wal`(1.3MB)에 있다(2026-07-30 프로덕션 실측). ① **WAL만 지우면 DB 전체가 사라진다.** ② **백업본으로 app.db만 덮어쓰고 WAL을 남기면 그 WAL이 복구본 위로 재생되어 복구가 조용히 무효화되고 `integrity_check`는 여전히 `ok`를 반환한다**(실측). app.db 교체와 WAL/SHM 제거는 **반드시 한 세트**로 한다. 복구 성공 판정은 `integrity_check`가 아니라 **행 수 대조**다. 절차: [복구 런북](docs/guides/sqlite-restore-runbook.md)
-- **SQLite 자동 백업 (P6.3, 인프로세스)**: `src/lib/db/sqlite/backup.ts`의 `scheduleBackups`가 `instrumentation.register()`에서 배선되어 주기적으로 `raw.backup()` 온라인 덤프를 `<SQLITE 디렉터리>/backups/app-YYYYMMDD-HHmmss.db`로 남기고 보관 정책(`SQLITE_BACKUP_RETENTION`, 기본 7)에 따라 오래된 파일을 정리한다. 타이머는 `.unref()`되어 종료를 막지 않고, `':memory:'`/비활성(`SQLITE_BACKUP_ENABLED=false`) 시 건너뛴다. **단일 인스턴스·동일 볼륨 전제** — 논리 손상·잘못된 마이그레이션·실수 삭제 방어용이며, 볼륨 자체 손실 대비(오프-볼륨 DR)는 Railway 볼륨 스냅샷 또는 Litestream→S3(옵션·비용) 담당. `selectBackupsToPrune`은 `app-<timestamp>.db` 패턴만 후보로 삼아 라이브 DB·WAL/SHM은 절대 삭제하지 않음
+- **SQLite 자동 백업 (P6.3, 인프로세스)**: `src/lib/db/sqlite/backup.ts`의 `scheduleBackups`가 `instrumentation.register()`에서 배선되어 주기적으로 `raw.backup()` 온라인 덤프를 `<SQLITE 디렉터리>/backups/app-YYYYMMDD-HHmmss.db`로 남기고 보관 정책(`SQLITE_BACKUP_RETENTION`, 기본 7)에 따라 오래된 파일을 정리한다. 타이머는 `.unref()`되어 종료를 막지 않고, `':memory:'`/비활성(`SQLITE_BACKUP_ENABLED=false`) 시 건너뛴다. **단일 인스턴스·동일 볼륨 전제** — 논리 손상·잘못된 마이그레이션·실수 삭제 방어용이며, 볼륨 자체 손실 대비(오프-볼륨 DR)는 Railway 볼륨 스냅샷 또는 Litestream→S3(옵션·비용) 담당. `selectBackupsToPrune`은 `app-<timestamp>.db` 패턴만 후보로 삼아 라이브 DB·WAL/SHM은 절대 삭제하지 않음. **부작용**: 백업 파일을 `readonly: true`로 열어 검증만 해도 SQLite가 `<백업명>.db-shm`(32KB)·`.db-wal`(0B)을 백업 디렉터리에 만드는데, 위 패턴에 안 걸려 **영원히 회수되지 않는다**(2026-07-31 리허설에서 발견 — 전 세션 검증 잔재가 남아 있었다). 복구 정확성에는 영향이 없으나(2단계는 `.db`만 복사) 인시던트 중 "이 백업엔 왜 WAL이 붙어 있지?" 혼란을 만든다 → **검증 후 `rm -f /data/backups/*.db-wal /data/backups/*.db-shm`**. 지워도 백업은 `integrity ok`로 남는다(실측)
 - **DB 보존 정책 (무한 증가 테이블)**: `src/lib/db/sqlite/retention.ts`의 `scheduleRetention`이 `instrumentation.register()`에서 백업 스케줄러와 나란히 배선된다(주기 기본 24h, `.unref()`, `':memory:'`·`DB_RETENTION_ENABLED=false` 시 스킵). `generated_codes`만 `pruneOldVersions()`로 정리되고 `platform_events`(모든 도메인 이벤트)·`auth_tokens`·`user_daily_limits`는 삭제 경로가 없어 단조 증가하던 것을 해소. **되돌릴 수 없는 삭제이므로 안전장치 필수**: ① `auth_tokens`는 만료(`expires_at`)됐거나 사용된(`consumed_at`) 토큰만 삭제 — **유효한 미사용 토큰은 절대 삭제 금지**(인증·재설정 링크가 조용히 죽음), ② `user_daily_limits.usage_date`는 로컬 `YYYY-MM-DD`라 cutoff도 `localDateCutoff`(로컬 기준)를 써야 함(UTC로 자르면 타임존에 따라 오늘 카운터 삭제), ③ 세 DELETE는 단일 트랜잭션, ④ `0`·음수·비정수 env는 기본값 폴백(전체 삭제 사고 방지)
 - **배포/생성 레이트리밋 환불 (SQLite)**: 배포·생성 실패 시 `SqliteRateLimitRepository`가 일일 카운터를 in-process로 환불한다(`GREATEST(count-1, 0)`, 동기 트랜잭션). 과거 Supabase PG 함수(`decrement_daily_deploy`/`decrement_daily_generation`, migration 007/021)와 동일 보상 의미를 SQLite 레포 메서드로 재현 — `.rpc()` 호출 없음
 - **생성 상태 폴링 `not_found` 처리**: `/api/v1/generate/status`는 프로젝트 미존재·권한 없음 시 `status: 'not_found'`를 반환한다. `pollGenerationStatus`의 `GenerationStatusData.status` union에 `'not_found'`가 포함되어야 하며(누락 시 'unknown'으로 오처리되어 잘못된 사용자 메시지 표시), 전용 핸들러로 "프로젝트를 찾을 수 없습니다" 메시지를 낸다
@@ -410,27 +410,26 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 
 ## 다음 작업 대기열 (2026-07-31 기준)
 
-**열린 이슈 3건. 코드 작업은 전부 끝났고, 남은 둘은 사용자가 손을 대야 진행된다.**
-2026-07-30 세션에서 #219·#221·#223을 종료했고 #220·#222는 코드·문서까지 끝낸 뒤 마지막 단계만 남겼다.
+**열린 이슈 2건. 코드 작업은 전부 끝났고, 남은 하나는 사용자가 손을 대야 진행된다.**
+2026-07-30 세션에서 #219·#221·#223을, 2026-07-31 세션에서 **#222를 종료**했다. #220만 마지막 단계가 남았다.
 
 | Issue | 상태 | 다음 세션이 할 일 |
 |-------|------|------------------|
-| [#220](https://github.com/xzawed/CustomWebService/issues/220) 에러·알림 sink | **코드 완료**(PR #231) | **`SLACK_WEBHOOK_URL` 값이 등록되면** 합성 경보를 발생시켜 도착 확인. 절차 전부: [monitoring-sink-setup.md](docs/guides/monitoring-sink-setup.md) |
-| [#222](https://github.com/xzawed/CustomWebService/issues/222) SQLite 복구 | **런북·로컬 리허설 완료**(PR #234) | **시간대만 정해지면** 프로덕션 쓰기 리허설. 체크리스트: [복구 런북 하단](docs/guides/sqlite-restore-runbook.md) |
-| [#216](https://github.com/xzawed/CustomWebService/issues/216) 데이터 확보 후 재검토 3건 | 트리거 **전부 미충족**(2026-07-30 실측) | **착수하지 않는다.** 손대면 근거 없는 변경이다. 재확인만 할 것 |
+| [#220](https://github.com/xzawed/CustomWebService/issues/220) 에러·알림 sink | **코드 완료**(PR #231) · **여전히 블로킹** | **`SLACK_WEBHOOK_URL` 값이 등록되면** 합성 경보를 발생시켜 도착 확인. 2026-07-31 실측: 키는 존재하나 **값이 빈 문자열**이라 `sendSlackAlert`는 no-op. 절차 전부: [monitoring-sink-setup.md](docs/guides/monitoring-sink-setup.md) |
+| ~~[#222](https://github.com/xzawed/CustomWebService/issues/222) SQLite 복구~~ | **완료(2026-07-31)** | 프로덕션 쓰기 리허설 성공(총 5분, 롤백 데이터 0건). 실측·발견 사항은 [복구 런북](docs/guides/sqlite-restore-runbook.md) |
+| [#216](https://github.com/xzawed/CustomWebService/issues/216) 데이터 확보 후 재검토 3건 | 트리거 **전부 미충족**(2026-07-31 재확인) | **착수하지 않는다.** 손대면 근거 없는 변경이다. 재확인만 할 것 |
 
-### 착수 전 사용자에게 물어볼 것 (이 둘이 유일한 블로커)
+### 착수 전 사용자에게 물어볼 것 (남은 유일한 블로커)
 
-1. **#220** — Slack webhook URL을 Railway에 등록했는지. **값을 대화로 받지 말 것**(시크릿) — 대시보드에서 직접 설정하도록 안내하고, `railway variable list`로 **키 존재만** 확인한다.
-2. **#222** — 프로덕션 쓰기 리허설을 진행할 **시간대**. 재시작 다운타임 ~30–60초 + 백업 시점 이후 쓰기 롤백이 발생한다.
+1. **#220** — Slack webhook URL을 Railway에 등록했는지. **값을 대화로 받지 말 것**(시크릿) — 대시보드에서 직접 설정하도록 안내하고, `railway variables`로 **키 존재와 값 길이만** 확인한다(키만 있고 값이 비어 있는 상태가 실제로 있었다).
 
 ### #216 트리거 재확인 방법 (변경은 하지 말 것)
 
-| 항목 | 확인 |
-|---|---|
-| site 프록시 한도 | `GET /api/v1/admin/site-proxy-stats` → `trackedProjects`가 0이면 미충족 |
-| 캐시 민감도 플래그 | `src/data/apiCatalog.json`에서 `cache_ttl_seconds` + `auth_type=api_key` + `is_active=true`가 동시에 참인 행이 생겼는지. **기상청 단기·중기예보가 비활성으로 잠들어 있다가 활성화되면 즉시 해당** |
-| adaptive thinking 확대 | 제품 결정. 생성 품질을 올려야 할 필요가 생겼을 때만 |
+| 항목 | 확인 | 2026-07-31 실측 |
+|---|---|---|
+| site 프록시 한도 | `GET /api/v1/admin/site-proxy-stats` → `trackedProjects`가 0이면 미충족 | `trackedProjects: 0` — **미충족** |
+| 캐시 민감도 플래그 | `src/data/apiCatalog.json`에서 `cache_ttl_seconds` + `auth_type=api_key` + `is_active=true`가 동시에 참인 행이 생겼는지. **기상청 단기·중기예보가 비활성으로 잠들어 있다가 활성화되면 즉시 해당** | 동시 충족 **0행** (`cache_ttl_seconds` 보유 14행 중 `api_key`는 기상청 2건뿐이고 둘 다 비활성) — **미충족** |
+| adaptive thinking 확대 | 제품 결정. 생성 품질을 올려야 할 필요가 생겼을 때만 | 트리거 없음 |
 
 ## 세션 시작 체크리스트 (필수)
 

--- a/docs/guides/sqlite-restore-runbook.md
+++ b/docs/guides/sqlite-restore-runbook.md
@@ -48,8 +48,12 @@
 
 ```bash
 railway link            # 프로젝트 연결 확인
-railway ssh "ls -la /data /data/backups"
+railway ssh --service CustomWebService "ls -la /data /data/backups"
 ```
+
+> **`--service CustomWebService`를 붙일 것.** Railway 프로젝트 `xzawed`에는 서비스가 3개
+> (`CustomWebService`·`ArcanaInsight`·`SCAManager`) 있다. 생략하면 엉뚱한 서비스에 붙을 수 있다.
+> 이 문서의 모든 `railway ssh`/`railway redeploy`는 이 플래그를 전제한다.
 
 확인할 것:
 
@@ -75,7 +79,22 @@ b.close();
 `integrity: ok`가 아니거나 행 수가 비정상이면 **그 백업은 쓰지 않는다.** 이전 백업으로 내려간다.
 
 > 경로의 `better-sqlite3@13.0.1`은 버전이 올라가면 바뀐다. 다음으로 찾는다:
-> `railway ssh "find /app -maxdepth 5 -type d -name better-sqlite3"`
+> `railway ssh --service CustomWebService "find /app -maxdepth 5 -type d -name better-sqlite3"`
+
+#### 검증 후 반드시 잔재를 지운다 (2026-07-31 리허설에서 발견)
+
+백업 파일을 **`readonly: true`로 열어도** SQLite가 WAL 모드 DB의 읽기 락을 잡느라
+`<백업명>.db-shm`(32KB)과 `<백업명>.db-wal`(0B)을 백업 디렉터리에 만든다.
+그런데 `selectBackupsToPrune`은 **`app-<timestamp>.db` 패턴만 후보로 삼으므로 이 잔재를 영원히 회수하지 않는다.**
+
+```bash
+railway ssh --service CustomWebService "rm -f /data/backups/*.db-wal /data/backups/*.db-shm"
+```
+
+- **지워도 안전하다** — `.backup()` 산출물은 자기완결 파일이고, 읽기 전용 열기는 데이터를 쓰지 않는다.
+  실측: 잔재 삭제 후 백업 3개 전부 `integrity: ok` + 행 수 정상이었다(백업 파일 mtime도 변하지 않았다).
+- 복구 절차 자체에는 영향이 없다(2단계는 `.db`만 복사한다). **디스크 누수와 인시던트 중 혼란**이 문제다 —
+  "이 백업엔 왜 WAL이 붙어 있지?"를 사고 한복판에서 따지게 된다.
 
 ---
 
@@ -100,6 +119,10 @@ railway ssh "
 `INCIDENT_DIR` 값을 기록해 둔다.
 
 > **`cp`이지 `mv`가 아니다** — 앱이 아직 살아 있는 상태에서 원본을 옮기면 열린 fd와 어긋난다.
+>
+> **`railway ssh`는 root로 붙으므로 `/data/incident-*`는 root 소유로 생성된다**(실측).
+> 앱은 `nextjs`로 도는데 이 디렉터리는 앱이 읽을 필요가 없으니 그대로 둬도 무방하다.
+> 6) 롤백은 root로 `cp -a` 후 `chown nextjs:nodejs`를 하므로 영향받지 않는다.
 
 ### 2) 파일 교체 (앱이 도는 중에 `mv`로 inode 치환)
 
@@ -130,8 +153,8 @@ railway ssh "
 ### 3) 재시작으로 확정
 
 ```bash
-railway deployment list --json | head -20     # 현재 배포 id 확인
-railway redeploy                              # 또는 대시보드에서 Restart
+railway deployment list --json | head -20                 # 현재 배포 id 확인
+railway redeploy --service CustomWebService -y            # 또는 대시보드에서 Restart
 ```
 
 재시작하면 컨테이너가 새 `/data/app.db`를 열고, `instrumentation.register()`가
@@ -139,6 +162,11 @@ railway redeploy                              # 또는 대시보드에서 Restar
 
 배포 상태 판별은 [CLAUDE.md의 "Railway 배포 상태 판별"](../../CLAUDE.md) 절을 따른다
 (신규 커밋이 아니면 `WAITING`이 길게 이어질 수 있다).
+
+> **`railway redeploy`는 단순 재시작이 아니라 이미지 빌드부터 다시 한다.** 실측(2026-07-31):
+> 트리거 → `BUILDING`(~2분 10초) → `DEPLOYING`(~22초) → `SUCCESS`. **트리거에서 SUCCESS까지 2분 32초.**
+> 같은 커밋 재배포라 CI 대기(`WAITING`)는 없었다.
+> 더 짧게 끝내려면 대시보드 **Restart**를 쓴다(빌드를 건너뛴다).
 
 ### 4) 검증 — 무엇을 보고 "성공"이라 하는가
 
@@ -235,45 +263,71 @@ railway redeploy
 |---|---|---|
 | 2026-07-30 | 로컬 (better-sqlite3 13.0.1, Node 24) | 위 "실측으로 확인된 전제" 6항목 전부 확인. 크래시 WAL 재생으로 복구가 무효화되는 것과 구버전 백업 마이그레이션 자동 적용을 포함 |
 | 2026-07-30 | 프로덕션 (읽기 전용 조사) | `/data` 파일 구성·백업 7개 존재·백업본 무결성 `ok`·app.db 단독 테이블 0개 확인 |
-| — | 프로덕션 (쓰기 리허설) | **미수행.** 다운타임이 발생하므로 시간대 합의 후 진행 — 아래 체크리스트 |
-
-> **문서만 쓰고 끝내지 않는다는 것이 이 이슈의 요지다.** 프로덕션 쓰기 리허설을 마치면
-> 실제 소요 시간·걸린 지점을 이 표와 본문에 반영할 것.
+| **2026-07-31** | **프로덕션 (쓰기 리허설)** | **성공.** 위 "복구 절차" 1)~5)를 그대로 실행. 총 5분, 롤백된 데이터 0건. 아래 실측 참조 |
 
 ---
 
-## 프로덕션 쓰기 리허설 실행 체크리스트 (#222 잔여)
+## 프로덕션 쓰기 리허설 실측 (2026-07-31, #222 완료)
 
-> 사용자가 **프로덕션까지 리허설**을 승인했다. 남은 것은 **시간대 합의**뿐이다.
-> 다음 세션은 이 체크리스트만 따르면 되고, 절차 자체는 위 "복구 절차"를 그대로 쓴다.
+절차는 위 "복구 절차"를 **한 줄도 바꾸지 않고** 그대로 따랐다. 중단 조건에 걸린 항목은 없었다.
 
-### 착수 전 사용자 확인 필요 ⚠️
+### 타임라인 (UTC)
+
+| 시각 | 단계 |
+|---|---|
+| 10:19:45 | 1) 사고 상태 보존 → `INCIDENT_DIR=/data/incident-20260731-101945` |
+| 10:20:0x | 2) 파일 교체 — `app.db` 4096B → 417792B, WAL/SHM 제거 확인(`CLEAN`) |
+| 10:20:06 | 3) `railway redeploy` 트리거 |
+| 10:22:16 | `BUILDING` → `DEPLOYING` |
+| 10:22:38 | `SUCCESS` (트리거로부터 **2분 32초**) |
+| 10:22:55 | 4) 검증 개시 — 4항목 전부 통과 |
+| 10:24 | 5) 정리 (`.old` 삭제, `incident-*` 보존) |
+
+> **서비스 중단 시간은 직접 측정하지 않았다.** 배포 단계만 관측했고(`DEPLOYING` 구간 ~22초),
+> 검증 시점의 `/api/v1/health`는 200이었다. 다음 리허설에서 중단 폭을 재려면
+> 재배포 트리거 직후부터 health를 1초 간격으로 폴링할 것.
+
+### 대상 백업과 검증 결과
+
+- 대상: `/data/backups/app-20260730-154416.db` (417792B)
+- 사전 검증: `integrity ok` / FK 0 / 12테이블
+
+| 판정 항목 | 결과 |
+|---|---|
+| `/api/v1/health` | **200** |
+| `integrity_check` | **ok** |
+| `foreign_key_check` | **0행** |
+| 행 수 대조 (12테이블) | **전부 일치** — `api_catalog=61`, `users=2`, `projects=1`, `generated_codes=1`, `platform_events=26`, `project_apis=3`, `auth_tokens=1`, `user_daily_limits=1`, `feature_flags=7`, `__drizzle_migrations=4`, `generation_locks=0`, `user_api_keys=0` |
+| 앱 경유 읽기 end-to-end | 랜딩 200 / `/login` 200 / `/api/v1/projects` **401**(인증 경계 정상) / `/api/v1/catalog` `total=36`(활성 API 수 일치) |
+
+복구 후 부팅 백업 `app-20260731-102217.db`가 새로 생성됐고, 보존 정책(7개)이
+가장 오래된 `app-20260729-165713.db`를 정리했다 — 백업 스케줄러도 함께 검증됐다.
+
+### 사전 재배포는 불필요할 수 있다 (기존 지침 수정)
+
+이전 체크리스트는 "리허설 직전에 배포를 한 번 트리거해 최신 백업을 만든다"였다.
+**백업 이후 쓰기가 없었다면 이 단계는 재시작을 한 번 더 하는 손해일 뿐이다.** 판단 방법:
+
+```bash
+railway ssh --service CustomWebService "ls -la /data /data/backups"
+```
+
+- `app.db-wal`의 mtime이 **대상 백업 시각보다 앞서면** 그 백업 이후 쓰기가 0건이다
+  (WAL 모드에서 모든 쓰기는 `-wal`로 가므로 mtime이 곧 마지막 쓰기 시각).
+- 이번 실측: WAL mtime `07-30 14:31` < 백업 `07-30 15:44` → **롤백 데이터 0건**, 사전 재배포 생략.
+- 라이브 DB와 백업의 행 수를 대조해 교차 확인했다(12테이블 전부 일치).
+
+쓰기가 활발한 시점에 복구해야 한다면 기존 지침대로 **먼저 재배포해 최신 백업을 만든 뒤** 그것을 쓴다.
+
+### 여전히 유효한 착수 전 확인 사항
 
 | 항목 | 내용 |
 |---|---|
-| **시간대** | 재시작 다운타임 ~30–60초. 한국 사용자 기준 저트래픽 시간대를 정할 것 |
-| **데이터 롤백 범위** | 복구 시점 = 사용할 백업의 시각. **그 이후 쓰기는 되돌아간다.** 백업은 배포마다 + 24h 주기로 생성되므로, 최근 배포 직후라면 손실 폭이 거의 없다 |
+| **시간대** | 저트래픽 시간대를 고를 것. `railway redeploy`는 빌드부터 다시 하므로 트리거~복귀에 **2분 30초 안팎**이 든다(대시보드 Restart는 더 짧다) |
+| **데이터 롤백 범위** | 복구 시점 = 사용할 백업의 시각. 그 이후 쓰기는 되돌아간다. 위 WAL mtime 비교로 폭을 미리 잴 것 |
 | **인플라이트 쓰기** | `mv`와 재시작 사이의 쓰기는 unlink된 옛 inode로 흘러가 유실된다 |
 
-### 손실을 최소화하는 순서
-
-1. **리허설 직전에 배포를 한 번 트리거**한다(예: 무해한 재배포).
-   부팅 시 `scheduleBackups`가 즉시 백업을 뜨므로 **가장 최신 시점의 백업**이 생긴다.
-2. 그 백업 파일명을 복구 대상으로 쓴다 → 롤백되는 데이터가 사실상 없다.
-
-### 실행
-
-1. [ ] 사전 준비 — `railway ssh "ls -la /data /data/backups"`로 대상 백업 확정
-2. [ ] **복구 대상 백업 검증** (`integrity_check` + 행 수 기록) — 이 수치가 4단계 판정 기준이 된다
-3. [ ] 1) 사고 상태 보존 → `INCIDENT_DIR` 기록
-4. [ ] 2) 파일 교체 — **WAL/SHM이 남아 있으면 재시작 금지**
-5. [ ] 3) `railway redeploy`
-6. [ ] 4) 검증 4항목 (health 200 / `integrity ok` / FK 0 / **행 수 대조** / 로그인 end-to-end)
-7. [ ] 5) 정리 (`.old` 삭제, `/data/incident-*`는 보존)
-8. [ ] 실제 소요 시간·걸린 지점을 위 "리허설 기록" 표와 본문에 반영
-9. [ ] [#222](https://github.com/xzawed/CustomWebService/issues/222) 종료
-
-### 중단 조건
+### 중단 조건 (다음 리허설·실제 복구에도 그대로 적용)
 
 아래 중 하나라도 나오면 **즉시 6) 롤백**으로 간다.
 


### PR DESCRIPTION
## 배경

[#222](https://github.com/xzawed/CustomWebService/issues/222)의 마지막 남은 단계였던 **프로덕션 쓰기 리허설**을 수행했다.
런북([sqlite-restore-runbook.md](docs/guides/sqlite-restore-runbook.md))의 "복구 절차" 1)~5)를 **한 줄도 바꾸지 않고** 그대로 실행했고, 중단 조건에 걸린 항목은 없었다.

## 결과 — 성공 (총 5분, 롤백된 데이터 0건)

| 판정 항목 | 결과 |
|---|---|
| `/api/v1/health` | 200 |
| `integrity_check` | ok |
| `foreign_key_check` | 0행 |
| 행 수 대조 | **12테이블 전부 일치** (`api_catalog=61`, `users=2`, `projects=1`, …) |
| 앱 경유 읽기 | 랜딩 200 · `/login` 200 · `/api/v1/projects` 401 · `/api/v1/catalog` `total=36` |

대상 백업 `app-20260730-154416.db`. WAL mtime(`07-30 14:31`)이 백업 시각(`15:44`)보다 앞서 **백업 이후 쓰기가 0건**이었으므로 사전 재배포를 생략했고, 라이브 DB와 행 수를 대조해 교차 확인했다.

복구 후 부팅 백업이 새로 생성되고 보존 정책(7개)이 최고령 백업을 정리한 것까지 확인 — 백업 스케줄러도 함께 검증됐다.

## 리허설이 드러낸 것 (문서만 썼으면 못 찾았을 것들)

1. **백업 검증 잔재가 회수되지 않는다.** 백업 파일을 `readonly: true`로 열어도 SQLite가 WAL 읽기 락 때문에 `<백업명>.db-shm`(32KB)·`.db-wal`(0B)을 만드는데, `selectBackupsToPrune`이 `app-<timestamp>.db` 패턴만 후보로 삼아 **영원히 남는다**. 전 세션 검증 잔재가 실제로 남아 있었다.
   - 복구 정확성에는 무해하다(2단계는 `.db`만 복사) — 문제는 디스크 누수와 **인시던트 중 혼란**이다.
   - 잔재 삭제 후 백업 3개 전부 `integrity ok`·행 수 정상임을 확인하고 절차에 편입했다.
2. **사전 재배포는 조건부로 불필요하다.** 기존 체크리스트는 무조건 재배포를 시켰으나, WAL mtime이 대상 백업 시각보다 앞서면 재시작을 한 번 더 하는 손해일 뿐이다. 판단 방법을 명문화했다.
3. `railway redeploy`는 단순 재시작이 아니라 **빌드부터 다시 한다** — 트리거~`SUCCESS` 2분 32초. 더 짧게 끝내려면 대시보드 Restart.
4. `railway ssh`는 root로 붙어 `/data/incident-*`가 root 소유로 생성된다(롤백 절차에는 영향 없음).
5. Railway 프로젝트에 서비스가 3개라 `--service CustomWebService`가 필요하다 — 런북 전 명령에 반영.

## 정직하게 남긴 한계

**서비스 중단 폭은 직접 측정하지 않았다.** 배포 단계만 관측했고(`DEPLOYING` 구간 ~22초) 검증 시점 health는 200이었다. 다음 리허설에서 재는 방법(재배포 직후부터 health 1초 폴링)을 런북에 남겼다.

## 함께 갱신

- `CLAUDE.md` 대기열 — #222 종료, 남은 블로커는 #220 하나
- `CLAUDE.md` #216 트리거 표 — 2026-07-31 재확인 실측치 기입(3건 전부 미충족 → **착수하지 않음**)
- `CLAUDE.md` 백업 항목 — 검증 잔재 가정 추가

## 변경 범위

문서만 변경(`CLAUDE.md`, 런북). 소스 코드 변경 없음.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)
