### PR TITLE
fix: 생성 성공이 늦은 폴링 실패로 뒤집히던 버그 수정 + 이메일 설정 관측 수단

### DIFF
--- a/docs/architecture/system-spec.md
+++ b/docs/architecture/system-spec.md
@@ -198,7 +198,25 @@ Opus 4.8은 생략 = 사고 없음이었지만 **Opus 5는 생략 시 adaptive�
 - 적용 여부는 `GET /api/v1/admin/debug`의 `models.<task>.fellBack`이 `false`인지로 확인한다
 - **구세대 ID를 목록에서 지우지 말 것** — 지우면 env를 되돌리는 **롤백이 무시된다**
 
-### 3.6 Alpine 이중 init은 warnings로만 올린다
+### 3.6 🔇 생성 상태는 터미널 래치를 갖는다 — 먼저 도착한 종료가 이긴다
+
+`generationStore`의 `updateProgress`·`completeGeneration`·`failGeneration`은
+**`status === 'generating'`일 때만** 상태를 바꾼다. `startGeneration`만 무조건적이다(재시도 진입점).
+
+**깨지면**: 생성은 SSE + 폴링 **이중 경로**로 돈다. 탭 복귀 시 `visibilitychange`가
+`void pollForCompletion(...)`으로 폴링을 fire-and-forget 시작하는데 `pollGenerationStatus`에는
+**abort가 없다.** 페이지의 `generationCompleted`·`switchedToPolling` 플래그는 *두 번째 폴링 시작*만
+막을 뿐 **이미 도는 폴링을 멈추지 못한다.**
+
+그래서 SSE가 `complete`를 준 뒤에도 살아 있는 폴링이 타임아웃·tracker TTL 만료로 `failGeneration`을
+부르면, 가드가 없을 때 **성공이 실패로 뒤집혀 사용자가 성공 직후 에러 화면을 본다.**
+`pollGenerationStatus`에는 `failGeneration` 호출부가 5곳이라 이 경로가 그만큼 많다.
+
+> **이 래치는 안전벨트이고 근본 해결이 아니다.** 근본 해결은 폴링 취소(단일 terminal owner)이며
+> [WBS의 E3 순서](../superpowers/plans/2026-07-31-project-wbs.md)에 P3로 잡혀 있다.
+> 그 전까지 이 가드를 제거하지 말 것. `generationStore.test.ts`가 5가지 역전 순서를 고정한다.
+
+### 3.7 Alpine 이중 init은 warnings로만 올린다
 
 `detectAlpineDoubleInit()`이 검출하되 `errors`가 아니라 `warnings`다 — 보안 문제가 아니므로 게시를 막지 않는다.
 검출 규칙은 **JS 본문을 보지 않는다**(`x-init`이 `init`을 부르면 정의돼 있으면 이중 실행, 없으면 ReferenceError라 어느 쪽이든 버그).

--- a/docs/superpowers/plans/2026-07-31-project-wbs.md
+++ b/docs/superpowers/plans/2026-07-31-project-wbs.md
@@ -41,7 +41,7 @@
 | ID | 작업 | 크기 |
 |----|------|------|
 | **B1** | **`AUTH_URL=https://xzawed.xyz` Railway 등록.** 현재 미설정이라 `callback-url`이 `0.0.0.0:8080`이다. `AUTH_TRUST_HOST=true`라 로그인은 동작해 영향은 낮지만, **`env-vars.md`에 행 자체가 없어** 문서 추가도 함께 필요 | S |
-| **B2** | **`RESEND_API_KEY`·`EMAIL_FROM` 실제 설정 여부 확인.** 미설정이면 인증 메일이 no-op → `assertEmailVerified()`가 generate·regenerate·deploy를 403으로 막아 **신규 사용자가 제품을 아예 못 쓴다.** 확인 후 문서의 상태 컬럼 갱신 | S |
+| **B2** | **`RESEND_API_KEY`·`EMAIL_FROM` 실제 설정 여부 확인.** 미설정이면 인증 메일이 no-op → `assertEmailVerified()`가 generate·regenerate·deploy를 403으로 막아 **신규 사용자가 제품을 아예 못 쓴다.** → **2026-07-31에 관측 수단을 만들었다**: `GET /api/v1/admin/debug`의 `email.configured`/`fromSet`/`fromDomain`(값은 미노출). 배포 후 이 엔드포인트로 확인하면 되고 Railway 콘솔이 더 이상 필요 없다 | S |
 | B3 | 키 의존 API **24개 재활성화** (카탈로그 61행 중 활성 36 / 비활성 25) | M |
 | B4 | 프록시 키 prefix **실키 검증**(`needsPrefixFix`) — 코드는 완료, 실키로 확인된 적 없음 | S |
 | B5 | Unsplash Production 심사 (Demo는 50건/시간) | S |
