### PR TITLE
fix: 알림 sink 등록·실경보 도착 검증 완료 + 브라우저 산출물 무시 (#220)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,8 @@ test-results/
 # 임시 검증 산출물
 verification-report.json
 verify.log
+
+# Playwright MCP 브라우저 산출물(스냅샷·콘솔 로그·스크린샷)
+# 접근성 스냅샷은 페이지에 보이는 값을 그대로 담는다 — 2026-07-31에 Slack Incoming Webhook URL이
+# 평문으로 기록된 것을 실제로 확인했다. 커밋되면 라이브 시크릿이 유출되므로 반드시 무시한다.
+.playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 - `MAX_APIS_PER_PROJECT`, `MAX_DAILY_GENERATIONS` 등 제한 설정
 - `AI_MODEL_SUGGESTION` — 추천용 모델 (기본: `claude-haiku-4-5`)
 - `AI_MODEL_GENERATION` — 코드 생성 모델 (기본: `claude-opus-5`, Sonnet 폴백: `claude-sonnet-5`)
-- `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN` / `SLACK_WEBHOOK_URL` — 에러·알림 sink. **Slack만 사용**(`errorRateMonitor` 생성 실패율 + `scheduleBackups` 백업 실패/복구 → `sendSlackAlert`). **Sentry는 의도적으로 미도입**(#220). `SLACK_WEBHOOK_URL`이 Railway에 실제로 설정되기 전까지 경보는 여전히 유실된다(`sendSlackAlert` no-op)
+- `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN` / `SLACK_WEBHOOK_URL` — 에러·알림 sink. **Slack만 사용**(`errorRateMonitor` 생성 실패율 + `scheduleBackups` 백업 실패/복구 → `sendSlackAlert`). **Sentry는 의도적으로 미도입**(#220). `SLACK_WEBHOOK_URL`은 **2026-07-31에 등록·실경보 도착까지 검증 완료** — 경보는 xzawed 워크스페이스 `#alerts` 채널로 간다. **빈 문자열은 미설정과 같다**(`if (!webhookUrl)` no-op) — 점검 시 키 존재가 아니라 **값 길이**를 볼 것. 절차·실측: [monitoring-sink-setup.md](docs/guides/monitoring-sink-setup.md)
 - `LOG_LEVEL` — 로그 상세도 (`debug`/`info`/`warn`/`error`, 기본 `info`)
 - `ET_COMPLEXITY_THRESHOLD` — Extended Thinking 활성화 임계값 (기본: 35점, `evaluateComplexityScore()` 결과 비교)
 - `QUALITY_LOOP_ITERATION_TIMEOUT_MS` — Quality Loop 반복당 타임아웃 (기본: 120000ms = 120초)
@@ -410,18 +410,22 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 
 ## 다음 작업 대기열 (2026-07-31 기준)
 
-**열린 이슈 2건. 코드 작업은 전부 끝났고, 남은 하나는 사용자가 손을 대야 진행된다.**
-2026-07-30 세션에서 #219·#221·#223을, 2026-07-31 세션에서 **#222를 종료**했다. #220만 마지막 단계가 남았다.
+**열린 이슈는 #216 하나이고, 그것은 "착수하지 않는다"가 결론이다.**
+2026-07-30 세션에서 #219·#221·#223을, 2026-07-31 세션에서 **#220·#222를 종료**했다.
 
 | Issue | 상태 | 다음 세션이 할 일 |
 |-------|------|------------------|
-| [#220](https://github.com/xzawed/CustomWebService/issues/220) 에러·알림 sink | **코드 완료**(PR #231) · **여전히 블로킹** | **`SLACK_WEBHOOK_URL` 값이 등록되면** 합성 경보를 발생시켜 도착 확인. 2026-07-31 실측: 키는 존재하나 **값이 빈 문자열**이라 `sendSlackAlert`는 no-op. 절차 전부: [monitoring-sink-setup.md](docs/guides/monitoring-sink-setup.md) |
+| ~~[#220](https://github.com/xzawed/CustomWebService/issues/220) 에러·알림 sink~~ | **완료(2026-07-31)** | Slack 앱 `xzawed alerts` + `#alerts` 채널 신설, `SLACK_WEBHOOK_URL` 등록, **실제 백업 실패 경보 도착 확인**. 실측: [monitoring-sink-setup.md](docs/guides/monitoring-sink-setup.md) |
 | ~~[#222](https://github.com/xzawed/CustomWebService/issues/222) SQLite 복구~~ | **완료(2026-07-31)** | 프로덕션 쓰기 리허설 성공(총 5분, 롤백 데이터 0건). 실측·발견 사항은 [복구 런북](docs/guides/sqlite-restore-runbook.md) |
 | [#216](https://github.com/xzawed/CustomWebService/issues/216) 데이터 확보 후 재검토 3건 | 트리거 **전부 미충족**(2026-07-31 재확인) | **착수하지 않는다.** 손대면 근거 없는 변경이다. 재확인만 할 것 |
 
-### 착수 전 사용자에게 물어볼 것 (남은 유일한 블로커)
+### 알림 sink가 살아난 뒤 판단할 것 (ADR이 보류로 남긴 항목)
 
-1. **#220** — Slack webhook URL을 Railway에 등록했는지. **값을 대화로 받지 말 것**(시크릿) — 대시보드에서 직접 설정하도록 안내하고, `railway variables`로 **키 존재와 값 길이만** 확인한다(키만 있고 값이 비어 있는 상태가 실제로 있었다).
+실경보를 받아 본 뒤에 정하기로 미뤄 둔 것들이다. 지금부터는 판단 근거가 쌓인다.
+
+- `ERROR_RATE_ALERT_THRESHOLD`(기본 5회/5분) 조정 — 실제 경보 빈도를 보고
+- 다일 장애 재알림(시간 윈도 리마인더) — 전이 1회로 충분한지
+- 배포 레이트리밋 환불 실패·이벤트 persist 실패 등 best-effort 경로에 경보를 붙일지
 
 ### #216 트리거 재확인 방법 (변경은 하지 말 것)
 

--- a/docs/decisions/2026-07-30-monitoring-sink-slack-only.md
+++ b/docs/decisions/2026-07-30-monitoring-sink-slack-only.md
@@ -102,16 +102,44 @@ Sentry 관련 env와 config 파일은 코드에 남겨 둔다 — 지우면 나�
 better-sqlite3 백업 오류는 대체로 EACCES·디스크 풀·경로라 시크릿 유출 위험은 낮지만
 표면을 좁게 유지한다.
 
-## 아직 완료되지 않은 것 (#220은 열려 있다)
+## 완료 확인 (2026-07-31, #220 종료)
 
-**이 PR은 코드 배선까지다.** `SLACK_WEBHOOK_URL`이 Railway에 실제로 설정되기 전까지
-sink는 비활성이고 경보는 여전히 유실된다. 남은 완료 조건:
+코드 배선(PR #231) 이후 남아 있던 두 조건을 모두 충족했다.
 
-- [ ] `SLACK_WEBHOOK_URL`을 Railway에 등록 (webhook URL 값이 필요 — 사용자 제공 대기)
-- [ ] **합성 경보를 한 번 발생시켜 실제 도착 확인** — 설정만 하고 끝내지 않는다
+- [x] `SLACK_WEBHOOK_URL`을 Railway에 등록 — xzawed 워크스페이스에 Slack 앱 `xzawed alerts` 생성,
+      전용 채널 **`#alerts`** 신설 후 Incoming Webhook 발급·등록
+- [x] **합성 경보로 실제 도착 확인** — 관리자 엔드포인트를 새로 만들지 않고
+      `SQLITE_BACKUP_DIR=/etc/cws-probe-backups` 프로브로 **실제 백업 실패 경로**를 유발
 
-값을 넣지 않은 상태로 배포해도 안전하다 — `sendSlackAlert`가 no-op이라 동작 변화가 없고,
-로그에는 `SLACK_WEBHOOK_URL 미설정` 경고가 남아 미설정 사실이 드러난다.
+도착한 경보(원문):
+
+```
+🔴 SQLite 백업 실패
+주기 백업이 실패했습니다. 볼륨·디스크·경로를 확인하세요.
+• dir: /etc/cws-probe-backups
+• error: EACCES: permission denied, mkdir '/etc/cws-probe-backups'
+• consecutiveFailures: 1
+환경: production | 2026-07-31T11:37:58.263Z
+```
+
+### 실측으로 확인된 설계 가정
+
+| 가정 | 실측 |
+|---|---|
+| `null → fail` 전이 시 error 경보 1회 | **확인** — 부팅 백업 실패로 1건 도착 |
+| 연속 실패 억제(매 주기 경보 금지) | **확인** — 실패 상태가 지속됐으나 추가 경보 없음 |
+| env 되돌림·재배포로는 **복구 경보를 검증할 수 없다** | **확인** — 프로브 제거 후 백업이 정상 재개됐지만 복구 경보는 오지 않았다. `healthy`가 클로저 로컬이라 새 프로세스에선 `null → true`(첫 성공)이지 `fail → success`(복구)가 아니다 |
+| 알림 실패가 스케줄러를 죽이지 않음 | 이번 검증 범위 밖(전이 매트릭스 6종은 단위 테스트가 고정) |
+
+프로브는 원복했다(`SQLITE_BACKUP_DIR` 삭제 → **수동 재배포**). `variableDelete`는 재배포를 트리거하지
+않는다는 기존 실측이 GraphQL 경로에서도 그대로 재현됐다. 원복 후 부팅 백업 `app-20260731-114008.db`가
+정상 생성되고 `/etc/cws-probe-backups`는 남지 않았다.
+
+### 빠지기 쉬운 함정 — 빈 문자열은 미설정과 같다
+
+검증 전 프로덕션은 **키는 존재하는데 값이 빈 문자열**이었다. `sendSlackAlert`가 `if (!webhookUrl)`로
+판정하므로 크래시 없이 조용히 no-op이 된다. `railway variables`에서 **키 존재만 보면 설정된 것처럼
+보이므로 값 길이를 확인해야 한다.**
 
 ## 이번 범위에서 의도적으로 제외
 

--- a/docs/guides/monitoring-sink-setup.md
+++ b/docs/guides/monitoring-sink-setup.md
@@ -1,12 +1,16 @@
 # 알림 sink 설정 및 검증 (#220)
 
-> **상태**: 코드 배선 완료(PR #231). **`SLACK_WEBHOOK_URL` 등록과 도착 확인만 남았다.**
-> 배경·결정: [ADR](../decisions/2026-07-30-monitoring-sink-slack-only.md)
+> **상태**: ✅ **완료(2026-07-31).** 코드 배선(PR #231) → `SLACK_WEBHOOK_URL` 등록 → 합성 경보 도착 확인까지 끝났다.
+> 경보는 xzawed 워크스페이스 **`#alerts`** 채널(Slack 앱 `xzawed alerts`)로 간다.
+> 배경·결정·실측: [ADR](../decisions/2026-07-30-monitoring-sink-slack-only.md)
 
 sink는 **Slack 하나로 고정**했다. Sentry는 의도적으로 도입하지 않는다(env·config는 되돌릴 수 있게 보존).
 
-현재 `SLACK_WEBHOOK_URL`이 비어 있어 `sendSlackAlert`는 `logger.warn` 한 줄만 남기고 반환한다 —
-**경보 경로는 살아 있으나 아무 곳에도 도착하지 않는다.**
+아래 절차는 **webhook을 재발급하거나 채널을 옮길 때** 다시 쓰는 문서다.
+
+> ⚠️ **빈 문자열은 미설정과 같다.** `sendSlackAlert`는 `if (!webhookUrl)`로 판정하므로 키만 있고
+> 값이 비면 크래시 없이 조용히 no-op이 된다 — 2026-07-31 이전 프로덕션이 정확히 이 상태였다.
+> 점검할 때 **키 존재가 아니라 값 길이**를 확인할 것.
 
 ---
 
@@ -134,12 +138,32 @@ railway ssh "rm -rf /data/probe"
 
 ---
 
-## 5. 완료 후 갱신할 것
+## 5. 2026-07-31 실행 기록
 
-- [ ] [#220](https://github.com/xzawed/CustomWebService/issues/220) 종료
-- [ ] [CLAUDE.md](../../CLAUDE.md)의 `SENTRY_DSN`/`SLACK_WEBHOOK_URL` 항목에서 "설정 전까지 유실" 문구 갱신
-- [ ] [env-vars.md](../reference/env-vars.md) 모니터링 절의 ⚠️ 경고 갱신
-- [ ] [ADR](../decisions/2026-07-30-monitoring-sink-slack-only.md)의 "아직 완료되지 않은 것" 절에 도착 확인 결과 기록
+위 절차를 그대로 수행해 **A(실패 경보만)로 완료 조건을 충족**했다.
+
+| 시각(UTC) | 단계 |
+|---|---|
+| 11:07 | Slack 앱 `xzawed alerts` 생성 · Incoming Webhooks On · `#alerts` 채널 신설 후 웹훅 발급 |
+| 11:18 | 웹훅 단독 스모크 테스트 — `HTTP 200 / ok`, 메시지 도착 확인 |
+| 11:29 | `SLACK_WEBHOOK_URL` 등록 → 자동 재배포 → 11:34 `SUCCESS` |
+| 11:35 | 프로브 `SQLITE_BACKUP_DIR=/etc/cws-probe-backups` 설정 → 재배포 → 11:37:59 `SUCCESS` |
+| 11:37:58 | 🔴 **SQLite 백업 실패 경보 `#alerts` 도착** (EACCES, `consecutiveFailures: 1`) |
+| 11:38 | 프로브 삭제 → **수동 재배포**(delete는 트리거 안 함) → 11:40:28 `SUCCESS` |
+| 11:40 | 백업 정상 재개(`app-20260731-114008.db`), `/etc/cws-probe-backups` 잔재 없음 |
+
+B(복구 경보)는 건너뛰었다. 대신 **복구 경보가 오지 않는다는 것 자체를 확인**했다 — 재배포로
+`healthy`가 리셋되어 `null → true`(첫 성공)가 되기 때문이며, 이 문서 4절의 제약 설명과 일치한다.
+
+### 걸린 지점 (다음에 반복하지 말 것)
+
+- **Railway CLI가 약 15분간 전 요청 타임아웃**했다. GraphQL 엔드포인트는 같은 시각 0.18초에 200을 반환했으므로
+  API 장애가 아니라 CLI 문제다. 막히면 `backboard.railway.com/graphql/v2`에 직접 `variableUpsert`/
+  `deploymentRedeploy`를 호출해 우회할 수 있다(토큰은 `~/.railway/config.json`).
+- **Git Bash에서 `/etc/...` 같은 값을 인자로 넘기면 MSYS 경로 변환이 `C:/Program Files/Git/etc/...`로 망가뜨린다.**
+  리눅스에서는 상대경로로 해석돼 mkdir이 **성공**하므로 프로브가 조용히 무효가 된다. `MSYS_NO_PATHCONV=1`을 붙일 것.
+- **브라우저 자동화로 이 작업을 하면 스냅샷 파일에 webhook URL이 평문으로 남는다.**
+  `.playwright-mcp/`를 `.gitignore`에 넣어 둔 이유다(2026-07-31 추가).
 
 ---
 

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -115,10 +115,14 @@ DB 어댑터 없는 JWT 무상태 세션. 공개 셀프서비스 회원가입, D
 
 ## 모니터링
 
-> ⚠️ **알림 sink는 Slack으로 고정했다. Sentry는 의도적으로 도입하지 않는다** (#220).
+> ✅ **알림 sink는 Slack으로 고정했고 2026-07-31에 실경보 도착까지 검증됐다** (#220).
 > 코드 경로: `errorRateMonitor`(생성 실패율) + `scheduleBackups`(SQLite 백업 실패·복구, 상태 전이 1회 경보) → `sendSlackAlert`.
-> **`SLACK_WEBHOOK_URL`이 Railway에 실제로 설정되기 전까지 sink는 비활성이다** — `sendSlackAlert`는 경고 로그만 남기고 반환하므로 경보는 여전히 유실된다.
+> `SLACK_WEBHOOK_URL`은 Railway에 설정되어 있고 경보는 xzawed 워크스페이스 **`#alerts`** 채널로 간다.
 > Sentry 관련 env(`SENTRY_DSN` 등)는 코드에 남아 있으나 미사용·미도입 결정. 값을 넣지 않는 것이 기본이다.
+>
+> **주의: 빈 문자열은 미설정과 같다.** `sendSlackAlert`는 `if (!webhookUrl)`로 판정하므로 키만 있고 값이 비면
+> 크래시 없이 조용히 no-op이 된다(2026-07-31 이전 프로덕션이 정확히 이 상태였다).
+> 확인할 때 **키 존재가 아니라 값 길이**를 볼 것.
 
 | 변수 | 필수 | Railway | 설명 |
 |------|------|---------|------|
@@ -127,7 +131,7 @@ DB 어댑터 없는 JWT 무상태 세션. 공개 셀프서비스 회원가입, D
 | `SENTRY_ORG` | 선택 | ❌ | (미도입) Sentry 조직 슬러그 (소스맵 업로드용) |
 | `SENTRY_PROJECT` | 선택 | ❌ | (미도입) Sentry 프로젝트 슬러그 |
 | `SENTRY_AUTH_TOKEN` | 선택 | ❌ | (미도입) Sentry 소스맵 업로드 토큰 |
-| `SLACK_WEBHOOK_URL` | 선택 | ❌ | **활성 알림 sink.** Slack Incoming Webhook URL. 미설정 시 알림 스킵(로그 한 줄). `sendSlackAlert` ← `errorRateMonitor` + `scheduleBackups` 백업 실패/복구 |
+| `SLACK_WEBHOOK_URL` | 선택 | ✅ | **활성 알림 sink (2026-07-31 설정·검증 완료).** Slack Incoming Webhook URL → xzawed 워크스페이스 `#alerts`. 미설정·**빈 문자열**이면 알림 스킵(로그 한 줄). `sendSlackAlert` ← `errorRateMonitor` + `scheduleBackups` 백업 실패/복구 |
 | `ERROR_RATE_ALERT_THRESHOLD` | 선택 | ➖ | 코드 생성 실패율 알림 임계값 (기본: `5`). 5분 윈도우 내 `CODE_GENERATION_FAILED` 횟수가 이 값 이상이면 Slack 알림 1회 발송 (윈도우 내 중복 알림 방지). 인메모리·단일 인스턴스 전제. 코드 위치: `src/lib/monitoring/errorRateMonitor.ts` |
 | `LOG_LEVEL` | 선택 | ➖ | 로그 상세도 임계값 (`debug`/`info`/`warn`/`error`, 기본 `info`). 이 값보다 낮은 레벨은 출력하지 않는다. 코드 위치: `src/lib/utils/logger.ts` |
 


### PR DESCRIPTION
## 배경

[#220](https://github.com/xzawed/CustomWebService/issues/220)의 코드 배선은 PR #231에서 끝났고, 남은 것은 **`SLACK_WEBHOOK_URL` 등록과 실제 도착 확인**이었다. 이번에 둘 다 완료했다.

## 수행한 것

- Slack 앱 `xzawed alerts` 생성(xzawed 워크스페이스) + **전용 채널 `#alerts` 신설**
- Incoming Webhook 발급 → `SLACK_WEBHOOK_URL` Railway 등록 → 재배포 반영
- 관리자 엔드포인트를 새로 만들지 않고, [가이드](docs/guides/monitoring-sink-setup.md)의 A 절차대로 `SQLITE_BACKUP_DIR=/etc/cws-probe-backups` 프로브로 **실제 백업 실패 경로**를 유발

도착한 경보 — 가이드가 예고한 문구·EACCES 에러까지 정확히 일치:

```
🔴 SQLite 백업 실패
주기 백업이 실패했습니다. 볼륨·디스크·경로를 확인하세요.
• dir: /etc/cws-probe-backups
• error: EACCES: permission denied, mkdir '/etc/cws-probe-backups'
• consecutiveFailures: 1
환경: production | 2026-07-31T11:37:58.263Z
```

프로브는 원복했고(삭제 → **수동 재배포**), 백업이 `app-20260731-114008.db`로 정상 재개되며 `/etc/cws-probe-backups` 잔재도 없음을 확인했다.

## 실측으로 확인된 설계 가정

| 가정 | 결과 |
|---|---|
| `null → fail` 전이 시 error 경보 1회 | **확인** |
| 연속 실패 억제(매 주기 경보 금지) | **확인** — 추가 경보 없음 |
| env 되돌림·재배포로는 **복구 경보를 검증할 수 없다** | **확인** — 백업이 정상 재개됐지만 복구 경보는 오지 않았다. `healthy`가 클로저 로컬이라 새 프로세스에선 `null → true`(첫 성공)이지 `fail → success`가 아니다 |
| `variableDelete`는 재배포를 트리거하지 않는다 | **확인** — GraphQL 경로에서도 동일. 수동 재배포 필수 |

## 빠지기 쉬운 함정을 문서에 고정

검증 전 프로덕션은 **키는 존재하는데 값이 빈 문자열**이었다. `sendSlackAlert`가 `if (!webhookUrl)`로 판정하므로 크래시 없이 조용히 no-op이 되고, `railway variables`에서 키 존재만 보면 설정된 것처럼 보인다. **값 길이를 확인하라**고 CLAUDE.md·env-vars.md·setup 가이드 세 곳에 명시했다.

## `.gitignore`에 `.playwright-mcp/` 추가 (보안)

브라우저 자동화로 이 작업을 하는 동안 접근성 스냅샷 2개에 **라이브 webhook URL이 평문으로** 기록된 것을 확인했다. 이 디렉터리는 untracked이면서 무시되지도 않아 `git add -A` 한 번이면 시크릿이 커밋된다.

- 커밋 이력 유출 여부 확인 → **없음** (`git log --all -- .playwright-mcp/` 0건)
- 재발을 구조적으로 차단(주의 문구가 아니라 `.gitignore`로)

## 변경 범위

문서 4개 + `.gitignore`. **소스 코드 변경 없음.**

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)
