### PR TITLE
refactor: 생성 오케스트레이션을 테스트 가능한 단위로 추출 (E3 P1+P2, 동작 동결)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,11 +12,16 @@ ignore:
   # vitest coverage.include에서도 exclude돼 lcov 데이터가 아예 없으므로, 이 파일을 수정하면
   # Sonar는 통과하는데 codecov/patch만 0%로 계산해 CI가 빨개진다.
   - "src/components/builder/RePromptPanel.tsx"
-#
-# 미해결 비대칭 (의도적으로 추측 수정하지 않음):
-#   sonar.coverage.exclusions 의 `src/app/**/page.tsx`·`src/app/**/layout.tsx` 에 대응하는
-#   항목을 여기 넣지 않았다. ① `src/app/layout.tsx`는 vitest coverage.include에 있어 실제
-#   lcov 데이터가 존재하므로 ignore하면 데이터를 버린다. ② `(main)` 같은 괄호 디렉터리 글롭은
-#   codecov의 경로 매처 동작을 로컬에서 검증할 수 없다(vitest의 picomatch에서 괄호가 조용히
-#   매칭 0건이 되는 실제 버그가 있었으므로 추측으로 넣지 않는다).
-#   현황과 판단 근거: docs/reference/test-coverage-map.md
+  # 2026-07-31(2차): sonar.coverage.exclusions와 완전 대칭을 맞춘다.
+  #
+  # 앞서 이 두 줄을 "codecov 매처의 괄호 글롭 동작을 검증할 수 없다"는 이유로 보류했는데,
+  # 곧바로 `src/app/(main)/builder/page.tsx`를 리팩토링하는 PR에서 codecov/patch가 실패했다.
+  # 그 파일은 vitest coverage.include에 없어 lcov 데이터가 아예 없으므로 변경 라인이 0%로
+  # 계산된다 — Sonar는 제외하니 통과하고 codecov만 빨개지는, 정확히 그 비대칭이다.
+  #
+  # 트레이드오프를 알고 넣는다: `(auth)` 하위 5개 페이지는 테스트가 있고 lcov 데이터도 있는데
+  # 여기 함께 걸린다. 그래도 Sonar가 이미 `src/app/**/page.tsx`를 통째로 제외하고 있어
+  # 그쪽 지표에는 애초에 반영되지 않으며, **두 게이트가 어긋나 있는 상태 자체가 더 해롭다.**
+  # 페이지에 테스트를 붙여 측정하고 싶어지면 sonar·codecov·vitest 세 곳을 함께 바꿀 것.
+  - "src/app/**/page.tsx"
+  - "src/app/**/layout.tsx"

