### PR TITLE
docs: operations.md 전면 재작성 — SQLite 컷오버 이후 기준으로 (D-a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,8 @@ pnpm tsx scripts/generateCountries.ts  # 국가 데이터(src/data/countries.jso
 | better-sqlite3 v13 N-API 프리빌트 전환·빌드 툴체인 제거 ADR (2026-07-28) | [docs/decisions/2026-07-28-better-sqlite3-v13-napi-prebuilds.md](docs/decisions/2026-07-28-better-sqlite3-v13-napi-prebuilds.md) |
 | 환경변수 목록 | [docs/reference/env-vars.md](docs/reference/env-vars.md) |
 | 에러 클래스 참조 | [docs/reference/error-codes.md](docs/reference/error-codes.md) |
-| 배포/운영 작업 | [docs/guides/deployment.md](docs/guides/deployment.md) |
+| 배포·CI/CD·도메인 | [docs/guides/deployment.md](docs/guides/deployment.md) |
+| **일상 운영·모니터링·백업·장애 대응** | [docs/guides/operations.md](docs/guides/operations.md) |
 | **SQLite 컷오버 + Supabase/Postgres/OAuth 제거 ADR (P8.2, 2026-06-23)** | [docs/decisions/2026-06-23-sqlite-cutover-and-supabase-removal.md](docs/decisions/2026-06-23-sqlite-cutover-and-supabase-removal.md) |
 | SQLite 전환 WBS 계획 (Phase 1~8) | [docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md](docs/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md) |
 | SQLite 컷오버 런북 | [docs/guides/sqlite-cutover-runbook.md](docs/guides/sqlite-cutover-runbook.md) |

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -1,305 +1,258 @@
 # 운영 가이드
 
-> **최종 업데이트:** 2026-04-12
+> **최종 업데이트:** 2026-07-31  
+> **대상:** 프로덕션(https://xzawed.xyz)을 **오늘** 점검·대응해야 하는 운영자  
+> **스택:** Railway 단일 인스턴스 · 임베디드 SQLite(`/data/app.db`) · Auth.js 로컬 인증 · Slack 경보
+
+배포·CI·Dockerfile·도메인 연결은 [deployment.md](deployment.md)에 있다.  
+불변조건·계약은 [system-spec.md](../architecture/system-spec.md), 환경변수 전체는 [env-vars.md](../reference/env-vars.md),  
+엔드포인트 스키마는 [api-endpoints.md](../reference/api-endpoints.md)를 본다. **이 문서는 중복하지 않고 링크한다.**
 
 ---
 
-## 1. 모니터링
+## 0. 전제 (읽기 전)
 
-### 모니터링 항목
-
-| 항목 | 도구 | 주기 |
-|------|------|------|
-| 사이트 가동 여부 | UptimeRobot | 5분 |
-| 에러 추적 | Sentry | 실시간 |
-| API 응답 시간 | Railway Observability | 실시간 |
-| DB 사용량 | Supabase Dashboard | 일간 |
-| 무료 한도 사용률 | 수동 확인 | 주간 |
-
-### 알림 설정
-
-| 이벤트 | 알림 채널 | 대상 |
-|--------|-----------|------|
-| 사이트 다운 | Email | 운영자 |
-| 에러 급증 | Sentry Email | 운영자 |
-| 무료 한도 80% 도달 | Email | 운영자 |
-| 생성 서비스 장애 | 대시보드 표시 | 사용자 |
-
-### 주간 모니터링 체크리스트
-
-매주 월요일에 확인:
-
-| # | 확인 항목 | 확인 위치 |
-|---|-----------|-----------|
-| 1 | Railway 크레딧 사용률 | Railway Dashboard → Usage |
-| 2 | Railway 프로젝트 수 | Railway Dashboard → Projects |
-| 3 | Railway 실행 시간 사용률 | Railway Dashboard → Usage |
-| 4 | Supabase DB 용량 | Supabase Dashboard → Database → Size |
-| 5 | Supabase 대역폭 | Supabase Dashboard → Usage |
-| 6 | GitHub Actions 사용 시간 | GitHub → Settings → Billing → Actions |
-| 7 | Claude API 사용량 | Anthropic Console → Usage |
-| 8 | Sentry 이벤트 수 | Sentry Dashboard → Stats |
-
-### `/api/v1/health` 엔드포인트
-
-UptimeRobot에서 5분마다 호출 → Supabase 일시정지 방지 겸용. 인증 없는 공개 호출은 가동 여부 확인용 최소 응답만 반환합니다(UptimeRobot은 이 응답으로 가동 여부만 확인):
-
-```json
-{
-  "status": "ok",
-  "timestamp": "2026-03-20T12:00:00Z"
-}
-```
-
-상세 정보는 `?detailed=true` 쿼리와 `Authorization: Bearer ${ADMIN_API_KEY}` 헤더가 **모두** 있어야 노출됩니다:
-
-```json
-{
-  "status": "ok",
-  "timestamp": "2026-03-20T12:00:00Z",
-  "checks": {
-    "database": "ok",
-    "ai": "ok",
-    "aiProvider": "claude",
-    "deploy": "ok"
-  },
-  "usage": {
-    "todayGenerations": 23,
-    "totalProjects": 87,
-    "totalUsers": 0,
-    "limits": {
-      "maxDailyGenerationsPerUser": 10,
-      "maxApisPerProject": 0,
-      "maxProjectsPerUser": 0
-    }
-  }
-}
-```
+| 전제 | 의미 |
+|------|------|
+| **Supabase 없음** | 2026-06-23 SQLite 컷오버로 DB·Auth·Dashboard 전부 제거. Supabase 절차는 무시한다. |
+| **Sentry 미도입** | 알림 sink는 **Slack 하나**(`#alerts`). Sentry 대시보드를 찾지 말 것. |
+| **단일 인스턴스** | 인메모리 레이트리밋·진행률·site 프록시 집계는 프로세스 재시작 시 초기화된다. |
+| **자격 증명** | `ADMIN_API_KEY`, Railway 로그인, Anthropic/GitHub 콘솔 접근은 **운영자 소관**. 이 문서는 값을 다루하지 않는다. |
 
 ---
 
-## 2. 트러블슈팅
+## 1. 일상 운영 — 오늘 무엇을 볼까
 
-### 사이트 접속 불가
+### 1.1 빠른 순서 (증상 없을 때)
 
-1. Railway Dashboard → Deployments 탭에서 최신 배포 상태 확인
-2. "Active" (초록색)이 아니면 이전 배포로 롤백 (Rollback 버튼)
-3. Cloudflare DNS가 Railway URL을 정상 가리키는지 확인
+1. 공개 헬스: `GET /api/v1/health` → `{"status":"ok",...}`  
+2. 관리자 진단: `GET /api/v1/admin/debug` → `models.*.fellBack === false`, `email.configured`/`fromSet`  
+3. 생성 품질 추이: `GET /api/v1/admin/qc-stats` (기본 최근 7일)  
+4. (트래픽 있을 때) `GET /api/v1/admin/site-proxy-stats` → `blockedByProject` 해석  
+5. Railway 최신 배포 상태: `railway deployment list --json` — 판별표는 [§4](#4-장애-대응)
 
-### 로그인 후 대시보드로 이동하지 않음
+이상 징후(배포 실패, `fellBack: true`, 이메일 미설정, 생성 실패 급증, 백업 경보)가 있을 때만 깊게 판다. 정상이면 여기까지.
 
-Supabase Dashboard → Authentication → URL Configuration에서 Redirect URLs 확인:
-- `https://xzawed.xyz/callback` 이 목록에 있어야 함
+### 1.2 관리자 API 공통
 
-### 카탈로그 항목이 비정상적으로 적게 보임
-
-정상 활성 카탈로그는 23개입니다. 이보다 현저히 적게 보이면 seed.sql을 아직 실행하지 않은 것. Supabase SQL Editor에서 `supabase/seed.sql`을 실행하세요.
-
-### DB 연동 기능 전체 실패 (Supabase 일시정지)
-
-```
-증상: 모든 DB 연동 기능 실패
-긴급 대응:
-1. Supabase Dashboard → 프로젝트 → "Restore" 클릭 (수 분 소요)
-2. UptimeRobot Health Check가 정상 설정되었는지 확인
-3. 재발 방지: /api/v1/health 엔드포인트 호출 주기 확인
-```
-
-> Supabase Free 플랜은 7일간 비활성 시 자동 일시정지됩니다.  
-> UptimeRobot에서 `/api/v1/health`를 5분마다 호출하여 방지합니다.
-
-### DNS 변경 후 사이트가 안 열림
-
-1. 5~10분 기다린 후 다시 시도
-2. 브라우저 캐시 지우기 (Ctrl+Shift+Delete)
-3. 시크릿 모드로 시도
-4. 24시간이 지나도 안 되면 DNS 설정 재확인
-
-### 서브도메인(`slug.xzawed.xyz`) 404 에러
-
-- Cloudflare에 `*` 와일드카드 CNAME 레코드가 있는지 확인
-- Railway에 `*.xzawed.xyz` 커스텀 도메인이 추가되어 있는지 확인
-- `NEXT_PUBLIC_ROOT_DOMAIN=xzawed.xyz` 환경변수가 설정되어 있는지 확인
-
----
-
-## 3. 무료 티어 한도 관리
-
-### 서비스별 무료 한도 상세
-
-#### Railway (플랫폼 호스팅)
-
-| 항목 | 무료 한도 | 주의사항 |
-|------|-----------|---------|
-| 크레딧 | $5 / 월 | 실행 시간 + 리소스 사용량 기준 |
-| 실행 시간 | 500시간 / 월 | Trial 플랜 기준 |
-| 메모리 | 512 MB | 기본 서비스 크기 |
-| 프로젝트 수 | 무제한 | 크레딧 한도 내 |
-| 팀 멤버 | 1명 (Trial) | 개인 계정만 |
-
-**위험 시나리오:** 월 $5 크레딧 소진 시 서비스 중단
-
-**대응 방안:**
-```
-크레딧 관리:
-├── 비활성 서비스 자동 정리 (90일 미사용)
-├── 사용자당 최대 서비스 5개 제한
-└── 한도 도달 시 GitHub Pages로 대체 배포
-
-리소스 관리:
-├── 코드 생성 로직 최적화 (프롬프트 간결화)
-├── 생성 결과 캐싱 (유사 요청 재사용)
-└── 비피크 시간대 생성 유도
-```
-
-#### Supabase (데이터베이스)
-
-| 항목 | 무료 한도 | 주의사항 |
-|------|-----------|---------|
-| 데이터베이스 | 500 MB | generated_codes 테이블이 주 소비 |
-| 대역폭 | 5 GB / 월 | API 호출 빈도에 비례 |
-| Storage | 1 GB | 현재 미사용 예정 |
-| Edge Functions | 500,000 호출 / 월 | 현재 미사용 예정 |
-| Auth MAU | 50,000 | 충분 |
-| Realtime | 200 동시 접속 | 충분 |
-| 일시정지 | 7일 비활성 시 자동 일시정지 | **주의: 주기적 활성화 필요** |
-
-**위험 시나리오:**
-- `generated_codes` 테이블의 코드 데이터가 500MB를 초과
-- 7일간 사용자가 없으면 DB 자동 일시정지
-
-**대응 방안:**
-```
-DB 용량 관리:
-├── generated_codes: 프로젝트당 최신 3버전만 보관
-├── 90일 이상 미사용 프로젝트의 코드 자동 삭제
-├── 코드 데이터 압축 저장 (gzip)
-└── 월간 용량 모니터링 쿼리 실행
-
-일시정지 방지:
-├── UptimeRobot으로 5분마다 Health Check 호출
-└── /api/v1/health 엔드포인트 구현 (DB 조회 포함)
-```
-
-**용량 모니터링 쿼리:**
-```sql
--- 테이블별 용량 확인
-SELECT
-  schemaname || '.' || tablename AS table_name,
-  pg_size_pretty(pg_total_relation_size(schemaname || '.' || tablename)) AS total_size
-FROM pg_tables
-WHERE schemaname = 'public'
-ORDER BY pg_total_relation_size(schemaname || '.' || tablename) DESC;
-
--- generated_codes 테이블 행 수 및 평균 크기
-SELECT
-  COUNT(*) AS total_rows,
-  pg_size_pretty(AVG(LENGTH(code_html) + LENGTH(code_css) + LENGTH(code_js))::bigint) AS avg_code_size,
-  pg_size_pretty(pg_total_relation_size('generated_codes')) AS total_table_size
-FROM generated_codes;
-```
-
-#### Claude API (AI 코드 생성)
-
-| 항목 | 주의사항 |
-|------|---------|
-| 크레딧 | 사용량 기반 과금 — 크레딧 소진 시 생성 불가 |
-| RPM (분당 요청) | API 플랜에 따라 상이 — 동시 사용자 제한 |
-
-**대응 방안:**
-```
-요청 관리:
-├── 사용자당 일일 10회 생성 제한
-├── 생성 요청 큐잉 (동시 요청 제한)
-├── 429 에러 시 자동 재시도 (exponential backoff)
-└── 유사 요청 캐싱 (동일 API+유사 컨텍스트)
-
-폴백 전략:
-├── 한도 초과 시 "잠시 후 다시 시도" 안내 + 예상 대기 시간
-└── 재시도 로직 (지수 백오프, 최대 3회)
-```
-
-#### GitHub
-
-| 항목 | 무료 한도 | 주의사항 |
-|------|-----------|---------|
-| 저장소 수 | 무제한 | |
-| Actions 시간 | 2,000분 / 월 | CI/CD 파이프라인 |
-| API 요청 | 5,000 / 시간 (인증) | 서비스 배포 시 소비 |
-
-#### 기타 서비스
-
-| 서비스 | 무료 한도 | 예상 사용량 | 여유도 |
-|--------|-----------|------------|--------|
-| Sentry | 5,000 이벤트 / 월 | ~500 | ✅ 충분 |
-| UptimeRobot | 50 모니터 | ~10 | ✅ 충분 |
-| Resend | 100 이메일 / 일, 3,000 / 월 | ~10/일 | ✅ 충분 |
-
-### 한도 초과 시 긴급 대응 매뉴얼
-
-#### Railway 크레딧 초과
-```
-증상: 사이트 접근 불가 (서비스 중단)
-긴급 대응:
-1. Railway Dashboard에서 크레딧 사용량 확인
-2. 다음 달 1일 크레딧 초기화까지 대기
-   또는
-3. 정적 페이지를 GitHub Pages로 임시 전환
-4. 이미지/정적 파일 CDN으로 분리 검토
-```
-
-#### Supabase 용량 초과
-```
-증상: DB 쓰기 실패, 서비스 생성 불가
-긴급 대응:
-1. 오래된 generated_codes 삭제
-   DELETE FROM generated_codes WHERE created_at < NOW() - INTERVAL '90 days';
-2. 비활성 프로젝트 정리
-3. 용량 재확인
-```
-
-#### Claude API 한도 초과
-```
-증상: 코드 생성 요청 시 429 에러
-긴급 대응:
-1. RPM 초과: 1분 대기 후 자동 재시도
-2. 크레딧 초과: "생성 한도에 도달했습니다" 안내
-3. Anthropic Console에서 사용량 확인 및 크레딧 충전
-```
-
-### 비용 발생 방지 안전장치
-
-| 서비스 | 주의사항 |
-|--------|---------|
-| **Railway** | Trial(무료) 플랜 — ⚠️ 유료 플랜으로 업그레이드하지 않도록 주의 |
-| **Supabase** | Free 플랜은 자동 과금 없음 — ⚠️ "Upgrade" 버튼 클릭 주의 |
-| **Claude API** | 사용량 기반 — Anthropic Console에서 사용량 주기적 확인 |
-| **GitHub** | Free 플랜 Actions 초과 시 자동 중단 — ⚠️ Spending limit: $0 확인 |
-
-### 사용량 예측 (100명 DAU 기준)
-
-| 항목 | 일일 | 월간 | 한도 | 여유 |
-|------|------|------|------|------|
-| DB 읽기 (100명 × 20쿼리 × 2KB) | 4MB | 120MB | 5GB | ✅ |
-| 코드 생성 (100명 × 2회) | 200회 | 6,000회 | API 플랜 기준 | ✅ |
-| DB 쓰기 (200회 × 20KB) | 4MB | 120MB | 500MB | ⚠️ |
-| 배포 | 100회 | 3,000프로젝트 | 크레딧 기반 | ⚠️ |
-
-**병목 지점:**
-1. **Supabase DB 용량** (500MB): 약 4개월 후 한도 도달 → 정리 정책 필수
-2. **Railway 크레딧** ($5/월): 사용량에 따라 한도 도달 → 비활성 정리 필수
-3. **Claude API**: 동시 요청 과다 시 병목 → 큐잉 필수
-
----
-
-## 4. 관리자 API
+모든 `/api/v1/admin/*` 는 `Authorization: Bearer <ADMIN_API_KEY>` 가 필요하다.  
+키 미설정·불일치 → 403. 상세 스키마·에러 코드: [api-endpoints.md — 관리자](../reference/api-endpoints.md).
 
 ```bash
-# QC 통계 조회
-GET /api/v1/admin/qc-stats
-Authorization: Bearer ${ADMIN_API_KEY}
-
-# 수동 QC 트리거
-POST /api/v1/admin/trigger-qc
-Authorization: Bearer ${ADMIN_API_KEY}
+# 예: 프로덕션 진단 (키는 셸 히스토리에 남기지 않도록 주의)
+curl -sS -H "Authorization: Bearer $ADMIN_API_KEY" \
+  "https://xzawed.xyz/api/v1/admin/debug"
 ```
+
+| 메서드 · 경로 | 답하는 질문 | 언제 쓰는가 |
+|---------------|-------------|-------------|
+| **GET** `/api/v1/admin/debug` | Node/플랫폼, **실제 적용 AI 모델**(`models.<task>.env` / `resolved` / **`fellBack`**), **이메일 설정 여부**(`email.configured` · `fromSet` · `fromDomain` — 값 자체는 비노출), standalone 필수 모듈 로드(`playwright-core`, `@anthropic-ai/sdk`, `better-sqlite3`, `drizzle-orm`) | **첫 진단.** 모델 env 변경 직후, 생성 500, 신규 가입자가 생성·배포 403일 때(`RESEND_API_KEY` 없으면 인증 메일이 no-op → `assertEmailVerified`가 막음) |
+| **GET** `/api/v1/admin/qc-stats?days=7` | 기간 내 생성 수·실패 수·실성공률, 구조/모바일/렌더링 QC 평균, Stage 스킵·Quality Loop 지표, 흔한 QC 실패 항목 | 생성 품질·실패율 추이. Slack 생성 실패 경보 후 원인 파악 |
+| **GET** `/api/v1/admin/site-proxy-stats?limit=50` | 게시 사이트(익명) 프록시 프로젝트별 허용/차단. **`blockedByIp` vs `blockedByProject` 구분** | 429 민원, 한도 조정 근거 수집. 인메모리 → **재시작 시 0**. `trackedProjects: 0`이면 아직 집계 트래픽 없음([#216](https://github.com/xzawed/CustomWebService/issues/216) 트리거 미충족 — **임의로 한도 바꾸지 말 것**) |
+| **GET** `/api/v1/admin/keys-verify` | 활성·플랫폼 키 의존 API의 env 키를 **배포 런타임에서** 실호출 검증(키 값 비노출) | 키 의존 API 재활성화 직후, 401 의심. **로컬/`railway run`은 sealed env 미주입** — 배포 환경에서만 유효 |
+| **POST** `/api/v1/admin/verify-catalog` | 활성 API GET을 라이브 호출해 `verification_status` 갱신(`working/degraded→verified`, `broken→broken`, 변경 시에만 쓰기; `key_gated`/`unknown` 보존) | 카탈로그 이상 의심·시드 반영 후. **스케줄 없음 — 관리자 수동 트리거**(플래핑·무인 outbound 방지) |
+| **GET** `/api/v1/admin/catalog-dump` | 프로덕션 `api_catalog` 전체(활성·비활성) 안전 투영 + `summary.active`/`inactive` | “카탈로그가 몇 개?” **하드코딩 숫자를 믿지 말고 이 응답으로 확인**. 시드 JSON diff용 |
+| **POST** `/api/v1/admin/trigger-qc` | 특정 `projectId`에 Fast+Deep QC 재실행 | QC 디버깅. `ENABLE_RENDERING_QC` 꺼져 있으면 400 |
+| **POST** `/api/v1/admin/test-generation` | 관리자 소유의 일회 생성 파이프라인 스모크(비용 발생) | 로드/통합 점검. 본문 스키마·비용 주의 — [api-endpoints.md](../reference/api-endpoints.md) |
+
+### 1.3 공개 헬스
+
+| 호출 | 응답 | 용도 |
+|------|------|------|
+| `GET /api/v1/health` | `{ "status": "ok", "timestamp": "..." }` | 가동 여부·외부 업타임 모니터. **인프라 상세 없음** |
+| `GET /api/v1/health?detailed=true` + `Authorization: Bearer <ADMIN_API_KEY>` | `status`: `healthy` / `degraded` / `unhealthy`, `checks`(database·ai·deploy), `usage` | DB ping·오늘 생성 수·AI/배포 설정 여부. 인증 실패 시 **공개 응답으로 폴백**(상세 존재 비노출). 관리자 키 IP 한도 초과 시 `429` + `status: "rate_limited"` — **공개 ok로 오인하지 말 것** |
+
+> Supabase 일시정지 방지용 헬스체크 서술은 **폐기**. SQLite는 프로젝트 pause가 없다.
+
+### 1.4 카탈로그 개수
+
+- **“활성 N개” 고정 문구를 문서/대시보드에 박지 않는다.** 진실원은 DB(`api_catalog.is_active`)이며 랜딩 카피도 `getActiveApiCount()`로 읽는다.
+- 운영 확인: `GET /api/v1/admin/catalog-dump` → `data.summary`.
+- 번들 시드 [`src/data/apiCatalog.json`](../../src/data/apiCatalog.json) 기준(이 문서 작성 시 로컬 검증): **총 61 · 활성 36 · 비활성 25**. 프로덕션은 배포·ensureCatalog·수동 변경으로 달라질 수 있다.
+- `supabase/seed.sql` **삭제됨**. 시드는 부팅 시 빈 테이블일 때만 JSON 삽입 + `ensureCatalogEntries` 멱등 반영. 절차 세부는 컷오버 ADR·[`sqlite-cutover-runbook.md`](sqlite-cutover-runbook.md).
+
+---
+
+## 2. 모니터링·경보
+
+### 2.1 Slack sink (활성)
+
+| 항목 | 내용 |
+|------|------|
+| 채널 | xzawed 워크스페이스 **`#alerts`** (앱 `xzawed alerts`) |
+| env | `SLACK_WEBHOOK_URL` — **키 존재가 아니라 값 길이**. 빈 문자열 = 미설정 = 조용한 no-op |
+| Sentry | **의도적 미도입**. env 잔재가 있어도 sink로 쓰지 않음 |
+| 설정·재발급·합성 경보 | **[monitoring-sink-setup.md](monitoring-sink-setup.md)** (2026-07-31 실경보 검증 완료) |
+
+### 2.2 경보 생산자 (코드에 배선된 것만)
+
+| 생산자 | 조건 | 동작 |
+|--------|------|------|
+| `errorRateMonitor` (`src/lib/monitoring/errorRateMonitor.ts`) | 5분 윈도우 내 `CODE_GENERATION_FAILED` ≥ `ERROR_RATE_ALERT_THRESHOLD`(기본 **5**) | Slack error 1회/윈도(`alerted` 플래그). 인메모리·단일 인스턴스 |
+| `scheduleBackups` (`src/lib/db/sqlite/backup.ts`) | 백업 **상태 전이**만: 첫 실패 또는 성공→실패 → error, 실패→성공 → info 복구 | 연속 실패 중 재알림 없음. 알림 실패는 스케줄러를 죽이지 않음(void+catch) |
+
+임계값 조정·다일 리마인더·site 프록시 Slack 승격은 **실경보·트래픽 데이터 후** 판단한다. 근거 없이 바꾸지 말 것 — [project WBS F그룹](../superpowers/plans/2026-07-31-project-wbs.md).
+
+### 2.3 경보 외 관측
+
+| 수단 | 용도 | 소유·주기 |
+|------|------|-----------|
+| Railway 로그 / Observability | 런타임 에러·배포 로그 | 인시던트 시 또는 배포 직후 — **고정 주간 의식 없음** |
+| Anthropic Console | 토큰·크레딧·429 | 생성 장애·비용 의심 시 운영자가 콘솔 확인 |
+| GitHub Actions | CI 실패 → 배포 대기 | 푸시 이벤트 기반 |
+| `#alerts` | 생성 실패율·백업 실패/복구 | 이벤트 기반(§2.2) |
+
+외부 업타임 모니터(UptimeRobot 등)를 쓰는 경우 공개 `/api/v1/health`를 가리키면 된다. **이 저장소에 강제 연동·필수 주기는 없다.**
+
+---
+
+## 3. 백업·보존
+
+구현: [`backup.ts`](../../src/lib/db/sqlite/backup.ts), [`retention.ts`](../../src/lib/db/sqlite/retention.ts).  
+env: [env-vars.md — SQLite 백업·DB 보존](../reference/env-vars.md).  
+**복구 절차는 여기에 쓰지 않는다** → [sqlite-restore-runbook.md](sqlite-restore-runbook.md).
+
+### 3.1 자동 백업
+
+| 항목 | 기본값 | 비고 |
+|------|--------|------|
+| 활성 | `SQLITE_BACKUP_ENABLED` ≠ `false` | |
+| 주기 | `SQLITE_BACKUP_INTERVAL_MS` = **24h** | 부팅 시 **즉시 1회** + interval. 배포마다 새 백업이 생기는 이유 |
+| 보관 개수 | `SQLITE_BACKUP_RETENTION` = **7** | `app-YYYYMMDD-HHmmss.db` 패턴만 삭제 후보 — 라이브 DB·WAL/SHM 절대 비대상 |
+| 경로 | `SQLITE_BACKUP_DIR` 또는 `<SQLITE 디렉터리>/backups` | 프로덕션 전형: `/data/backups/` · 라이브 DB `/data/app.db` |
+| 방식 | better-sqlite3 `.backup()` | WAL 중에도 자기완결 스냅샷. 단일 인스턴스·**동일 볼륨** 전제(오프-볼륨 DR은 별 과제) |
+| 경보 | §2.2 | 실패/복구 전이만 |
+
+### 3.2 DB 보존(정리)
+
+| 테이블 | 기본 보존 | 삭제 조건 |
+|--------|-----------|-----------|
+| `platform_events` | `EVENT_RETENTION_DAYS` = **90** | `created_at` 이 cutoff 이전 |
+| `auth_tokens` | `AUTH_TOKEN_RETENTION_DAYS` = **7** | **`expires_at` 지남 또는 `consumed_at` 있음** + cutoff. **유효한 미사용 토큰은 절대 삭제하지 않음**(인증·재설정 링크 보호) |
+| `user_daily_limits` | `DAILY_LIMIT_RETENTION_DAYS` = **30** | `usage_date` &lt; **로컬** 날짜 cutoff(UTC로 자르면 오늘 카운터 삭제 위험) |
+
+- 주기: `DB_RETENTION_INTERVAL_MS` 기본 24h, 부팅 시 1회. `DB_RETENTION_ENABLED=false` 시 스킵.
+- 세 DELETE는 **단일 동기 트랜잭션**. `0`/음수/비정수 env → 기본값 폴백(전체 삭제 사고 방지).
+- `generated_codes` 버전 정리는 이 스케줄러가 아니라 코드 저장 경로의 `pruneOldVersions()` 담당.
+
+### 3.3 복구가 필요할 때
+
+1. [sqlite-restore-runbook.md](sqlite-restore-runbook.md)만 따른다.  
+2. **WAL은 데이터 본체에 가깝다** — `app.db`만 덮고 WAL을 남기면 복구가 조용히 무효화되고 `integrity_check`는 여전히 `ok`일 수 있다(런북 실측).  
+3. 성공 판정은 integrity만이 아니라 **행 수 대조**.
+
+---
+
+## 4. 장애 대응
+
+### 4.1 Railway 배포 상태 해석
+
+Wait for CI가 활성이다. 신규 커밋은 CI 완료까지 `WAITING`에 머무를 수 있다.  
+**env 단독 변경 재배포가 항상 FAILED인 것은 아니다**(실증: 정상 `SUCCESS` 가능). `FAILED`면 **실제 실패로 보고 로그를 먼저 챙긴다** — 후속 배포로 대체되면 로그가 사라진다.
+
+| 상황 | 해석 |
+|------|------|
+| 신규 커밋 · `WAITING` 지속 | 정상 — CI 완료 대기 |
+| env 단독 변경 · 같은 커밋 · `SUCCESS` | 정상 |
+| env 단독 변경 · 같은 커밋 · `FAILED` | **조사** — 로그 즉시 수집 |
+| 신규 커밋 · `BUILDING`/`DEPLOYING` 중 `FAILED` | 실제 배포 실패 |
+| 서비스 health 죽음 | 장애 — 롤백 검토 |
+
+상세·quirks: 프로젝트 지침 [CLAUDE.md — Railway 배포 상태 판별](../../Claude.md).  
+`railway variables` 메타의 `patchId` 유무로 env 변경 재배포 vs 커밋 배포를 구분할 수 있다.
+
+### 4.2 실패 배포 로그 수집 (대체되기 전)
+
+```bash
+railway deployment list --json          # 실패 deployment id
+railway logs -b <deployment-id>         # 빌드
+railway logs -d <deployment-id>         # 런타임/배포
+```
+
+서비스가 여러 개 있는 프로젝트에서는 `--service CustomWebService`를 명시한다([복구 런북](sqlite-restore-runbook.md)과 동일).
+
+### 4.3 롤백
+
+1. **배포 태그**로 이전 정상 커밋 식별:  
+   `git tag -l 'deploy/*'`  
+   성공 배포 후 관례: `git tag deploy/YYYY-MM-DD-HHmm && git push origin --tags`  
+2. 해당 커밋으로 재배포(Railway 대시보드 Rollback 또는 태그 커밋 재배포).  
+3. env/`railway.toml`/`startCommand` 함정: Dockerfile `ENTRYPOINT`를 덮어쓰면 비root·`/data` chown 경로가 깨질 수 있다 — [Claude.md 배포 품질 원칙](../../Claude.md).
+
+### 4.4 증상별 초동 (현재 스택 기준)
+
+| 증상 | 초동 |
+|------|------|
+| 사이트 전체 다운 | §4.1 배포 상태 → 로그 → 공개 health → 필요 시 롤백 |
+| 생성 실패 급증 / Slack 생성 경보 | `admin/debug`(모델·모듈) → `qc-stats` → Anthropic 상태/크레딧 → Railway 로그. 임계·윈도는 §2.2 |
+| 신규 가입 후 생성·배포 403 | `admin/debug`의 `email.configured`/`fromSet`. Resend 미설정이면 인증 메일 no-op |
+| 서브도메인 404 | DNS `*` CNAME, Railway `*.xzawed.xyz`, `NEXT_PUBLIC_ROOT_DOMAIN` — [deployment.md](deployment.md) |
+| 게시 사이트 API만 404(미리보기는 정상) | middleware `SUBDOMAIN_PASSTHROUGH_PREFIXES`에 `/api/v1/proxy` 등 예외 여부 — 시스템 명세·Claude 배포 품질 |
+| DB 손상·오염 의심 | **[sqlite-restore-runbook.md](sqlite-restore-runbook.md)**. “Supabase Restore” 없음 |
+| 카탈로그가 비정상적으로 적음 | `catalog-dump`의 `summary`. seed.sql 실행 지시 **금지(파일 없음)**. 필요 시 시드 JSON·ensureCatalog·`verify-catalog` |
+| site 프록시 429 | `site-proxy-stats`에서 IP vs 프로젝트 한도 구분. 한도 변경은 ADR 기준표 + 데이터 있을 때만 |
+
+보안 인시던트 절차: [incident-response.md](../security/incident-response.md).
+
+---
+
+## 5. 정기 점검 vs 트리거 기반
+
+**존재하지 않는 “매주 월요일 의식”을 만들지 않는다.** 아래만 구분한다.
+
+### 5.1 자동(코드/플랫폼이 돌림)
+
+| 무엇 | 주기·트리거 | 비고 |
+|------|-------------|------|
+| SQLite 백업 | 부팅 1회 + 기본 24h | §3.1 |
+| DB 보존 prune | 부팅 1회 + 기본 24h | §3.2 |
+| 생성 실패율 Slack | 5분 윈도 임계 | §2.2 |
+| 백업 실패/복구 Slack | 상태 전이 | §2.2 |
+| CI → (main) 배포 | 푸시 | [deployment.md](deployment.md) |
+| Wait for CI | 신규 커밋 배포 전 | §4.1 |
+
+### 5.2 수동·트리거 (스케줄 없음 · 운영자 판단)
+
+| 무엇 | 트리거 예 |
+|------|-----------|
+| `admin/debug` · health detailed | 세션 시작, 배포 직후, 장애 신고 |
+| `qc-stats` | 품질 의심, 생성 경보 후 |
+| `site-proxy-stats` | 429·오남용 의심. `trackedProjects:0`이면 데이터 없음 — **한도 재조정 착수 금지**([#216](https://github.com/xzawed/CustomWebService/issues/216)) |
+| `keys-verify` | 키 활성화·교체 후 |
+| `verify-catalog` | 카탈로그 이상·대규모 시드 변경 후(자동 cron 없음) |
+| `catalog-dump` | 시드 동기화 diff, 활성 개수 확인 |
+| Anthropic/Railway 사용량 | 비용·한도 의심 시 각 콘솔(운영자 계정) |
+| 배포 태그 부착 | 배포 **성공 확인 후** (관례) |
+| Slack webhook 재발급 | 유출·채널 이전 — [monitoring-sink-setup.md](monitoring-sink-setup.md) |
+| SQLite 복구 리허설 | 인시던트 전 연습 시 런북 |
+
+### 5.3 비용·외부 한도 (요약을 넘기지 않음)
+
+한도 숫자는 플랜·시점에 따라 바뀌므로 **대시보드 실측이 진실원**이다. 이 문서에 Trial $5·Supabase 500MB·Sentry 이벤트 같은 **폐기 수치를 다시 적지 않는다.**
+
+| 의존성 | 운영자가 볼 곳 | 비고 |
+|--------|----------------|------|
+| Railway | Dashboard Usage / 크레딧 | 호스팅·볼륨. 크레딧 소진 시 서비스 중단 가능 |
+| Anthropic | Console Usage | 생성 불능·429. 앱 일일 생성 한도는 env(`MAX_DAILY_GENERATIONS` 등) — [env-vars.md](../reference/env-vars.md) |
+| GitHub Actions | Billing / Actions | CI 분 |
+| Resend | 대시보드 | 인증·재설정 메일. 미설정 시 no-op([§1.2 debug.email](#12-관리자-api-공통)) |
+| SQLite 디스크 | 볼륨 `/data` | 보존 정책이 무한 증가를 완화. 용량 위기는 복구 런북·볼륨 확장 판단 |
+
+배포 파이프라인·무료 티어 표의 일부 구문([deployment.md §7](deployment.md))은 아직 컷오버 이전 잔재가 있을 수 있다. **운영 판단은 이 문서와 실측 콘솔을 우선**한다.
+
+---
+
+## 6. 관련 문서
+
+| 문서 | 역할 |
+|------|------|
+| [deployment.md](deployment.md) | CI/CD, Railway 배포, 도메인, Playwright QC 이미지 |
+| [monitoring-sink-setup.md](monitoring-sink-setup.md) | Slack webhook 등록·합성 경보 |
+| [sqlite-restore-runbook.md](sqlite-restore-runbook.md) | DB 손상 시 백업 복구 |
+| [sqlite-cutover-runbook.md](sqlite-cutover-runbook.md) | (역사) PG→SQLite 컷오버 |
+| [env-vars.md](../reference/env-vars.md) | 환경변수 전체 |
+| [api-endpoints.md](../reference/api-endpoints.md) | 헬스·관리자 API 스키마 |
+| [system-spec.md](../architecture/system-spec.md) | 깨면 사고 나는 불변조건 |
+| [incident-response.md](../security/incident-response.md) | 보안 인시던트 |
+| [2026-07-31-project-wbs.md](../superpowers/plans/2026-07-31-project-wbs.md) | 잔여 작업·관측 대기 항목 |
+| [Claude.md](../../Claude.md) | 프로젝트 헌법(배포 품질·Railway 판별·운영 함정) |

--- a/docs/superpowers/plans/2026-07-31-project-wbs.md
+++ b/docs/superpowers/plans/2026-07-31-project-wbs.md
@@ -106,7 +106,8 @@
 
 | ID | 작업 | 크기 |
 |----|------|------|
-| D-a | **`docs/guides/operations.md` 전면 재작성.** 최종 갱신이 2026-04-12(SQLite 컷오버 이전)라 Sentry·Supabase Dashboard·Supabase Auth URL·삭제된 `seed.sql`·"활성 23개"·"Supabase DB 500MB"가 그대로다. **`deployment.md`가 이 문서를 참조**하므로 오독 위험이 실재한다 | M |
+| ~~D-a~~ | ~~`docs/guides/operations.md` 전면 재작성~~ → ✅ **완료(2026-07-31)**. Sentry·Supabase Dashboard·`seed.sql`·"활성 23개"·"500MB" 등 폐기 내용을 걷어내고 관리자 진단 엔드포인트 중심으로 다시 썼다. **CLAUDE.md 문서 테이블에 `operations.md` 행이 아예 없던 것**도 함께 고쳤다 — 그게 이 문서가 방치된 원인 중 하나였다 | — |
+| **D-e** | **`docs/guides/deployment.md`에도 Supabase·Sentry 잔재가 있다** (D-a 작업 중 발견, 범위 밖으로 남김). operations.md가 "deployment 7절 잔재 가능, 실측 우선"으로 경고하고 있으나 근본 수정이 필요하다 | S |
 | D-b | `docs/guides/development.md`·`testing.md`의 Supabase 시그니처 제거 — `createProjectService(supabase)` 같은 코드가 "✅ 올바른 방식" 블록에 남아 있다(실제 팩토리는 무인자) | S |
 | D-c | `plans/2026-06-09-test-flakiness-followups.md`의 stale quirk 정정 — `pollGenerationStatus`의 `failed` 처리를 "미수정 보존"으로 기술하나 **코드는 이미 즉시 실패**로 개선됐다 | S |
 | D-d | `AUTH_URL`·`DB_PROVIDER` env 문서화 (둘 다 `env-vars.md`에 행이 없다) | S |


### PR DESCRIPTION
## 배경

`docs/guides/operations.md`의 최종 갱신이 **2026-04-12로 SQLite 컷오버(2026-06-23) 이전**이라, 존재하지 않는 인프라의 운영 절차를 안내하고 있었다. `deployment.md`가 이 문서를 참조하므로 오독 위험이 실재했다.

## 걷어낸 것 — 전부 폐기된 절차

| 내용 | 실제 |
|---|---|
| Sentry 실시간 에러 추적·주간 이벤트 점검 | **Sentry는 의도적 미도입**. sink는 Slack 하나 |
| Supabase Dashboard·Auth URL·일시정지/Restore·"DB 500MB" | 2026-06-23에 전부 제거됨 |
| `supabase/seed.sql` 실행 지시 | **그 파일은 삭제됐다** |
| "활성 카탈로그 23개" | 실제 61행 중 활성 36 |
| UptimeRobot으로 Supabase pause 방지 | SQLite에 pause 개념 없음 |
| "매주 월요일" 체크리스트 | **그 주기를 지키는 소유자가 없다** |

마지막 항목이 특히 중요하다. **없는 주기를 문서가 만들어내지 않도록** 자동(스케줄러가 실제로 도는 것) / 트리거 기반(사건이 생겼을 때)으로 다시 분류했다.

## 새 구조 — "오늘 뭔가 해야 하는 운영자" 기준

전제(Supabase·Sentry 없음, 단일 인스턴스) → 일상 점검 → 모니터링·경보 → 백업·보존 → 장애 대응 → 정기 vs 트리거.

**관리자 진단 엔드포인트 8개를 주요 도구로 전면에 세웠다.** 각각이 무슨 질문에 답하고 언제 꺼내 쓰는지를 적었다. 특히 `GET /api/v1/admin/debug`는 이번 주에 `models.<task>.fellBack`(모델 env 조용한 폴백)과 `email.configured`(이메일 no-op 여부)를 노출하게 되어 Railway 콘솔 없이 확인 가능한 범위가 넓어졌다.

## 중복하지 않고 링크한다

복구 수순은 `sqlite-restore-runbook.md`, webhook 발급은 `monitoring-sink-setup.md`, Railway 상태 해석은 `CLAUDE.md`로 링크했다. **중복 서술이 이 문서가 stale해진 원인**이므로 같은 실수를 반복하지 않는다.

## CLAUDE.md — 색인에 없었다

문서 참조 테이블에 **`operations.md` 행이 아예 없었다.** "배포/운영"이 `deployment.md` 하나만 가리키고 있었다. **색인에 없으니 아무도 갱신하지 않은 것**이다. 배포(CI/CD·도메인)와 일상 운영을 분리했다.

## 검증 (모든 수치를 소스로 재확인)

| 사실 | 출처 | 결과 |
|---|---|---|
| 카탈로그 61 / 활성 36 / 비활성 25 | `apiCatalog.json` 집계 | 일치 |
| 보존 90 / 7 / 30일 | `retention.ts` | 일치 |
| 백업 24h · 7개 보관 | `backup.ts` | 일치 |
| 생성 실패율 5분 윈도 · 임계 5 | `errorRateMonitor.ts` | 일치 |
| admin 라우트 8개 | 디렉터리 | 일치 |
| 내부 링크 35개 | 파일 존재 확인 | 깨짐 0 |

확인할 수 없는 것(현재 플랜 한도 등)은 **추측해 적지 않고 "대시보드 실측이 진실원"으로 남겼다.**

## 신규 발견

작업 중 **`deployment.md`에도 Supabase·Sentry 잔재**가 있음을 확인했다. 범위 밖이라 이 PR에서 고치지 않고 WBS에 **D-e**로 등록했으며, operations.md에는 "deployment 7절 잔재 가능, 실측 우선" 경고를 달았다.

## 변경 범위

문서 3개(`operations.md` 재작성, `CLAUDE.md` 색인, WBS 갱신). **코드 변경 없음.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