@@ -119,7 +119,7 @@
 |----|------|------|
 | E1 | ~~커버리지 집계 설정 정합화~~ | **완료(2026-07-31)** |
 | E2 | ~~클라이언트 상태·훅 테스트~~ | **완료(2026-07-31)** — 스토어 6 + `usePublish` |
-| E3 | builder 생성 핸들러 추출 + 테스트 (T1) | L |
+| E3 | builder 생성 핸들러 추출 + 테스트 (T1) — **아래 P0~P4로 분할**. P0은 완료 | L |
 | E4 | 라우트 테스트 (T2: `projects/[id]`, `popular-services`) | S |
 | E5 | 약한 테스트 보강 (T4 PublishDialog 실패 분기, T5 템플릿 11종 계약) | M |
 | E6 | **E2E 확장 (T3)** — 미리보기↔게시 동등성, Host 헤더 서브도메인, 인증·생성·게시 | L |
@@ -127,6 +127,31 @@
 
 > **E6이 가장 값어치가 크다.** [테스트 지도 5절](../../reference/test-coverage-map.md)의
 > "단위 테스트로 구조적으로 못 잡는 결함" 4종의 유일한 방어선이다.
+
+### E3 분할 계획 — 한 PR로 하지 않는다 (2026-07-31 설계 협의 결과)
+
+`builder/page.tsx`의 `handleGenerate`(:173)는 **인지 복잡도 48**(SonarCloud 최악)이고 테스트가 0건이다.
+단순히 파일을 옮기면 **복잡도가 그대로 따라오고** 안전망 없이 프로덕션 결제 인접 경로를 건드리게 된다.
+
+| 단계 | 내용 | 상태 |
+|---|---|---|
+| **P0** | **스토어 터미널 래치 + 역전 순서 테스트 5종.** 페이지를 건드리지 않고 성공↔실패 역전을 먼저 막는다 | ✅ **완료(2026-07-31)** |
+| P1 | `parseSseBlocks` + `consumeGenerationStream` 추출 + **특성화 테스트**(현 동작을 그대로 고정, 고치지 않는다) | 대기 |
+| P2 | `runClientGeneration` 추출, 페이지 `handleGenerate`를 얇은 래퍼로 | 대기 |
+| P3 | **폴링 취소(단일 terminal owner)** — `pollGenerationStatus`에 abort 도입. 여기서 P1의 특성화 테스트를 새 계약으로 뒤집는다 | 대기 |
+| P4 | `RePromptPanel`이 같은 스트림 헬퍼를 재사용 (지금은 SSE+폴링을 사설로 복제하고 있다) | 선택 |
+
+**설계 원칙 (협의로 확정)**
+
+- 추출 단위는 **커스텀 훅이 아니라 `src/lib/generation/` 아래 순수 DI 함수**다.
+  잡으려는 버그가 렌더가 아니라 **순서·종료 경합**이므로, `pollGenerationStatus` 선례를 따른다
+- **페이지에 남는 것**: `useRouter`·JSX·빌더 스텝 상태가 필요한 모든 것.
+  **나가는 것**: `fetch` + 스트림 + 콜백만 필요한 모든 것
+- **P1에서 동작을 고치지 않는다.** 기계적 이동 버그와 의도적 동작 변경을 같은 커밋에 섞으면
+  안전망 없는 경로에서 원인을 가릴 수 없다
+- **복잡도 48 → 15 미만은 단일 추출로는 안 된다.** 스트림 단위를
+  `appendAndParseSse` / `dispatchSseEvent` / 루프로 더 쪼개야 한다
+- `builder/page.tsx:323`(연관성 게이트, 복잡도 21)은 **별개 작업**이다 — 여기 묶지 말 것
 
 ---
 