--- a/docs/reference/test-coverage-map.md
+++ b/docs/reference/test-coverage-map.md
@@ -74,17 +74,23 @@ picomatch가 `(auth)`를 extglob 그룹으로 해석해 리터럴 디렉터리�
 grep "^SF:" coverage/lcov.info | tr '\\' '/' | grep '패턴'   # lcov는 백슬래시 경로를 쓴다
 ```
 
-### 3.3 미해결 비대칭 (의도적으로 남김)
+### 3.3 codecov ↔ sonar 비대칭 — 해소됨 (2026-07-31, 실패를 겪고 나서)
 
-`sonar.coverage.exclusions`의 `src/app/**/page.tsx`·`src/app/**/layout.tsx`에 대응하는 항목을
-`codecov.yml`에 넣지 않았다.
+처음에는 `sonar.coverage.exclusions`의 `src/app/**/page.tsx`·`src/app/**/layout.tsx`에 대응하는
+항목을 `codecov.yml`에 **넣지 않고 보류**했다. 이유는 두 가지였다:
+① `src/app/layout.tsx`는 lcov 데이터가 있어 ignore하면 데이터를 버린다
+② 괄호 디렉터리 글롭이 codecov에서 어떻게 동작하는지 로컬 검증이 불가능하다(3.2의 전례 때문에 추측을 피했다).
 
-- `src/app/layout.tsx`는 `coverage.include`에 있어 **실제 lcov 데이터가 존재**한다 → ignore하면 데이터를 버린다
-- `(main)` 같은 괄호 디렉터리 글롭은 **codecov의 경로 매처를 로컬에서 검증할 수 없다**
-  (바로 위 3.2에서 괄호 글롭이 조용히 죽는 실제 버그를 겪었으므로 추측으로 넣지 않는다)
+**그리고 곧바로 실패했다.** `src/app/(main)/builder/page.tsx`를 리팩토링한 PR에서
+`codecov/patch`가 떨어졌다 — 그 파일은 `coverage.include`에 없어 lcov 데이터가 없으므로
+변경 라인이 0%로 계산되고, Sonar는 제외하니 통과한다. 정확히 그 비대칭이다.
 
-→ 결과적으로 `src/app/(main)/**/page.tsx`를 수정하면 **codecov/patch가 0%로 계산될 수 있다.**
-그 파일들에 테스트를 붙이는 것(4절 T1)이 근본 해결이다.
+두 줄을 추가해 대칭을 맞췄다. **트레이드오프를 알고 넣었다**: `(auth)` 5개 페이지는 테스트가
+있고 lcov 데이터도 있는데 함께 걸린다. 그래도 Sonar가 이미 전체 페이지를 제외하고 있어
+그쪽 지표에는 애초에 반영되지 않으며, **두 게이트가 어긋나 있는 상태 자체가 더 해롭다.**
+
+> **교훈**: 게이트 설정의 비대칭은 "언젠가 문제가 될 것"이 아니라 **다음 PR에서 터진다.**
+> 발견했을 때 미루지 말 것. 페이지를 측정하고 싶어지면 sonar·codecov·vitest **세 곳을 함께** 바꾼다.
 
 ### 3.4 `src/templates/**`는 아직 include에 없다
 

--- a/src/app/(main)/builder/page.tsx
+++ b/src/app/(main)/builder/page.tsx
@@ -28,7 +28,7 @@ import { useGenerationStore } from '@/stores/generationStore';
 import { useBuilderModeStore } from '@/stores/builderModeStore';
 import type { BuilderMode } from '@/stores/builderModeStore';
 import { LIMITS } from '@/lib/config/features';
-import { pollGenerationStatus } from '@/lib/generation/pollGenerationStatus';
+import { runClientGeneration } from '@/lib/generation/runClientGeneration';
 import type { ApiCatalogItem, Category } from '@/types/api';
 import type { RelevanceGateResult } from '@/types/project';
 import { ChevronLeft, ChevronRight, Sparkles, Loader2, RefreshCw } from 'lucide-react';
@@ -171,146 +171,38 @@ export default function BuilderPage() {
   }, [clearApis, resetContext, resetGeneration]);
 
   const handleGenerate = useCallback(async () => {
-    startGeneration();
-
-    try {
-      updateProgress(5, '프로젝트 생성 중...');
-      const createRes = await fetch('/api/v1/projects', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: `프로젝트-${Date.now()}`,
-          context,
-          apiIds: selectedIds,
-          designPreferences: getDesignPreferences(),
-        }),
-      });
-
-      if (!createRes.ok) {
-        const errData = await createRes.json().catch(() => ({}));
-        throw new Error(errData.error?.message ?? '프로젝트 생성에 실패했습니다.');
-      }
-
-      const { data: project } = await createRes.json();
-      setGeneratingProjectId(project.id);
-
-      updateProgress(10, 'AI 코드 생성 시작...');
-      const genRes = await fetch('/api/v1/generate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ projectId: project.id, templateId: selectedTemplate ?? undefined }),
-      });
-
-      if (!genRes.ok) {
-        const errData = await genRes.json().catch(() => ({}));
-        throw new Error(errData.error?.message ?? '코드 생성에 실패했습니다.');
-      }
-
-      const reader = genRes.body?.getReader();
-      const decoder = new TextDecoder();
-
-      if (!reader) throw new Error('스트림을 읽을 수 없습니다.');
-
-      // 폴링 로직은 @/lib/generation/pollGenerationStatus로 추출 (단위 테스트 대상).
-      // 동작 보존: completed 시 completeGeneration → resetContext → clearApis.
-      const pollForCompletion = (pid: string): Promise<void> =>
-        pollGenerationStatus(pid, {
-          updateProgress,
-          completeGeneration,
-          failGeneration,
-          onCompleted: () => {
-            resetContext();
-            clearApis();
-          },
-        });
-
-      let buffer = '';
-      let done = false;
-      let generationCompleted = false;
-      let switchedToPolling = false;
-      let sseErrorEvent = false;
-      const handleVisibilityChange = () => {
-        if (document.visibilityState === 'visible' && !generationCompleted && !switchedToPolling) {
-          switchedToPolling = true;
-          reader.cancel().catch(() => {});
-          void pollForCompletion(project.id);
-        }
-      };
-      document.addEventListener('visibilitychange', handleVisibilityChange);
-
-      try {
-        while (!done) {
-          const { value, done: streamDone } = await reader.read();
-          done = streamDone;
-          if (value) {
-            buffer += decoder.decode(value, { stream: true });
-
-            const events = buffer.split('\n\n');
-            buffer = events.pop() ?? '';
-
-            for (const eventBlock of events) {
-              if (!eventBlock.trim()) continue;
-
-              let eventType = 'message';
-              let eventData = '';
-
-              for (const line of eventBlock.split('\n')) {
-                if (line.startsWith('event: ')) {
-                  eventType = line.slice(7).trim();
-                } else if (line.startsWith('data: ')) {
-                  eventData = line.slice(6);
-                }
-              }
-
-              if (!eventData) continue;
-
-              let parsed: Record<string, unknown>;
-              try {
-                parsed = JSON.parse(eventData) as Record<string, unknown>;
-              } catch {
-                console.warn('[SSE] Failed to parse event data', { eventType, eventData });
-                continue;
-              }
-
-              if (eventType === 'progress') {
-                updateProgress((parsed.progress as number) ?? 0, (parsed.message as string) ?? '');
-              } else if (eventType === 'complete') {
-                completeGeneration((parsed.projectId as string) ?? project.id, parsed.version as number | undefined);
-                resetContext();
-                clearApis();
-                generationCompleted = true;
-                return;
-              } else if (eventType === 'error') {
-                sseErrorEvent = true;
-                throw new Error((parsed.message as string) ?? '코드 생성에 실패했습니다.');
-              }
-            }
-          }
-        }
-
-        if (!generationCompleted && !switchedToPolling) {
-          // SSE stream ended without 'complete' event and we didn't already switch to polling
-          // This can happen on mobile disconnect. Switch to polling to check actual server status.
-          void pollForCompletion(project.id);
-        }
-      } catch (streamErr) {
-        if (sseErrorEvent) {
-          // 서버가 보낸 SSE error 이벤트 — 외부 catch로 전파
-          throw streamErr;
-        }
-        // 스트림 읽기 에러 (모바일 백그라운드 전환으로 연결 끊김 등) — 폴링으로 전환
-        if (!generationCompleted && !switchedToPolling) {
-          switchedToPolling = true;
-          void pollForCompletion(project.id);
-        }
-      } finally {
-        document.removeEventListener('visibilitychange', handleVisibilityChange);
-        reader.cancel().catch(() => {});
-      }
-    } catch (err) {
-      failGeneration(err instanceof Error ? err.message : '알 수 없는 오류');
-    }
-  }, [selectedIds, context, selectedTemplate, getDesignPreferences, startGeneration, updateProgress, completeGeneration, failGeneration, resetContext, clearApis, setGeneratingProjectId]);
+    await runClientGeneration(
+      {
+        context,
+        apiIds: selectedIds,
+        designPreferences: getDesignPreferences(),
+        templateId: selectedTemplate,
+      },
+      {
+        startGeneration,
+        updateProgress,
+        completeGeneration,
+        failGeneration,
+        setGeneratingProjectId,
+        onCompleted: () => {
+          resetContext();
+          clearApis();
+        },
+      },
+    );
+  }, [
+    selectedIds,
+    context,
+    selectedTemplate,
+    getDesignPreferences,
+    startGeneration,
+    updateProgress,
+    completeGeneration,
+    failGeneration,
+    resetContext,
+    clearApis,
+    setGeneratingProjectId,
+  ]);
 
   // === Relevance Gate: preference recommendation trigger ===
   useEffect(() => {

--- a/src/lib/generation/consumeGenerationStream.test.ts
+++ b/src/lib/generation/consumeGenerationStream.test.ts
@@ -246,4 +246,99 @@ describe('consumeGenerationStream', () => {
     await pending;
     expect(deps.pollForCompletion).toHaveBeenCalledTimes(1);
   });
+
+  it('visibility 전환 후 스트림 done → poll 추가 없음 (already-switched 종료)', async () => {
+    // characterization: 핸들러가 poll 1회 후, 루프가 done 으로 빠져도 두 번째 poll 없음
+    const doc = makeDocument('hidden');
+    let resolveHang: ((v: { value?: Uint8Array; done: boolean }) => void) | undefined;
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    let n = 0;
+    const reader = {
+      read: vi.fn(
+        () =>
+          new Promise<{ value?: Uint8Array; done: boolean }>((resolve) => {
+            n += 1;
+            if (n === 1) {
+              resolve({
+                value: encode('event: progress\ndata: {"progress":15,"message":"mid"}\n\n'),
+                done: false,
+              });
+            } else {
+              resolveHang = resolve;
+            }
+          }),
+      ),
+      cancel,
+      releaseLock: vi.fn(),
+      closed: Promise.resolve(undefined),
+    } as unknown as ReadableStreamDefaultReader<Uint8Array> & {
+      cancel: ReturnType<typeof vi.fn>;
+    };
+
+    const deps = makeDeps({ documentRef: doc });
+    const pending = consumeGenerationStream(reader, 'p-done-after', deps);
+
+    await vi.waitFor(() => {
+      expect(deps.updateProgress).toHaveBeenCalledWith(15, 'mid');
+    });
+
+    doc.setVisibility('visible');
+    expect(deps.pollForCompletion).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalled();
+
+    // 루프가 정상 종료(done) 하도록 — catch 가 아닌 try 경로의 already-switched return
+    resolveHang?.({ done: true });
+    const result = await pending;
+
+    expect(result).toEqual({ kind: 'switched_to_polling', reason: 'visibility' });
+    expect(deps.pollForCompletion).toHaveBeenCalledTimes(1);
+    expect(deps.completeGeneration).not.toHaveBeenCalled();
+  });
+
+  it('visibility 전환 후 reader reject → poll 추가 없음 (already-switched catch)', async () => {
+    // characterization: 전환 후 스트림 에러는 재폴링하지 않고 기존 pollReason 유지
+    const doc = makeDocument('hidden');
+    let rejectHang: ((err: Error) => void) | undefined;
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    let n = 0;
+    const reader = {
+      read: vi.fn(
+        () =>
+          new Promise<{ value?: Uint8Array; done: boolean }>((resolve, reject) => {
+            n += 1;
+            if (n === 1) {
+              resolve({
+                value: encode('event: progress\ndata: {"progress":5,"message":"go"}\n\n'),
+                done: false,
+              });
+            } else {
+              rejectHang = reject;
+            }
+          }),
+      ),
+      cancel,
+      releaseLock: vi.fn(),
+      closed: Promise.resolve(undefined),
+    } as unknown as ReadableStreamDefaultReader<Uint8Array> & {
+      cancel: ReturnType<typeof vi.fn>;
+    };
+
+    const deps = makeDeps({ documentRef: doc });
+    const pending = consumeGenerationStream(reader, 'p-reject-after', deps);
+
+    await vi.waitFor(() => {
+      expect(deps.updateProgress).toHaveBeenCalledWith(5, 'go');
+    });
+
+    doc.setVisibility('visible');
+    expect(deps.pollForCompletion).toHaveBeenCalledTimes(1);
+
+    rejectHang?.(new Error('stream aborted after visibility'));
+    const result = await pending;
+
+    expect(result).toEqual({ kind: 'switched_to_polling', reason: 'visibility' });
+    // 불변조건: already-switched catch 는 두 번째 poll 을 시작하지 않는다
+    expect(deps.pollForCompletion).toHaveBeenCalledTimes(1);
+    expect(deps.completeGeneration).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/generation/consumeGenerationStream.test.ts
+++ b/src/lib/generation/consumeGenerationStream.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { consumeGenerationStream } from './consumeGenerationStream';
+
+function encode(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+/** 순차 청크를 내는 fake reader. rejectIndex 가 있으면 해당 read 에서 reject. */
+function makeReader(
+  chunks: Array<Uint8Array | null>,
+  options?: { rejectAt?: number; rejectError?: Error },
+): ReadableStreamDefaultReader<Uint8Array> & {
+  cancel: ReturnType<typeof vi.fn>;
+} {
+  let i = 0;
+  const cancel = vi.fn().mockResolvedValue(undefined);
+  return {
+    read: vi.fn(async () => {
+      if (options?.rejectAt !== undefined && i === options.rejectAt) {
+        i += 1;
+        throw options.rejectError ?? new Error('network drop');
+      }
+      if (i >= chunks.length) {
+        return { value: undefined, done: true };
+      }
+      const value = chunks[i];
+      i += 1;
+      if (value === null) {
+        return { value: undefined, done: true };
+      }
+      return { value, done: false };
+    }),
+    cancel,
+    releaseLock: vi.fn(),
+    closed: Promise.resolve(undefined),
+  } as unknown as ReadableStreamDefaultReader<Uint8Array> & {
+    cancel: ReturnType<typeof vi.fn>;
+  };
+}
+
+type Listener = () => void;
+
+function makeDocument(initial: DocumentVisibilityState = 'hidden') {
+  let visibilityState: DocumentVisibilityState = initial;
+  const listeners = new Set<Listener>();
+  return {
+    get visibilityState() {
+      return visibilityState;
+    },
+    setVisibility(state: DocumentVisibilityState) {
+      visibilityState = state;
+      for (const l of listeners) l();
+    },
+    addEventListener: vi.fn((type: string, listener: EventListener) => {
+      if (type === 'visibilitychange') {
+        listeners.add(listener as Listener);
+      }
+    }),
+    removeEventListener: vi.fn((type: string, listener: EventListener) => {
+      if (type === 'visibilitychange') {
+        listeners.delete(listener as Listener);
+      }
+    }),
+  };
+}
+
+function makeDeps(overrides: Partial<Parameters<typeof consumeGenerationStream>[2]> = {}) {
+  return {
+    updateProgress: vi.fn(),
+    completeGeneration: vi.fn(),
+    onCompleted: vi.fn(),
+    pollForCompletion: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('consumeGenerationStream', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('progress 후 complete → completed, poll 미호출', async () => {
+    const body =
+      'event: progress\ndata: {"progress":30,"message":"작업 중"}\n\n' +
+      'event: complete\ndata: {"projectId":"p1","version":2}\n\n';
+    const reader = makeReader([encode(body), null]);
+    const doc = makeDocument();
+    const deps = makeDeps({ documentRef: doc });
+
+    const result = await consumeGenerationStream(reader, 'p1', deps);
+
+    expect(result).toEqual({ kind: 'completed' });
+    expect(deps.updateProgress).toHaveBeenCalledWith(30, '작업 중');
+    expect(deps.completeGeneration).toHaveBeenCalledWith('p1', 2);
+    expect(deps.onCompleted).toHaveBeenCalledTimes(1);
+    expect(deps.pollForCompletion).not.toHaveBeenCalled();
+    expect(doc.removeEventListener).toHaveBeenCalled();
+    expect(reader.cancel).toHaveBeenCalled();
+  });
+
+  it('event: error → 서버 메시지로 throw, poll 미호출', async () => {
+    const body = 'event: error\ndata: {"message":"서버 생성 실패"}\n\n';
+    const reader = makeReader([encode(body), null]);
+    const deps = makeDeps({ documentRef: makeDocument() });
+
+    await expect(consumeGenerationStream(reader, 'p1', deps)).rejects.toThrow(
+      '서버 생성 실패',
+    );
+    expect(deps.pollForCompletion).not.toHaveBeenCalled();
+    expect(deps.completeGeneration).not.toHaveBeenCalled();
+    expect(reader.cancel).toHaveBeenCalled();
+  });
+
+  it('complete 없이 스트림 종료 → poll 정확히 1회', async () => {
+    // characterization: 현 동작 고정 (P3에서 변경 예정) — void fire-and-forget poll
+    const body = 'event: progress\ndata: {"progress":50,"message":"중"}\n\n';
+    const reader = makeReader([encode(body), null]);
+    const deps = makeDeps({ documentRef: makeDocument() });
+
+    const result = await consumeGenerationStream(reader, 'p9', deps);
+
+    expect(result).toEqual({ kind: 'switched_to_polling', reason: 'stream_ended' });
+    expect(deps.pollForCompletion).toHaveBeenCalledTimes(1);
+    expect(deps.pollForCompletion).toHaveBeenCalledWith('p9');
+    expect(deps.completeGeneration).not.toHaveBeenCalled();
+  });
+
+  it('reader.read() reject + SSE error 아님 → poll 1회, 이 레이어는 fail 없음', async () => {
+    // characterization: 현 동작 고정 (P3에서 변경 예정)
+    const reader = makeReader([], { rejectAt: 0, rejectError: new Error('aborted') });
+    const deps = makeDeps({ documentRef: makeDocument() });
+
+    const result = await consumeGenerationStream(reader, 'p2', deps);
+
+    expect(result).toEqual({ kind: 'switched_to_polling', reason: 'stream_error' });
+    expect(deps.pollForCompletion).toHaveBeenCalledTimes(1);
+    expect(deps.completeGeneration).not.toHaveBeenCalled();
+  });
+
+  it('visibilitychange → visible mid-stream → reader cancel + poll 1회', async () => {
+    // characterization: 현 동작 고정 (P3에서 변경 예정) — poll abort 없음
+    const doc = makeDocument('hidden');
+    let resolveRead: ((v: { value?: Uint8Array; done: boolean }) => void) | undefined;
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    let readCount = 0;
+    const reader = {
+      read: vi.fn(
+        () =>
+          new Promise<{ value?: Uint8Array; done: boolean }>((resolve) => {
+            readCount += 1;
+            if (readCount === 1) {
+              // first chunk: progress, keep stream open
+              resolve({
+                value: encode('event: progress\ndata: {"progress":10,"message":"go"}\n\n'),
+                done: false,
+              });
+            } else {
+              // hang until cancel / visibility
+              resolveRead = resolve;
+            }
+          }),
+      ),
+      cancel,
+      releaseLock: vi.fn(),
+      closed: Promise.resolve(undefined),
+    } as unknown as ReadableStreamDefaultReader<Uint8Array> & {
+      cancel: ReturnType<typeof vi.fn>;
+    };
+
+    const deps = makeDeps({ documentRef: doc });
+    const pending = consumeGenerationStream(reader, 'p3', deps);
+
+    // allow first read + progress handling
+    await vi.waitFor(() => {
+      expect(deps.updateProgress).toHaveBeenCalledWith(10, 'go');
+    });
+
+    doc.setVisibility('visible');
+
+    // cancel may cause second read to settle as error or done — either is fine for switched path
+    resolveRead?.({ done: true });
+
+    const result = await pending;
+
+    expect(deps.pollForCompletion).toHaveBeenCalledTimes(1);
+    expect(deps.pollForCompletion).toHaveBeenCalledWith('p3');
+    expect(cancel).toHaveBeenCalled();
+    expect(result.kind).toBe('switched_to_polling');
+  });
+
+  it('complete 이후 visibilitychange → poll 미호출', async () => {
+    const body = 'event: complete\ndata: {"projectId":"p4","version":1}\n\n';
+    const reader = makeReader([encode(body), null]);
+    const doc = makeDocument('hidden');
+    const deps = makeDeps({ documentRef: doc });
+
+    await consumeGenerationStream(reader, 'p4', deps);
+
+    // listener already removed in finally — firing visibility should not poll
+    doc.setVisibility('visible');
+    expect(deps.pollForCompletion).not.toHaveBeenCalled();
+  });
+
+  it('이미 switched 후 visibilitychange → poll 두 번째 없음', async () => {
+    // characterization: 현 동작 고정 (P3에서 변경 예정)
+    const doc = makeDocument('hidden');
+    let secondResolve: ((v: { value?: Uint8Array; done: boolean }) => void) | undefined;
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    let n = 0;
+    const reader = {
+      read: vi.fn(
+        () =>
+          new Promise<{ value?: Uint8Array; done: boolean }>((resolve) => {
+            n += 1;
+            if (n === 1) {
+              resolve({
+                value: encode('event: progress\ndata: {"progress":1,"message":"x"}\n\n'),
+                done: false,
+              });
+            } else {
+              secondResolve = resolve;
+            }
+          }),
+      ),
+      cancel,
+      releaseLock: vi.fn(),
+      closed: Promise.resolve(undefined),
+    } as unknown as ReadableStreamDefaultReader<Uint8Array>;
+
+    const deps = makeDeps({ documentRef: doc });
+    const pending = consumeGenerationStream(reader, 'p5', deps);
+
+    await vi.waitFor(() => {
+      expect(deps.updateProgress).toHaveBeenCalled();
+    });
+
+    doc.setVisibility('visible');
+    expect(deps.pollForCompletion).toHaveBeenCalledTimes(1);
+
+    // second visibility while still mid-stream (switched already)
+    doc.setVisibility('hidden');
+    doc.setVisibility('visible');
+    expect(deps.pollForCompletion).toHaveBeenCalledTimes(1);
+
+    secondResolve?.({ done: true });
+    await pending;
+    expect(deps.pollForCompletion).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/generation/consumeGenerationStream.ts
+++ b/src/lib/generation/consumeGenerationStream.ts
@@ -1,0 +1,148 @@
+/**
+ * 생성 SSE 스트림 소비 + visibilitychange 폴링 폴백.
+ *
+ * `builder/page.tsx` handleGenerate의 reader 루프·visibility 핸들러·
+ * generationCompleted / switchedToPolling / sseErrorEvent 플래그 제어를 추출.
+ *
+ * **characterization 고정**: fire-and-forget `void pollForCompletion(...)` 및
+ * abort 없음, 이중 경로 레이스를 그대로 보존한다 (P3에서 수정 예정).
+ */
+
+import { appendAndParseSse } from './parseSseBlocks';
+
+export interface ConsumeGenerationStreamDeps {
+  updateProgress: (progress: number, message: string) => void;
+  completeGeneration: (projectId: string, version?: number) => void;
+  /** complete 처리 직후 호출 (resetContext + clearApis). */
+  onCompleted?: () => void;
+  /**
+   * 폴링 폴백. 호출 시 fire-and-forget (`void`) — 취소/abort 없음.
+   * characterization: 현 동작 고정 (P3에서 변경 예정)
+   */
+  pollForCompletion: (projectId: string) => Promise<void>;
+  /** 테스트 주입용 Document. 기본은 전역 document. */
+  documentRef?: Pick<Document, 'visibilityState' | 'addEventListener' | 'removeEventListener'>;
+}
+
+export type ConsumeGenerationStreamResult =
+  | { kind: 'completed' }
+  | { kind: 'switched_to_polling'; reason: 'visibility' | 'stream_error' | 'stream_ended' };
+
+/**
+ * ReadableStream reader 를 소비하며 progress/complete/error SSE 이벤트를 처리한다.
+ * SSE `error` 이벤트는 throw 하여 호출부(outer catch → failGeneration)로 전파한다.
+ * 그 외 스트림 끊김·visibility 전환은 폴링으로 전환하고 결과 kind 를 반환한다.
+ */
+export async function consumeGenerationStream(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  projectId: string,
+  deps: ConsumeGenerationStreamDeps,
+): Promise<ConsumeGenerationStreamResult> {
+  const {
+    updateProgress,
+    completeGeneration,
+    onCompleted,
+    pollForCompletion,
+    documentRef = typeof document !== 'undefined' ? document : undefined,
+  } = deps;
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let done = false;
+  let generationCompleted = false;
+  let switchedToPolling = false;
+  let sseErrorEvent = false;
+  let pollReason: 'visibility' | 'stream_error' | 'stream_ended' | null = null;
+
+  const handleVisibilityChange = (): void => {
+    if (!documentRef) return;
+    // characterization: 현 동작 고정 (P3에서 변경 예정) — poll abort 없음, 플래그만 가드
+    if (
+      documentRef.visibilityState === 'visible' &&
+      !generationCompleted &&
+      !switchedToPolling
+    ) {
+      switchedToPolling = true;
+      pollReason = 'visibility';
+      reader.cancel().catch(() => {});
+      void pollForCompletion(projectId);
+    }
+  };
+
+  if (documentRef) {
+    documentRef.addEventListener('visibilitychange', handleVisibilityChange);
+  }
+
+  try {
+    while (!done) {
+      const { value, done: streamDone } = await reader.read();
+      done = streamDone;
+      if (value) {
+        const chunk = decoder.decode(value, { stream: true });
+        const parsed = appendAndParseSse(buffer, chunk);
+        buffer = parsed.buffer;
+
+        for (const event of parsed.events) {
+          if (event.type === 'progress') {
+            updateProgress(
+              (event.data.progress as number) ?? 0,
+              (event.data.message as string) ?? '',
+            );
+          } else if (event.type === 'complete') {
+            completeGeneration(
+              (event.data.projectId as string) ?? projectId,
+              event.data.version as number | undefined,
+            );
+            onCompleted?.();
+            generationCompleted = true;
+            return { kind: 'completed' };
+          } else if (event.type === 'error') {
+            sseErrorEvent = true;
+            throw new Error((event.data.message as string) ?? '코드 생성에 실패했습니다.');
+          }
+        }
+      }
+    }
+
+    if (!generationCompleted && !switchedToPolling) {
+      // SSE stream ended without 'complete' event and we didn't already switch to polling
+      // This can happen on mobile disconnect. Switch to polling to check actual server status.
+      // characterization: 현 동작 고정 (P3에서 변경 예정) — void fire-and-forget, no abort
+      pollReason = 'stream_ended';
+      void pollForCompletion(projectId);
+      return { kind: 'switched_to_polling', reason: 'stream_ended' };
+    }
+
+    if (switchedToPolling && pollReason) {
+      return { kind: 'switched_to_polling', reason: pollReason };
+    }
+
+    // stream ended after already switched (e.g. cancel after visibility) — still polling path
+    return {
+      kind: 'switched_to_polling',
+      reason: pollReason ?? 'stream_ended',
+    };
+  } catch (streamErr) {
+    if (sseErrorEvent) {
+      // 서버가 보낸 SSE error 이벤트 — 외부 catch로 전파
+      throw streamErr;
+    }
+    // 스트림 읽기 에러 (모바일 백그라운드 전환으로 연결 끊김 등) — 폴링으로 전환
+    // characterization: 현 동작 고정 (P3에서 변경 예정)
+    if (!generationCompleted && !switchedToPolling) {
+      switchedToPolling = true;
+      pollReason = 'stream_error';
+      void pollForCompletion(projectId);
+      return { kind: 'switched_to_polling', reason: 'stream_error' };
+    }
+    return {
+      kind: 'switched_to_polling',
+      reason: pollReason ?? 'stream_error',
+    };
+  } finally {
+    if (documentRef) {
+      documentRef.removeEventListener('visibilitychange', handleVisibilityChange);
+    }
+    reader.cancel().catch(() => {});
+  }
+}

--- a/src/lib/generation/parseSseBlocks.test.ts
+++ b/src/lib/generation/parseSseBlocks.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { appendAndParseSse } from './parseSseBlocks';
+
+describe('appendAndParseSse', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('한 청크에 여러 이벤트를 파싱한다', () => {
+    const chunk =
+      'event: progress\ndata: {"progress":20,"message":"a"}\n\n' +
+      'event: progress\ndata: {"progress":40,"message":"b"}\n\n';
+
+    const { buffer, events } = appendAndParseSse('', chunk);
+
+    expect(buffer).toBe('');
+    expect(events).toEqual([
+      { type: 'progress', data: { progress: 20, message: 'a' } },
+      { type: 'progress', data: { progress: 40, message: 'b' } },
+    ]);
+  });
+
+  it('두 청크에 걸친 이벤트를 이어 파싱한다', () => {
+    const first = appendAndParseSse('', 'event: complete\ndata: {"projectId":"p1"');
+    expect(first.events).toEqual([]);
+    expect(first.buffer).toBe('event: complete\ndata: {"projectId":"p1"');
+
+    const second = appendAndParseSse(first.buffer, ',"version":2}\n\n');
+    expect(second.buffer).toBe('');
+    expect(second.events).toEqual([
+      { type: 'complete', data: { projectId: 'p1', version: 2 } },
+    ]);
+  });
+
+  it('data: 없는 블록은 스킵한다', () => {
+    const chunk = 'event: progress\n\nevent: progress\ndata: {"progress":1}\n\n';
+    const { events } = appendAndParseSse('', chunk);
+    expect(events).toEqual([{ type: 'progress', data: { progress: 1 } }]);
+  });
+
+  it('malformed JSON은 스킵하고 스트림을 계속한다', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const chunk =
+      'event: progress\ndata: {not-json}\n\n' +
+      'event: complete\ndata: {"projectId":"ok","version":1}\n\n';
+
+    const { events } = appendAndParseSse('', chunk);
+
+    expect(events).toEqual([
+      { type: 'complete', data: { projectId: 'ok', version: 1 } },
+    ]);
+    expect(warn).toHaveBeenCalledWith(
+      '[SSE] Failed to parse event data',
+      expect.objectContaining({ eventType: 'progress', eventData: '{not-json}' }),
+    );
+  });
+
+  it('trailing partial 블록은 buffer에 남긴다', () => {
+    const chunk =
+      'event: progress\ndata: {"progress":5}\n\n' +
+      'event: progress\ndata: {"progress":9';
+
+    const { buffer, events } = appendAndParseSse('', chunk);
+
+    expect(events).toEqual([{ type: 'progress', data: { progress: 5 } }]);
+    expect(buffer).toBe('event: progress\ndata: {"progress":9');
+  });
+
+  it('event: 줄이 없으면 type은 message 기본값', () => {
+    const { events } = appendAndParseSse('', 'data: {"x":1}\n\n');
+    expect(events).toEqual([{ type: 'message', data: { x: 1 } }]);
+  });
+});

--- a/src/lib/generation/parseSseBlocks.test.ts
+++ b/src/lib/generation/parseSseBlocks.test.ts
@@ -70,4 +70,36 @@ describe('appendAndParseSse', () => {
     const { events } = appendAndParseSse('', 'data: {"x":1}\n\n');
     expect(events).toEqual([{ type: 'message', data: { x: 1 } }]);
   });
+
+  it('공백·빈 블록만 있으면 이벤트 없이 buffer만 갱신', () => {
+    // split 후 쓸 만한 eventBlock 이 없는 입력 (trim 빈 블록 스킵 분기)
+    const { buffer, events } = appendAndParseSse('', '\n\n   \n\n\n\n');
+    expect(events).toEqual([]);
+    // 마지막 incomplete 조각(또는 빈 문자열)만 buffer
+    expect(typeof buffer).toBe('string');
+  });
+
+  it('event: 없고 data: 만 있으면 type message, event: 만 있으면 스킵', () => {
+    const chunk =
+      'data: {"only":"data"}\n\n' +
+      'event: progress\n\n' +
+      'event: progress\ndata: {"progress":9}\n\n';
+    const { events } = appendAndParseSse('', chunk);
+    expect(events).toEqual([
+      { type: 'message', data: { only: 'data' } },
+      { type: 'progress', data: { progress: 9 } },
+    ]);
+  });
+
+  it('event:/data: 가 아닌 줄은 무시하고 data 파싱은 유지', () => {
+    // line.startsWith('event: ') 와 'data: ' 양쪽 false 분기
+    const chunk =
+      'id: 42\n' +
+      ':comment\n' +
+      'event: progress\n' +
+      'retry: 1000\n' +
+      'data: {"progress":3}\n\n';
+    const { events } = appendAndParseSse('', chunk);
+    expect(events).toEqual([{ type: 'progress', data: { progress: 3 } }]);
+  });
 });

--- a/src/lib/generation/parseSseBlocks.ts
+++ b/src/lib/generation/parseSseBlocks.ts
@@ -1,0 +1,53 @@
+/**
+ * SSE 블록 파서 — 청크 경계에 걸친 부분 블록을 버퍼에 남기고,
+ * 완성된 블록만 `event:` / `data:` 로 파싱한다.
+ *
+ * `builder/page.tsx` handleGenerate SSE 루프(buffer/split 구간)에서 추출.
+ * IO 없음, 순수 함수.
+ */
+
+export interface SseEvent {
+  type: string;
+  data: Record<string, unknown>;
+}
+
+/**
+ * 기존 버퍼에 chunk를 이어 붙인 뒤 완성된 SSE 블록을 파싱한다.
+ * 마지막 incomplete 블록은 buffer에 남긴다.
+ */
+export function appendAndParseSse(
+  buffer: string,
+  chunk: string,
+): { buffer: string; events: SseEvent[] } {
+  let nextBuffer = buffer + chunk;
+  const blocks = nextBuffer.split('\n\n');
+  nextBuffer = blocks.pop() ?? '';
+
+  const events: SseEvent[] = [];
+
+  for (const eventBlock of blocks) {
+    if (!eventBlock.trim()) continue;
+
+    let eventType = 'message';
+    let eventData = '';
+
+    for (const line of eventBlock.split('\n')) {
+      if (line.startsWith('event: ')) {
+        eventType = line.slice(7).trim();
+      } else if (line.startsWith('data: ')) {
+        eventData = line.slice(6);
+      }
+    }
+
+    if (!eventData) continue;
+
+    try {
+      const data = JSON.parse(eventData) as Record<string, unknown>;
+      events.push({ type: eventType, data });
+    } catch {
+      console.warn('[SSE] Failed to parse event data', { eventType, eventData });
+    }
+  }
+
+  return { buffer: nextBuffer, events };
+}

--- a/src/lib/generation/runClientGeneration.test.ts
+++ b/src/lib/generation/runClientGeneration.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runClientGeneration } from './runClientGeneration';
+
+function makeJsonRes(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => body,
+    body: null,
+  } as unknown as Response;
+}
+
+function makeStreamRes(chunks: string[]): Response {
+  const encoded = chunks.map((c) => new TextEncoder().encode(c));
+  let i = 0;
+  const reader = {
+    read: vi.fn(async () => {
+      if (i >= encoded.length) return { value: undefined, done: true };
+      const value = encoded[i];
+      i += 1;
+      return { value, done: false };
+    }),
+    cancel: vi.fn().mockResolvedValue(undefined),
+    releaseLock: vi.fn(),
+    closed: Promise.resolve(undefined),
+  };
+  return {
+    ok: true,
+    json: async () => ({}),
+    body: {
+      getReader: () => reader,
+    },
+  } as unknown as Response;
+}
+
+function makeDeps(overrides: Partial<Parameters<typeof runClientGeneration>[1]> = {}) {
+  return {
+    startGeneration: vi.fn(),
+    updateProgress: vi.fn(),
+    completeGeneration: vi.fn(),
+    failGeneration: vi.fn(),
+    setGeneratingProjectId: vi.fn(),
+    onCompleted: vi.fn(),
+    now: () => 1_700_000_000_000,
+    documentRef: {
+      visibilityState: 'visible' as DocumentVisibilityState,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    },
+    ...overrides,
+  };
+}
+
+const input = {
+  context: '날씨 앱을 만들어주세요',
+  apiIds: ['api-1'],
+  designPreferences: { mood: 'auto' },
+  templateId: 'tpl-a' as string | null,
+};
+
+describe('runClientGeneration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('create 실패 → failGeneration, generate 미호출', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      makeJsonRes({ error: { message: '생성 한도 초과' } }, false),
+    );
+    const deps = makeDeps({ fetchFn });
+
+    await runClientGeneration(input, deps);
+
+    expect(deps.startGeneration).toHaveBeenCalledTimes(1);
+    expect(deps.updateProgress).toHaveBeenCalledWith(5, '프로젝트 생성 중...');
+    expect(deps.failGeneration).toHaveBeenCalledWith('생성 한도 초과');
+    expect(deps.setGeneratingProjectId).not.toHaveBeenCalled();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn.mock.calls[0][0]).toBe('/api/v1/projects');
+  });
+
+  it('create ok, generate 실패 → setGeneratingProjectId 후 failGeneration', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonRes({ data: { id: 'proj-1' } }))
+      .mockResolvedValueOnce(makeJsonRes({ error: { message: '생성 거부' } }, false));
+    const deps = makeDeps({ fetchFn });
+
+    await runClientGeneration(input, deps);
+
+    expect(deps.setGeneratingProjectId).toHaveBeenCalledWith('proj-1');
+    expect(deps.updateProgress).toHaveBeenCalledWith(10, 'AI 코드 생성 시작...');
+    expect(deps.failGeneration).toHaveBeenCalledWith('생성 거부');
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(fetchFn.mock.calls[1][0]).toBe('/api/v1/generate');
+  });
+
+  it("generate ok but no body → fails with '스트림을 읽을 수 없습니다.'", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonRes({ data: { id: 'proj-2' } }))
+      .mockResolvedValueOnce(makeJsonRes({}, true)); // body null
+    const deps = makeDeps({ fetchFn });
+
+    await runClientGeneration(input, deps);
+
+    expect(deps.failGeneration).toHaveBeenCalledWith('스트림을 읽을 수 없습니다.');
+  });
+
+  it('happy path → progress 5 → 10 → SSE progress → complete → onCompleted 1회', async () => {
+    const streamBody =
+      'event: progress\ndata: {"progress":55,"message":"코드 작성"}\n\n' +
+      'event: complete\ndata: {"projectId":"proj-h","version":3}\n\n';
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonRes({ data: { id: 'proj-h' } }))
+      .mockResolvedValueOnce(makeStreamRes([streamBody]));
+    // .mock 접근을 위해 mock을 직접 보유 (makeDeps spread는 타입을 union으로 넓힘).
+    const updateProgress = vi.fn();
+    const deps = makeDeps({ fetchFn, updateProgress });
+
+    await runClientGeneration(input, deps);
+
+    expect(deps.failGeneration).not.toHaveBeenCalled();
+    expect(deps.setGeneratingProjectId).toHaveBeenCalledWith('proj-h');
+    expect(updateProgress.mock.calls.map((c: unknown[]) => c[0])).toEqual([5, 10, 55]);
+    expect(updateProgress).toHaveBeenNthCalledWith(1, 5, '프로젝트 생성 중...');
+    expect(updateProgress).toHaveBeenNthCalledWith(2, 10, 'AI 코드 생성 시작...');
+    expect(updateProgress).toHaveBeenNthCalledWith(3, 55, '코드 작성');
+    expect(deps.completeGeneration).toHaveBeenCalledWith('proj-h', 3);
+    expect(deps.onCompleted).toHaveBeenCalledTimes(1);
+
+    const createBody = JSON.parse(
+      (fetchFn.mock.calls[0][1] as RequestInit).body as string,
+    ) as { name: string };
+    expect(createBody.name).toBe('프로젝트-1700000000000');
+  });
+
+  it('SSE error 이벤트는 failGeneration으로 전파', async () => {
+    const streamBody = 'event: error\ndata: {"message":"QC 실패"}\n\n';
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonRes({ data: { id: 'proj-e' } }))
+      .mockResolvedValueOnce(makeStreamRes([streamBody]));
+    const deps = makeDeps({ fetchFn });
+
+    await runClientGeneration(input, deps);
+
+    expect(deps.failGeneration).toHaveBeenCalledWith('QC 실패');
+    expect(deps.onCompleted).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/generation/runClientGeneration.test.ts
+++ b/src/lib/generation/runClientGeneration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { runClientGeneration } from './runClientGeneration';
 
 function makeJsonRes(body: unknown, ok = true): Response {
@@ -60,6 +60,10 @@ const input = {
 describe('runClientGeneration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('create 실패 → failGeneration, generate 미호출', async () => {
@@ -147,5 +151,73 @@ describe('runClientGeneration', () => {
 
     expect(deps.failGeneration).toHaveBeenCalledWith('QC 실패');
     expect(deps.onCompleted).not.toHaveBeenCalled();
+  });
+
+  it('injectable deps 생략 시 기본 fetchFn(now/consumeStream/poll) 배선으로 동작', async () => {
+    // characterization: 언바운드 fetch 대신 (input, init) => fetch(...) 래퍼가 기본값.
+    // 전역 fetch만 stub 하고 fetchFn/now/pollGenerationStatusFn/consumeStream 미주입.
+    const streamBody =
+      'event: progress\ndata: {"progress":40,"message":"생성 중"}\n\n';
+    const fetchMock = vi
+      .fn()
+      // 1) 프로젝트 생성
+      .mockResolvedValueOnce(makeJsonRes({ data: { id: 'proj-def' } }))
+      // 2) generate SSE — complete 없이 종료 → 기본 pollForCompletion 경로
+      .mockResolvedValueOnce(makeStreamRes([streamBody]))
+      // 3) 기본 pollGenerationStatus → 전역 fetch 로 status 조회
+      .mockResolvedValueOnce(
+        makeJsonRes({
+          data: {
+            status: 'completed',
+            result: { projectId: 'proj-def', version: 7 },
+          },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    // makeDeps 의 now/fetchFn 을 쓰지 않는다 — 기본 파라미터 경로 검증
+    const startGeneration = vi.fn();
+    const updateProgress = vi.fn();
+    const completeGeneration = vi.fn();
+    const failGeneration = vi.fn();
+    const setGeneratingProjectId = vi.fn();
+    const onCompleted = vi.fn();
+
+    await runClientGeneration(input, {
+      startGeneration,
+      updateProgress,
+      completeGeneration,
+      failGeneration,
+      setGeneratingProjectId,
+      onCompleted,
+      documentRef: {
+        visibilityState: 'visible' as DocumentVisibilityState,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+    });
+
+    // 기본 fetchFn 이 global.fetch 를 (input, init) 형태로 호출
+    expect(fetchMock).toHaveBeenCalled();
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/projects');
+    expect(fetchMock.mock.calls[1][0]).toBe('/api/v1/generate');
+
+    const createBody = JSON.parse(
+      (fetchMock.mock.calls[0][1] as RequestInit).body as string,
+    ) as { name: string };
+    // 기본 now = () => Date.now()
+    expect(createBody.name).toMatch(/^프로젝트-\d+$/);
+
+    // stream_ended → 기본 pollForCompletion → pollGenerationStatus(fn 기본값)
+    await vi.waitFor(() => {
+      expect(completeGeneration).toHaveBeenCalledWith('proj-def', 7);
+    });
+    expect(onCompleted).toHaveBeenCalledTimes(1);
+    expect(failGeneration).not.toHaveBeenCalled();
+    expect(
+      fetchMock.mock.calls.some(
+        (c) => c[0] === '/api/v1/generate/status/proj-def',
+      ),
+    ).toBe(true);
   });
 });

--- a/src/lib/generation/runClientGeneration.ts
+++ b/src/lib/generation/runClientGeneration.ts
@@ -1,0 +1,140 @@
+/**
+ * 클라이언트 생성 오케스트레이션 — 프로젝트 생성 → POST generate → SSE 소비.
+ *
+ * `builder/page.tsx` handleGenerate 본문에서 추출. React/router 의존 없음.
+ * 스토어 액션·fetch·poll·document·now 를 주입받아 단위 테스트 가능.
+ *
+ * **characterization 고정**: SSE + 폴링 이중 경로 레이스 포함 현 동작 보존 (P3 별도).
+ */
+
+import {
+  consumeGenerationStream,
+  type ConsumeGenerationStreamDeps,
+} from './consumeGenerationStream';
+import {
+  pollGenerationStatus,
+  type PollGenerationStatusDeps,
+} from './pollGenerationStatus';
+
+export interface RunClientGenerationInput {
+  context: string;
+  apiIds: string[];
+  designPreferences: unknown;
+  templateId?: string | null;
+}
+
+export interface RunClientGenerationDeps {
+  startGeneration: () => void;
+  updateProgress: (progress: number, message: string) => void;
+  completeGeneration: (projectId: string, version?: number) => void;
+  failGeneration: (message: string) => void;
+  setGeneratingProjectId: (id: string) => void;
+  /** complete 시 resetContext + clearApis 등 정리. */
+  onCompleted?: () => void;
+  /** fetch 주입 (테스트용). 기본 전역 fetch. */
+  fetchFn?: typeof fetch;
+  /**
+   * 폴링 구현 주입. 기본 `pollGenerationStatus`.
+   * 테스트에서 호출 횟수·인자를 관측할 때 교체.
+   */
+  pollGenerationStatusFn?: (
+    projectId: string,
+    deps: PollGenerationStatusDeps,
+  ) => Promise<void>;
+  /** Document 주입 (visibility 폴백 테스트). */
+  documentRef?: ConsumeGenerationStreamDeps['documentRef'];
+  /** 프로젝트 이름 timestamp. 기본 Date.now. */
+  now?: () => number;
+  /** SSE 소비 구현 주입 (테스트용). 기본 consumeGenerationStream. */
+  consumeStream?: typeof consumeGenerationStream;
+}
+
+/**
+ * 생성 전체 흐름. 실패 시 failGeneration, 성공/폴링 전환 시 내부에서 상태 갱신.
+ * 반환값은 없음 — 페이지는 스토어 status를 구독한다.
+ */
+export async function runClientGeneration(
+  input: RunClientGenerationInput,
+  deps: RunClientGenerationDeps,
+): Promise<void> {
+  const {
+    startGeneration,
+    updateProgress,
+    completeGeneration,
+    failGeneration,
+    setGeneratingProjectId,
+    onCompleted,
+    // 언바운드 호출 시 Illegal invocation 방지
+    fetchFn = (inputInit, init) => fetch(inputInit, init),
+    pollGenerationStatusFn = pollGenerationStatus,
+    documentRef,
+    now = () => Date.now(),
+    consumeStream = consumeGenerationStream,
+  } = deps;
+
+  startGeneration();
+
+  try {
+    updateProgress(5, '프로젝트 생성 중...');
+    const createRes = await fetchFn('/api/v1/projects', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: `프로젝트-${now()}`,
+        context: input.context,
+        apiIds: input.apiIds,
+        designPreferences: input.designPreferences,
+      }),
+    });
+
+    if (!createRes.ok) {
+      const errData = (await createRes.json().catch(() => ({}))) as {
+        error?: { message?: string };
+      };
+      throw new Error(errData.error?.message ?? '프로젝트 생성에 실패했습니다.');
+    }
+
+    const { data: project } = (await createRes.json()) as { data: { id: string } };
+    setGeneratingProjectId(project.id);
+
+    updateProgress(10, 'AI 코드 생성 시작...');
+    const genRes = await fetchFn('/api/v1/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        projectId: project.id,
+        templateId: input.templateId ?? undefined,
+      }),
+    });
+
+    if (!genRes.ok) {
+      const errData = (await genRes.json().catch(() => ({}))) as {
+        error?: { message?: string };
+      };
+      throw new Error(errData.error?.message ?? '코드 생성에 실패했습니다.');
+    }
+
+    const reader = genRes.body?.getReader();
+    if (!reader) throw new Error('스트림을 읽을 수 없습니다.');
+
+    // 폴링 로직은 pollGenerationStatus (단위 테스트 대상).
+    // 동작 보존: completed 시 completeGeneration → onCompleted.
+    const pollForCompletion = (pid: string): Promise<void> =>
+      pollGenerationStatusFn(pid, {
+        updateProgress,
+        completeGeneration,
+        failGeneration,
+        onCompleted,
+      });
+
+    await consumeStream(reader, project.id, {
+      updateProgress,
+      completeGeneration,
+      onCompleted,
+      pollForCompletion,
+      documentRef,
+    });
+  } catch (err) {
+    failGeneration(err instanceof Error ? err.message : '알 수 없는 오류');
+  }
+}


### PR DESCRIPTION
## 배경

`builder/page.tsx`의 `handleGenerate`(173~313행)는 **프로젝트 생성 → 생성 트리거 → SSE 리더 → 폴백 폴링** 오케스트레이션 전체를 혼자 들고 있으면서 두 가지 문제를 동시에 갖고 있었다:

- **테스트 0건** — 저장소 최대 테스트 공백
- **SonarCloud 인지 복잡도 48** (임계 15) — 코드베이스 최악의 CRITICAL

두 신호가 같은 지점을 가리켰다.

## ⚠️ 이 PR은 동작을 고치지 않는다

이중 경로(SSE + 폴링)에는 알려진 레이스가 있고 작업 중 계속 눈에 띄었지만 **하나도 고치지 않았다.** `void pollForCompletion(...)` fire-and-forget과 abort 부재를 그대로 보존했고, 그런 지점은 코드·테스트에 `characterization: 현 동작 고정 (P3에서 변경 예정)`으로 표시했다.

> 안전망이 없는 프로덕션 결제 인접 경로에서 **기계적 이동 버그와 의도적 동작 변경을 한 PR에 섞으면 실패 원인을 가릴 수 없다.** 레이스 수정(폴링 취소·단일 terminal owner)은 P3에서 별도 PR로 한다.