--- a/src/__tests__/api/admin-debug.test.ts
+++ b/src/__tests__/api/admin-debug.test.ts
@@ -110,6 +110,62 @@ describe('GET /api/v1/admin/debug', () => {
     });
   });
 
+  // RESEND_API_KEY가 없으면 emailService가 조용히 no-op이 되고, 이메일 인증이 영원히
+  // 완료되지 않아 assertEmailVerified()가 생성·배포를 403으로 막는다 = 신규 사용자가 제품을
+  // 못 쓴다. 그런데 그 상태를 밖에서 볼 방법이 없었다.
+  describe('이메일 발송 설정 진단', () => {
+    it('설정돼 있으면 configured=true와 발신 도메인을 반환한다', async () => {
+      process.env.RESEND_API_KEY = 're_test_key_value';
+      process.env.EMAIL_FROM = 'noreply@xzawed.xyz';
+
+      const { GET } = await import('@/app/api/v1/admin/debug/route');
+      const body = (await (await GET(makeRequest())).json()) as {
+        data: { email: { configured: boolean; fromSet: boolean; fromDomain: string | null } };
+      };
+
+      expect(body.data.email.configured).toBe(true);
+      expect(body.data.email.fromSet).toBe(true);
+      expect(body.data.email.fromDomain).toBe('xzawed.xyz');
+    });
+
+    it('API 키 값 자체는 절대 응답에 담기지 않는다', async () => {
+      process.env.RESEND_API_KEY = 're_super_secret_do_not_leak';
+      process.env.EMAIL_FROM = 'noreply@xzawed.xyz';
+
+      const { GET } = await import('@/app/api/v1/admin/debug/route');
+      const raw = await (await GET(makeRequest())).text();
+
+      expect(raw).not.toContain('re_super_secret_do_not_leak');
+    });
+
+    it('미설정이면 configured=false로 드러난다 — 이메일이 조용히 죽은 상태를 보이게 한다', async () => {
+      delete process.env.RESEND_API_KEY;
+      delete process.env.EMAIL_FROM;
+
+      const { GET } = await import('@/app/api/v1/admin/debug/route');
+      const body = (await (await GET(makeRequest())).json()) as {
+        data: { email: { configured: boolean; fromSet: boolean; fromDomain: string | null } };
+      };
+
+      expect(body.data.email.configured).toBe(false);
+      expect(body.data.email.fromSet).toBe(false);
+      expect(body.data.email.fromDomain).toBeNull();
+    });
+
+    it('EMAIL_FROM이 빈 문자열이면 fromSet=false — Resend가 발송을 거부하므로 미설정과 같다', async () => {
+      process.env.RESEND_API_KEY = 're_test_key_value';
+      process.env.EMAIL_FROM = '';
+
+      const { GET } = await import('@/app/api/v1/admin/debug/route');
+      const body = (await (await GET(makeRequest())).json()) as {
+        data: { email: { configured: boolean; fromSet: boolean } };
+      };
+
+      expect(body.data.email.configured).toBe(true);
+      expect(body.data.email.fromSet).toBe(false);
+    });
+  });
+
   it('모듈 로드 실패 시 FAIL: 접두사 문자열을 반환한다', async () => {
     requireMock.mockImplementation((id: string) => {
       if (id === 'playwright-core') throw new Error('Cannot find module');

--- a/src/app/api/v1/admin/debug/route.ts
+++ b/src/app/api/v1/admin/debug/route.ts
@@ -37,6 +37,17 @@ export async function GET(request: Request): Promise<Response> {
           // env 값만으로는 실제 적용 모델을 알 수 없다 — 허용목록에 없는 값은 조용히
           // 기본값으로 폴백한다. `fellBack`이 true면 env가 무시되고 있다는 뜻이다.
           models: describeTaskModels(),
+          // 이메일 발송 설정 여부. `RESEND_API_KEY`가 없으면 `emailService`가 조용히
+          // no-op이 되고, 그러면 이메일 인증이 영원히 완료되지 않아 `assertEmailVerified()`가
+          // generate·regenerate·deploy를 403으로 막는다 — **신규 사용자가 제품을 아예 못 쓴다.**
+          // 그런데 그 상태를 밖에서 관측할 방법이 없어 Railway 콘솔을 봐야만 알 수 있었다.
+          // ⚠️ 값은 절대 노출하지 않는다. 설정 여부(boolean)와 발신 도메인만 노출한다.
+          email: {
+            configured: Boolean(process.env.RESEND_API_KEY),
+            // 빈 문자열이면 Resend가 발송을 거부하므로 미설정과 구분해서 본다.
+            fromSet: Boolean(process.env.EMAIL_FROM),
+            fromDomain: process.env.EMAIL_FROM?.split('@')[1] ?? null,
+          },
           modules: {
             'playwright-core': tryRequire('playwright-core'),
             '@anthropic-ai/sdk': tryRequire('@anthropic-ai/sdk'),

--- a/src/stores/generationStore.test.ts
+++ b/src/stores/generationStore.test.ts
@@ -65,25 +65,102 @@ describe('useGenerationStore', () => {
     expect(state.currentStep).toBe('생성 중');
   });
 
-  it('fail 이후 늦게 도착한 updateProgress는 status·generatingProjectId를 되살리지 않는다', () => {
+  // ── 터미널 래치 ─────────────────────────────────────────────────────────
+  // SSE + 폴링 이중 경로에서 늦게 도착한 종료가 먼저 확정된 결과를 덮어쓰지 못해야 한다.
+  // 폴링은 fire-and-forget으로 시작되고 abort가 없어, 이 순서들이 실제로 발생한다.
+
+  it('fail 이후 늦게 도착한 updateProgress는 아무것도 바꾸지 않는다', () => {
     const store = useGenerationStore.getState();
 
     store.startGeneration();
     store.setGeneratingProjectId('proj-late');
+    store.updateProgress(25, '생성 중');
     store.failGeneration('연결 끊김');
-
-    const afterFail = useGenerationStore.getState();
-    expect(afterFail.status).toBe('failed');
-    expect(afterFail.generatingProjectId).toBeNull();
 
     store.updateProgress(90, '거의 완료');
 
     const state = useGenerationStore.getState();
     expect(state.status).toBe('failed');
     expect(state.generatingProjectId).toBeNull();
-    expect(state.progress).toBe(90);
-    expect(state.currentStep).toBe('거의 완료');
     expect(state.error).toBe('연결 끊김');
+    // 종료 후에는 progress·currentStep도 얼어 있어야 한다 (이전엔 90으로 갱신됐다)
+    expect(state.progress).toBe(25);
+    expect(state.currentStep).toBe('생성 중');
+  });
+
+  it('complete 이후 늦게 도착한 updateProgress는 progress 100을 훼손하지 않는다', () => {
+    const store = useGenerationStore.getState();
+
+    store.startGeneration();
+    store.completeGeneration('proj-1', 2);
+    store.updateProgress(40, '뒤늦은 진행률');
+
+    const state = useGenerationStore.getState();
+    expect(state.status).toBe('completed');
+    expect(state.progress).toBe(100);
+  });
+
+  it('complete 이후 늦게 도착한 failGeneration은 성공을 실패로 뒤집지 못한다', () => {
+    // 실제 재현 경로: 탭 복귀로 폴링이 시작된 뒤 SSE가 complete를 전달 →
+    // 살아 있는 폴링이 타임아웃/tracker TTL 만료로 failGeneration을 부른다.
+    // 가드가 없으면 사용자가 성공 직후 에러 화면을 본다.
+    const store = useGenerationStore.getState();
+
+    store.startGeneration();
+    store.setGeneratingProjectId('proj-win');
+    store.completeGeneration('proj-win', 3);
+
+    store.failGeneration('생성 시간이 초과되었습니다. 대시보드에서 확인해주세요.');
+
+    const state = useGenerationStore.getState();
+    expect(state.status).toBe('completed');
+    expect(state.projectId).toBe('proj-win');
+    expect(state.version).toBe(3);
+    expect(state.error).toBeNull();
+  });
+
+  it('fail 이후 늦게 도착한 completeGeneration은 실패를 성공으로 뒤집지 못한다', () => {
+    const store = useGenerationStore.getState();
+
+    store.startGeneration();
+    store.failGeneration('코드 생성에 실패했습니다.');
+
+    store.completeGeneration('proj-late', 1);
+
+    const state = useGenerationStore.getState();
+    expect(state.status).toBe('failed');
+    expect(state.error).toBe('코드 생성에 실패했습니다.');
+    expect(state.projectId).toBeNull();
+  });
+
+  it('두 번째 completeGeneration은 첫 결과를 덮어쓰지 않는다', () => {
+    const store = useGenerationStore.getState();
+
+    store.startGeneration();
+    store.completeGeneration('proj-first', 1);
+    store.completeGeneration('proj-second', 9);
+
+    const state = useGenerationStore.getState();
+    expect(state.projectId).toBe('proj-first');
+    expect(state.version).toBe(1);
+  });
+
+  it('startGeneration은 터미널 상태에서도 열려 있어야 한다 (재시도 진입점)', () => {
+    const store = useGenerationStore.getState();
+
+    store.startGeneration();
+    store.failGeneration('첫 시도 실패');
+
+    store.startGeneration();
+
+    const state = useGenerationStore.getState();
+    expect(state.status).toBe('generating');
+    expect(state.error).toBeNull();
+    expect(state.progress).toBe(0);
+
+    // 재시도 이후에는 다시 전이가 허용된다
+    store.updateProgress(50, '재시도 중');
+    expect(useGenerationStore.getState().progress).toBe(50);
   });
 
   it('completeGeneration의 version 생략 시 null로 저장한다', () => {

--- a/src/stores/generationStore.ts
+++ b/src/stores/generationStore.ts
@@ -28,15 +28,35 @@ export const useGenerationStore = create<GenerationState>((set) => ({
   error: null,
   generatingProjectId: null,
 
+  // startGeneration은 유일하게 무조건적이다 — 재시도의 진입점이므로 터미널 상태에서도 열려야 한다.
   startGeneration: () =>
     set({ status: 'generating', progress: 0, currentStep: '', error: null, version: null }),
 
-  updateProgress: (progress, currentStep) => set({ progress, currentStep }),
+  // ── 터미널 래치 ───────────────────────────────────────────────────────────
+  // 아래 셋은 `generating`일 때만 상태를 바꾼다. **먼저 도착한 종료가 이긴다.**
+  //
+  // 이유(2026-07-31 발견, 실제 재현 가능한 버그였다): 생성은 SSE + 폴링 이중 경로로 돈다.
+  // 탭 복귀 시 `visibilitychange`가 `void pollForCompletion(...)`으로 폴링을 fire-and-forget
+  // 시작하는데 `pollGenerationStatus`에는 abort가 없다. 페이지의 `generationCompleted`·
+  // `switchedToPolling` 플래그는 **두 번째 폴링 시작만 막을 뿐 이미 도는 폴링을 멈추지 못한다.**
+  // 그래서 SSE가 complete를 준 뒤에도 살아 있는 폴링이 타임아웃·tracker TTL 만료로
+  // `failGeneration`을 부르면, 가드가 없을 때 **성공이 실패로 뒤집혀** 사용자가 성공 직후
+  // 에러 화면을 본다(`pollGenerationStatus`에는 failGeneration 호출부가 5곳이다).
+  //
+  // 이 래치는 안전벨트이고 근본 해결은 폴링 취소(단일 terminal owner)다.
+  // 근본 해결 전까지 이 가드를 제거하지 말 것.
+  updateProgress: (progress, currentStep) =>
+    set((s) => (s.status === 'generating' ? { progress, currentStep } : s)),
 
   completeGeneration: (projectId, version) =>
-    set({ status: 'completed', progress: 100, projectId, version: version ?? null, generatingProjectId: null }),
+    set((s) =>
+      s.status === 'generating'
+        ? { status: 'completed', progress: 100, projectId, version: version ?? null, generatingProjectId: null }
+        : s
+    ),
 
-  failGeneration: (error) => set({ status: 'failed', error, generatingProjectId: null }),
+  failGeneration: (error) =>
+    set((s) => (s.status === 'generating' ? { status: 'failed', error, generatingProjectId: null } : s)),
 
   reset: () =>
     set({ status: 'idle', progress: 0, currentStep: '', projectId: null, version: null, error: null, generatingProjectId: null }),


### PR DESCRIPTION
## 요약

E3(빌더 핸들러 추출) 설계를 Grok과 협의하다 **실제 재현 가능한 사용자 대면 버그**를 찾았다. 어제 제가 추가한 스토어 테스트가 오히려 이 버그를 "불변식"인 양 고정하고 있었다.

## 1. 성공이 실패로 뒤집힌다

생성은 SSE + 폴링 **이중 경로**로 돈다. 탭 복귀 시 `visibilitychange`(`builder/page.tsx:232-238`)가 `void pollForCompletion(...)`으로 폴링을 **fire-and-forget** 시작하는데, `pollGenerationStatus`에는 **abort가 없다.**

`generationCompleted`·`switchedToPolling` 플래그는 **두 번째 폴링 시작만 막을 뿐 이미 도는 폴링을 멈추지 못한다.** 따라서:

```
탭 복귀 → 폴링 시작 → 버퍼에 남은 SSE complete 처리(:278) → 성공 확정
        → 살아 있는 폴링이 타임아웃/tracker TTL 만료 → failGeneration(:220)
        → 스토어에 가드가 없어  completed → failed
```

`pollGenerationStatus`에는 `failGeneration` 호출부가 **5곳**(타임아웃·연결 복구 실패·`not_found` 등)이라 이 경로가 그만큼 많다. **사용자는 생성 성공 직후 에러 화면을 본다.**

### 수정 — 터미널 래치

`updateProgress`·`completeGeneration`·`failGeneration`을 `status === 'generating'`일 때만 동작하게 했다. **먼저 도착한 종료가 이긴다.** `startGeneration`만 무조건적으로 남긴다 — 재시도 진입점이기 때문이다.

역전 순서 5종을 테스트로 고정: `complete→fail` / `fail→complete` / `complete→progress` / `fail→progress` / 중복 `complete`. 재시도 경로가 여전히 열려 있는지도 단언한다.

> **어제 추가한 테스트가 `fail` 이후 progress가 90으로 갱신되는 것을 단언하고 있었다** — 버그를 사양으로 굳힌 셈이라 함께 바로잡았다.

이 래치는 **안전벨트이고 근본 해결이 아니다.** 근본 해결은 폴링 취소(단일 terminal owner)이며 WBS에 P3로 잡았다.

## 2. 이메일 설정이 밖에서 보이지 않았다 (B2)

`RESEND_API_KEY`가 없으면 `emailService`가 조용히 no-op → 이메일 인증이 영원히 완료되지 않음 → `assertEmailVerified()`가 generate·regenerate·deploy를 403으로 막음 = **신규 사용자가 제품을 아예 못 쓴다.**

그런데 **어떤 엔드포인트도 이 상태를 노출하지 않아** Railway 콘솔을 봐야만 알 수 있었다. WBS의 최우선 항목 B2가 계속 막혀 있던 이유다.

`GET /api/v1/admin/debug`에 추가:

```json
"email": { "configured": true, "fromSet": true, "fromDomain": "xzawed.xyz" }
```

- **값은 절대 노출하지 않는다** — 키 값이 응답 본문에 담기지 않는 것을 테스트로 단언
- `EMAIL_FROM=''`(빈 문자열)은 Resend가 발송을 거부하므로 미설정과 구분해 `fromSet=false`로 드러낸다

## 3. 문서

- `system-spec.md`: 터미널 래치를 **불변조건 3.6**으로 등록(🔇 표시 — 조용히 깨지는 종류)
- WBS: **E3를 P0~P4로 분할**하고 설계 원칙 명문화
  - 추출 단위는 **커스텀 훅이 아니라 순수 DI 함수** (잡으려는 버그가 렌더가 아니라 순서 경합이므로)
  - **P1에서는 동작을 고치지 않고 특성화만** — 기계적 이동 버그와 의도적 동작 변경을 섞으면 안전망 없는 경로에서 원인을 가릴 수 없다
  - **복잡도 48 → 15 미만은 단일 추출로 안 된다** — 스트림 단위를 더 쪼개야 한다
- B2 항목에 새 관측 수단 반영

## 검증

전체 **185파일 / 2322테스트 통과(+10)** · `pnpm type-check` 통과 · 변경 파일 `eslint` clean

## 배포 후 할 일

`GET /api/v1/admin/debug`를 호출해 `email.configured`를 확인하면 B2가 즉시 판정된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