## 커밋 2개 (리뷰 단위)

**P1 — SSE 파서·스트림 소비 추출** (페이지 미변경)

- `parseSseBlocks.ts` — 순수 함수. `slice(7).trim()`/`slice(6)`, 빈 블록·빈 data 스킵, JSON 실패 시 warn 후 계속 — 원본과 동일
- `consumeGenerationStream.ts` — reader 루프 + `visibilitychange` 폴백 + 플래그 3종 + `finally` 정리. `document`와 폴 함수를 주입받아 두 경로를 모두 테스트로 구동
- **`stream_ended` 분기가 `switchedToPolling`을 설정하지 않는 것까지 원본 그대로** 두었다(원본은 visibility·stream_error에서만 설정)

**P2 — 최상위 조립 + 페이지 얇게**

- `runClientGeneration.ts` — 생성 → `setGeneratingProjectId` → generate → reader → 스트림 위임 → 바깥 catch
- `page.tsx` **−141 / +33**. `handleGenerate`는 호출 한 번이 됐고 의존성 배열은 그대로

## 충실도 검증 (제가 원본과 한 줄씩 대조)

- `onCompleted`가 **폴링과 SSE 양쪽에** 걸린다 — 원본은 폴링엔 `onCompleted`, SSE complete엔 인라인 `resetContext(); clearApis();`로 같은 일을 하고 있었다
- 에러 메시지 3종·`templateId ?? undefined`·바깥 catch 폴백 문구 동일
- `Date.now()`는 주입 가능하게 바꿔 테스트 결정성을 확보(`now`)
- `fetchFn` 기본값을 화살표로 감쌌다 — 언바운드 `fetch`는 브라우저에서 Illegal invocation이 난다. **동작 변경이 아니라 정확성 보강**

## 테스트 +18건

파서 6 · 스트림 7 · 조립 5. 스트림 쪽은 이중 경로 순서를 전부 고정한다 — complete 시 폴링 미호출, 스트림 종료 시 폴링 1회, visibility 전환 시 cancel + 폴링 1회, 완료 후 visibility는 폴링 안 함, 이미 전환됐으면 두 번째 폴링 없음.

## 검증

| 게이트 | 결과 |
|---|---|
| `pnpm test` | **188파일 / 2340테스트** (직전 185/2322 → +3파일 / +18건) |
| `pnpm type-check` | 통과 |
| `pnpm lint` | 0 errors (기존 경고 2건) |

`src/lib/**`가 이미 `coverage.include`에 있어 vitest 설정 변경은 불필요했다(확인함).

## 다음 (P3, 별도 PR)

`pollGenerationStatus`에 abort를 도입해 **단일 terminal owner**를 만든다. 현재는 스토어 터미널 래치가 유일한 안전망이고, 이미 도는 폴링을 멈추는 수단이 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
