### PR TITLE
fix: 이전 실행의 폴러가 새 실행 상태를 오염시키던 것 차단 (E8)

### DIFF
--- a/src/app/(main)/builder/page.tsx
+++ b/src/app/(main)/builder/page.tsx
@@ -28,6 +28,7 @@ import { useGenerationStore } from '@/stores/generationStore';
 import { useBuilderModeStore } from '@/stores/builderModeStore';
 import type { BuilderMode } from '@/stores/builderModeStore';
 import { LIMITS } from '@/lib/config/features';
+import { abortGenerationSession } from '@/lib/generation/generationSession';
 import { runClientGeneration } from '@/lib/generation/runClientGeneration';
 import type { ApiCatalogItem, Category } from '@/types/api';
 import type { RelevanceGateResult } from '@/types/project';
@@ -162,6 +163,8 @@ export default function BuilderPage() {
     setStep(1);
     clearApis();
     resetContext();
+    // 고아 폴러 네트워크를 즉시 끊는다. 스토어 오염 1차 방어는 runId(E8).
+    abortGenerationSession();
     resetGeneration();
     setSuggestions([]);
     setApiRecommendations([]);

--- a/src/lib/generation/generationSession.test.ts
+++ b/src/lib/generation/generationSession.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  abortGenerationSession,
+  beginGenerationSession,
+  __resetGenerationSessionForTests,
+} from './generationSession';
+
+describe('generationSession', () => {
+  afterEach(() => {
+    __resetGenerationSessionForTests();
+  });
+
+  it('beginGenerationSession 은 이전 signal 을 abort 한다', () => {
+    const first = beginGenerationSession();
+    expect(first.aborted).toBe(false);
+
+    const second = beginGenerationSession();
+    expect(first.aborted).toBe(true);
+    expect(second.aborted).toBe(false);
+  });
+
+  it('연속 begin 시 첫 signal 만 abort 되고 둘째는 살아 있다', () => {
+    const a = beginGenerationSession();
+    const b = beginGenerationSession();
+    expect(a.aborted).toBe(true);
+    expect(b.aborted).toBe(false);
+
+    const c = beginGenerationSession();
+    expect(a.aborted).toBe(true);
+    expect(b.aborted).toBe(true);
+    expect(c.aborted).toBe(false);
+  });
+
+  it('abortGenerationSession 은 현재 signal 을 abort 하고 비운다', () => {
+    const signal = beginGenerationSession();
+    abortGenerationSession();
+    expect(signal.aborted).toBe(true);
+
+    // 다시 abort 해도 안전 (no-op)
+    abortGenerationSession();
+  });
+
+  it('abort 후 begin 은 새 비-abort signal 을 준다', () => {
+    const first = beginGenerationSession();
+    abortGenerationSession();
+    expect(first.aborted).toBe(true);
+
+    const next = beginGenerationSession();
+    expect(next.aborted).toBe(false);
+    expect(next).not.toBe(first);
+  });
+
+  it('__resetGenerationSessionForTests 는 현재 세션을 끊는다', () => {
+    const signal = beginGenerationSession();
+    __resetGenerationSessionForTests();
+    expect(signal.aborted).toBe(true);
+  });
+});

--- a/src/lib/generation/generationSession.ts
+++ b/src/lib/generation/generationSession.ts
@@ -1,0 +1,43 @@
+/**
+ * 빌더 create→generate 흐름 전용 생성 세션 AbortController 싱글톤.
+ *
+ * ⚠️ **재생성(regenerate) 경로와 공유하지 말 것.**
+ * 대시보드/RePromptPanel 재생성이 이 세션을 abort 하면, 빌더 쪽 폴링이 terminal
+ * 콜백 없이 조용히 종료되고 generationStore 가 `generating` 에 영원히 고착된다.
+ * 세션 abort 는 네트워크만 끊고 스토어 전이를 보장하지 않는다. 통일하지 말 것.
+ *
+ * - `beginGenerationSession`: 직전 세션을 abort 한 뒤 새 컨트롤러를 연다.
+ * - `abortGenerationSession`: 현재 세션을 abort 하고 비운다 (예: '이전' 버튼).
+ * - 실행 단위 상태 오염 방지는 `runId`(generationStore) 가 1차 방어다.
+ *   이 모듈은 네트워크 취소를 담당하는 2차 방어다.
+ */
+
+let currentController: AbortController | null = null;
+
+/** 직전 세션을 끊고 새 세션 signal 을 반환한다. */
+export function beginGenerationSession(): AbortSignal {
+  if (currentController) {
+    currentController.abort();
+  }
+  currentController = new AbortController();
+  return currentController.signal;
+}
+
+/** 현재 세션을 abort 하고 비운다. 이미 없으면 no-op. */
+export function abortGenerationSession(): void {
+  if (currentController) {
+    currentController.abort();
+    currentController = null;
+  }
+}
+
+/**
+ * 테스트 격리용. 모듈 싱글톤을 초기화한다.
+ * 프로덕션 코드에서 호출하지 말 것.
+ */
+export function __resetGenerationSessionForTests(): void {
+  if (currentController) {
+    currentController.abort();
+    currentController = null;
+  }
+}

--- a/src/lib/generation/runClientGeneration.test.ts
+++ b/src/lib/generation/runClientGeneration.test.ts
@@ -370,6 +370,69 @@ describe('runClientGeneration', () => {
     expect(capturedSignal?.aborted).toBe(false);
   });
 
+  // E8 2차 방어(네트워크 중단)의 두 진입점.
+  // 1차 방어는 runId 지만, 폴러가 계속 /status 를 두드리는 것은 별개 문제다.
+
+  it('세션이 실행 중 abort되면(=사용자가 이전 클릭) 이 실행의 폴링 signal도 끊긴다', async () => {
+    const streamBody =
+      'event: progress\ndata: {"progress":10,"message":"x"}\n\n';
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonRes({ data: { id: 'proj-mid' } }))
+      .mockResolvedValueOnce(makeStreamRes([streamBody]));
+
+    // 실행 도중 세션을 끊을 수 있도록 컨트롤러를 밖에서 쥔다
+    const session = new AbortController();
+
+    let capturedSignal: AbortSignal | undefined;
+    const pollGenerationStatusFn = vi
+      .fn()
+      .mockImplementation(async (_pid: string, pollDeps: PollGenerationStatusDeps) => {
+        capturedSignal = pollDeps.signal;
+        // 폴링이 도는 도중 사용자가 '이전'을 눌러 abortGenerationSession() 이 호출된 상황
+        session.abort();
+      });
+
+    const deps = makeDeps({
+      fetchFn,
+      pollGenerationStatusFn,
+      beginSession: () => session.signal,
+    });
+    await runClientGeneration(input, deps);
+
+    // 세션 abort 가 이 실행의 local controller 로 전파되어야 한다
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
+  it('시작 시점에 이미 abort된 세션이면 폴링 signal이 처음부터 aborted 다', async () => {
+    // 직전 실행이 방금 끊긴 직후 새 실행이 시작되는 경계
+    const alreadyAborted = new AbortController();
+    alreadyAborted.abort();
+
+    const streamBody =
+      'event: progress\ndata: {"progress":10,"message":"x"}\n\n';
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonRes({ data: { id: 'proj-pre' } }))
+      .mockResolvedValueOnce(makeStreamRes([streamBody]));
+
+    let capturedSignal: AbortSignal | undefined;
+    const pollGenerationStatusFn = vi
+      .fn()
+      .mockImplementation(async (_pid: string, pollDeps: PollGenerationStatusDeps) => {
+        capturedSignal = pollDeps.signal;
+      });
+
+    const deps = makeDeps({
+      fetchFn,
+      pollGenerationStatusFn,
+      beginSession: () => alreadyAborted.signal,
+    });
+    await runClientGeneration(input, deps);
+
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
   /**
    * 회귀: visibility → poll 시작 → 버퍼된 SSE complete 도착 후
    * 폴링 timeout 이 failGeneration 을 덮어쓰지 않아야 한다.

--- a/src/lib/generation/runClientGeneration.test.ts
+++ b/src/lib/generation/runClientGeneration.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { __resetGenerationSessionForTests } from './generationSession';
 import { runClientGeneration } from './runClientGeneration';
 import { pollGenerationStatus } from './pollGenerationStatus';
 import type { PollGenerationStatusDeps } from './pollGenerationStatus';
+
+const TEST_RUN_ID = 'run-test-fixed-id';
 
 function makeJsonRes(body: unknown, ok = true): Response {
   return {
@@ -109,13 +112,15 @@ function makeDocument(initial: DocumentVisibilityState = 'hidden') {
 
 function makeDeps(overrides: Partial<Parameters<typeof runClientGeneration>[1]> = {}) {
   return {
-    startGeneration: vi.fn(),
+    startGeneration: vi.fn(() => TEST_RUN_ID),
     updateProgress: vi.fn(),
     completeGeneration: vi.fn(),
     failGeneration: vi.fn(),
     setGeneratingProjectId: vi.fn(),
     onCompleted: vi.fn(),
     now: () => 1_700_000_000_000,
+    // 테스트 간 세션 싱글톤 간섭 방지 — 독립 AbortSignal
+    beginSession: () => new AbortController().signal,
     documentRef: {
       visibilityState: 'visible' as DocumentVisibilityState,
       addEventListener: vi.fn(),
@@ -139,6 +144,7 @@ describe('runClientGeneration', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    __resetGenerationSessionForTests();
   });
 
   it('create 실패 → failGeneration, generate 미호출', async () => {
@@ -150,8 +156,12 @@ describe('runClientGeneration', () => {
     await runClientGeneration(input, deps);
 
     expect(deps.startGeneration).toHaveBeenCalledTimes(1);
-    expect(deps.updateProgress).toHaveBeenCalledWith(5, '프로젝트 생성 중...');
-    expect(deps.failGeneration).toHaveBeenCalledWith('생성 한도 초과');
+    expect(deps.updateProgress).toHaveBeenCalledWith(
+      5,
+      '프로젝트 생성 중...',
+      TEST_RUN_ID,
+    );
+    expect(deps.failGeneration).toHaveBeenCalledWith('생성 한도 초과', TEST_RUN_ID);
     expect(deps.setGeneratingProjectId).not.toHaveBeenCalled();
     expect(fetchFn).toHaveBeenCalledTimes(1);
     expect(fetchFn.mock.calls[0][0]).toBe('/api/v1/projects');
@@ -167,8 +177,12 @@ describe('runClientGeneration', () => {
     await runClientGeneration(input, deps);
 
     expect(deps.setGeneratingProjectId).toHaveBeenCalledWith('proj-1');
-    expect(deps.updateProgress).toHaveBeenCalledWith(10, 'AI 코드 생성 시작...');
-    expect(deps.failGeneration).toHaveBeenCalledWith('생성 거부');
+    expect(deps.updateProgress).toHaveBeenCalledWith(
+      10,
+      'AI 코드 생성 시작...',
+      TEST_RUN_ID,
+    );
+    expect(deps.failGeneration).toHaveBeenCalledWith('생성 거부', TEST_RUN_ID);
     expect(fetchFn).toHaveBeenCalledTimes(2);
     expect(fetchFn.mock.calls[1][0]).toBe('/api/v1/generate');
   });
@@ -182,7 +196,10 @@ describe('runClientGeneration', () => {
 
     await runClientGeneration(input, deps);
 
-    expect(deps.failGeneration).toHaveBeenCalledWith('스트림을 읽을 수 없습니다.');
+    expect(deps.failGeneration).toHaveBeenCalledWith(
+      '스트림을 읽을 수 없습니다.',
+      TEST_RUN_ID,
+    );
   });
 
   it('happy path → progress 5 → 10 → SSE progress → complete → onCompleted 1회', async () => {
@@ -202,10 +219,10 @@ describe('runClientGeneration', () => {
     expect(deps.failGeneration).not.toHaveBeenCalled();
     expect(deps.setGeneratingProjectId).toHaveBeenCalledWith('proj-h');
     expect(updateProgress.mock.calls.map((c: unknown[]) => c[0])).toEqual([5, 10, 55]);
-    expect(updateProgress).toHaveBeenNthCalledWith(1, 5, '프로젝트 생성 중...');
-    expect(updateProgress).toHaveBeenNthCalledWith(2, 10, 'AI 코드 생성 시작...');
-    expect(updateProgress).toHaveBeenNthCalledWith(3, 55, '코드 작성');
-    expect(deps.completeGeneration).toHaveBeenCalledWith('proj-h', 3);
+    expect(updateProgress).toHaveBeenNthCalledWith(1, 5, '프로젝트 생성 중...', TEST_RUN_ID);
+    expect(updateProgress).toHaveBeenNthCalledWith(2, 10, 'AI 코드 생성 시작...', TEST_RUN_ID);
+    expect(updateProgress).toHaveBeenNthCalledWith(3, 55, '코드 작성', TEST_RUN_ID);
+    expect(deps.completeGeneration).toHaveBeenCalledWith('proj-h', 3, TEST_RUN_ID);
     expect(deps.onCompleted).toHaveBeenCalledTimes(1);
 
     const createBody = JSON.parse(
@@ -224,8 +241,37 @@ describe('runClientGeneration', () => {
 
     await runClientGeneration(input, deps);
 
-    expect(deps.failGeneration).toHaveBeenCalledWith('QC 실패');
+    expect(deps.failGeneration).toHaveBeenCalledWith('QC 실패', TEST_RUN_ID);
     expect(deps.onCompleted).not.toHaveBeenCalled();
+  });
+
+  it('스토어 writer 에 자신이 민팅한 runId 를 넘긴다', async () => {
+    const runId = 'run-owned-by-this-call';
+    const streamBody =
+      'event: complete\ndata: {"projectId":"proj-rid","version":1}\n\n';
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonRes({ data: { id: 'proj-rid' } }))
+      .mockResolvedValueOnce(makeStreamRes([streamBody]));
+    const startGeneration = vi.fn(() => runId);
+    const updateProgress = vi.fn();
+    const completeGeneration = vi.fn();
+    const failGeneration = vi.fn();
+    const deps = makeDeps({
+      fetchFn,
+      startGeneration,
+      updateProgress,
+      completeGeneration,
+      failGeneration,
+    });
+
+    await runClientGeneration(input, deps);
+
+    for (const call of updateProgress.mock.calls) {
+      expect(call[2]).toBe(runId);
+    }
+    expect(completeGeneration).toHaveBeenCalledWith('proj-rid', 1, runId);
+    expect(failGeneration).not.toHaveBeenCalled();
   });
 
   it('injectable deps 생략 시 기본 fetchFn(now/consumeStream/poll) 배선으로 동작', async () => {
@@ -251,7 +297,8 @@ describe('runClientGeneration', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     // makeDeps 의 now/fetchFn 을 쓰지 않는다 — 기본 파라미터 경로 검증
-    const startGeneration = vi.fn();
+    // beginSession 은 주입해 싱글톤 오염을 막는다
+    const startGeneration = vi.fn(() => TEST_RUN_ID);
     const updateProgress = vi.fn();
     const completeGeneration = vi.fn();
     const failGeneration = vi.fn();
@@ -265,6 +312,7 @@ describe('runClientGeneration', () => {
       failGeneration,
       setGeneratingProjectId,
       onCompleted,
+      beginSession: () => new AbortController().signal,
       documentRef: {
         visibilityState: 'visible' as DocumentVisibilityState,
         addEventListener: vi.fn(),
@@ -285,7 +333,7 @@ describe('runClientGeneration', () => {
 
     // stream_ended → 기본 pollForCompletion → pollGenerationStatus(fn 기본값)
     await vi.waitFor(() => {
-      expect(completeGeneration).toHaveBeenCalledWith('proj-def', 7);
+      expect(completeGeneration).toHaveBeenCalledWith('proj-def', 7, TEST_RUN_ID);
     });
     expect(onCompleted).toHaveBeenCalledTimes(1);
     expect(failGeneration).not.toHaveBeenCalled();
@@ -383,7 +431,7 @@ describe('runClientGeneration', () => {
     const updateProgress = vi.fn();
 
     const pending = runClientGeneration(input, {
-      startGeneration: vi.fn(),
+      startGeneration: vi.fn(() => TEST_RUN_ID),
       updateProgress,
       completeGeneration,
       failGeneration,
@@ -392,12 +440,13 @@ describe('runClientGeneration', () => {
       now: () => 1_700_000_000_000,
       fetchFn,
       pollGenerationStatusFn,
+      beginSession: () => new AbortController().signal,
       documentRef: doc,
     });
 
     // SSE progress 수신 대기
     await vi.waitFor(() => {
-      expect(updateProgress).toHaveBeenCalledWith(20, '생성 중');
+      expect(updateProgress).toHaveBeenCalledWith(20, '생성 중', TEST_RUN_ID);
     });
 
     // 탭 복귀 → poll 시작 (fire-and-forget)
@@ -418,7 +467,7 @@ describe('runClientGeneration', () => {
     await pollFinished;
 
     expect(completeGeneration).toHaveBeenCalledTimes(1);
-    expect(completeGeneration).toHaveBeenCalledWith('proj-race', 4);
+    expect(completeGeneration).toHaveBeenCalledWith('proj-race', 4, TEST_RUN_ID);
     expect(onCompleted).toHaveBeenCalledTimes(1);
     // 핵심 회귀: 폴링이 abort 된 뒤 failGeneration 을 호출하면 안 됨
     expect(failGeneration).not.toHaveBeenCalled();

--- a/src/lib/generation/runClientGeneration.ts
+++ b/src/lib/generation/runClientGeneration.ts
@@ -4,17 +4,19 @@
  * `builder/page.tsx` handleGenerate 본문에서 추출. React/router 의존 없음.
  * 스토어 액션·fetch·poll·document·now 를 주입받아 단위 테스트 가능.
  *
- * **E3 P3**: 호출마다 AbortController 하나를 소유한다 (generation session).
- * SSE terminal 시 abortPolling 으로 폴링을 끊고, outer catch 에서도 abort 하여
- * SSE terminal 도달 시 폴링을 abort 한다(방어적 불변조건).
- * ⚠️ 이것으로 "성공이 실패로 뒤집히는" 증상이 해결되지는 않는다 — 실제 원인은 폴링 예산
- * 부족이었고 pollGenerationStatus.maxAttempts 에서 수정했다.
+ * **E8**: 생성 세션은 `beginGenerationSession`(모듈 싱글톤)으로 열고,
+ * `startGeneration()` 이 민팅한 `runId` 를 모든 스토어 write 에 실어 보낸다.
+ * SSE terminal / outer catch 는 **이 실행의** local controller 만 abort 한다
+ * (전역 `abortGenerationSession` 을 catch 에서 부르면 더 새 세션을 죽일 수 있음).
+ *
+ * ⚠️ abort 는 네트워크 2차 방어. cross-run 상태 오염 1차 방어는 `runId` 가드다.
  */
 
 import {
   consumeGenerationStream,
   type ConsumeGenerationStreamDeps,
 } from './consumeGenerationStream';
+import { beginGenerationSession } from './generationSession';
 import {
   pollGenerationStatus,
   type PollGenerationStatusDeps,
@@ -28,10 +30,14 @@ export interface RunClientGenerationInput {
 }
 
 export interface RunClientGenerationDeps {
-  startGeneration: () => void;
-  updateProgress: (progress: number, message: string) => void;
-  completeGeneration: (projectId: string, version?: number) => void;
-  failGeneration: (message: string) => void;
+  startGeneration: () => string;
+  updateProgress: (progress: number, message: string, runId: string) => void;
+  completeGeneration: (
+    projectId: string,
+    version: number | undefined,
+    runId: string,
+  ) => void;
+  failGeneration: (message: string, runId: string) => void;
   setGeneratingProjectId: (id: string) => void;
   /** complete 시 resetContext + clearApis 등 정리. */
   onCompleted?: () => void;
@@ -51,6 +57,11 @@ export interface RunClientGenerationDeps {
   now?: () => number;
   /** SSE 소비 구현 주입 (테스트용). 기본 consumeGenerationStream. */
   consumeStream?: typeof consumeGenerationStream;
+  /**
+   * 세션 시작 주입 (테스트용). 기본 beginGenerationSession.
+   * 재생성 경로와 공유하지 말 것 — generationSession.ts 주석 참조.
+   */
+  beginSession?: () => AbortSignal;
 }
 
 /**
@@ -74,15 +85,40 @@ export async function runClientGeneration(
     documentRef,
     now = () => Date.now(),
     consumeStream = consumeGenerationStream,
+    beginSession = beginGenerationSession,
   } = deps;
 
-  // 생성 세션 단일 소유자 — SSE terminal / outer catch 가 이 컨트롤러로 폴링을 끊는다
-  const controller = new AbortController();
+  // 세션 signal (이전 빌더 생성 세션 abort) + 이 실행 전용 local controller.
+  // 폴링·abortPolling 은 local signal 을 쓴다. 세션 abort → local 도 abort.
+  // 전역 abort 를 outer catch 에서 부르지 않는다 — 더 새 begin 을 죽일 수 있음.
+  const sessionSignal = beginSession();
+  const runController = new AbortController();
+  if (sessionSignal.aborted) {
+    runController.abort();
+  } else {
+    sessionSignal.addEventListener(
+      'abort',
+      () => {
+        runController.abort();
+      },
+      { once: true },
+    );
+  }
 
-  startGeneration();
+  const runId = startGeneration();
+
+  const writeProgress = (progress: number, message: string): void => {
+    updateProgress(progress, message, runId);
+  };
+  const writeComplete = (projectId: string, version?: number): void => {
+    completeGeneration(projectId, version, runId);
+  };
+  const writeFail = (message: string): void => {
+    failGeneration(message, runId);
+  };
 
   try {
-    updateProgress(5, '프로젝트 생성 중...');
+    writeProgress(5, '프로젝트 생성 중...');
     const createRes = await fetchFn('/api/v1/projects', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -104,7 +140,7 @@ export async function runClientGeneration(
     const { data: project } = (await createRes.json()) as { data: { id: string } };
     setGeneratingProjectId(project.id);
 
-    updateProgress(10, 'AI 코드 생성 시작...');
+    writeProgress(10, 'AI 코드 생성 시작...');
     const genRes = await fetchFn('/api/v1/generate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -129,27 +165,28 @@ export async function runClientGeneration(
     // signal 공유로 SSE complete/error 가 폴링 terminal 을 차단한다.
     const pollForCompletion = (pid: string): Promise<void> =>
       pollGenerationStatusFn(pid, {
-        updateProgress,
-        completeGeneration,
-        failGeneration,
+        updateProgress: writeProgress,
+        completeGeneration: writeComplete,
+        failGeneration: writeFail,
         onCompleted,
-        signal: controller.signal,
+        signal: runController.signal,
       });
 
     await consumeStream(reader, project.id, {
-      updateProgress,
-      completeGeneration,
+      updateProgress: writeProgress,
+      completeGeneration: writeComplete,
       onCompleted,
       pollForCompletion,
       abortPolling: () => {
-        controller.abort();
+        runController.abort();
       },
       documentRef,
     });
   } catch (err) {
     // 이미 핸드오프된 폴링이 이후 timeout fail 을 찍지 않도록 먼저 끊는다.
+    // **이 실행의** controller 만 abort — 전역 abortGenerationSession 금지.
     // abort 는 멱등; SSE error 경로에서 이미 abortPolling 했어도 안전.
-    controller.abort();
-    failGeneration(err instanceof Error ? err.message : '알 수 없는 오류');
+    runController.abort();
+    writeFail(err instanceof Error ? err.message : '알 수 없는 오류');
   }
 }

--- a/src/stores/generationStore.test.ts
+++ b/src/stores/generationStore.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  abortGenerationSession,
+  __resetGenerationSessionForTests,
+} from '@/lib/generation/generationSession';
 import { useGenerationStore } from './generationStore';
 
 const initialState = {
@@ -9,6 +13,7 @@ const initialState = {
   version: null,
   error: null,
   generatingProjectId: null,
+  runId: null,
 };
 
 describe('useGenerationStore', () => {
@@ -17,10 +22,14 @@ describe('useGenerationStore', () => {
     useGenerationStore.setState(initialState);
   });
 
+  afterEach(() => {
+    __resetGenerationSessionForTests();
+  });
+
   it('start → progress → complete 전이 시 progress·status·generatingProjectId 불변식을 유지한다', () => {
     const store = useGenerationStore.getState();
 
-    store.startGeneration();
+    const runId = store.startGeneration();
     store.setGeneratingProjectId('proj-1');
 
     let state = useGenerationStore.getState();
@@ -30,8 +39,9 @@ describe('useGenerationStore', () => {
     expect(state.error).toBeNull();
     expect(state.version).toBeNull();
     expect(state.generatingProjectId).toBe('proj-1');
+    expect(state.runId).toBe(runId);
 
-    store.updateProgress(40, '스테이지 1');
+    store.updateProgress(40, '스테이지 1', runId);
     state = useGenerationStore.getState();
     // updateProgress는 status를 바꾸지 않는다
     expect(state.status).toBe('generating');
@@ -39,7 +49,7 @@ describe('useGenerationStore', () => {
     expect(state.currentStep).toBe('스테이지 1');
     expect(state.generatingProjectId).toBe('proj-1');
 
-    store.completeGeneration('proj-1', 3);
+    store.completeGeneration('proj-1', 3, runId);
     state = useGenerationStore.getState();
     expect(state.status).toBe('completed');
     expect(state.progress).toBe(100);
@@ -51,10 +61,10 @@ describe('useGenerationStore', () => {
   it('start → fail 전이 시 status=failed 이고 generatingProjectId를 비운다', () => {
     const store = useGenerationStore.getState();
 
-    store.startGeneration();
+    const runId = store.startGeneration();
     store.setGeneratingProjectId('proj-fail');
-    store.updateProgress(25, '생성 중');
-    store.failGeneration('타임아웃');
+    store.updateProgress(25, '생성 중', runId);
+    store.failGeneration('타임아웃', runId);
 
     const state = useGenerationStore.getState();
     expect(state.status).toBe('failed');
@@ -67,17 +77,16 @@ describe('useGenerationStore', () => {
 
   // ── 터미널 래치 ─────────────────────────────────────────────────────────
   // SSE + 폴링 이중 경로에서 늦게 도착한 종료가 먼저 확정된 결과를 덮어쓰지 못해야 한다.
-  // 폴링은 fire-and-forget으로 시작되고 abort가 없어, 이 순서들이 실제로 발생한다.
 
   it('fail 이후 늦게 도착한 updateProgress는 아무것도 바꾸지 않는다', () => {
     const store = useGenerationStore.getState();
 
-    store.startGeneration();
+    const runId = store.startGeneration();
     store.setGeneratingProjectId('proj-late');
-    store.updateProgress(25, '생성 중');
-    store.failGeneration('연결 끊김');
+    store.updateProgress(25, '생성 중', runId);
+    store.failGeneration('연결 끊김', runId);
 
-    store.updateProgress(90, '거의 완료');
+    store.updateProgress(90, '거의 완료', runId);
 
     const state = useGenerationStore.getState();
     expect(state.status).toBe('failed');
@@ -91,9 +100,9 @@ describe('useGenerationStore', () => {
   it('complete 이후 늦게 도착한 updateProgress는 progress 100을 훼손하지 않는다', () => {
     const store = useGenerationStore.getState();
 
-    store.startGeneration();
-    store.completeGeneration('proj-1', 2);
-    store.updateProgress(40, '뒤늦은 진행률');
+    const runId = store.startGeneration();
+    store.completeGeneration('proj-1', 2, runId);
+    store.updateProgress(40, '뒤늦은 진행률', runId);
 
     const state = useGenerationStore.getState();
     expect(state.status).toBe('completed');
@@ -106,11 +115,11 @@ describe('useGenerationStore', () => {
     // 가드가 없으면 사용자가 성공 직후 에러 화면을 본다.
     const store = useGenerationStore.getState();
 
-    store.startGeneration();
+    const runId = store.startGeneration();
     store.setGeneratingProjectId('proj-win');
-    store.completeGeneration('proj-win', 3);
+    store.completeGeneration('proj-win', 3, runId);
 
-    store.failGeneration('생성 시간이 초과되었습니다. 대시보드에서 확인해주세요.');
+    store.failGeneration('생성 시간이 초과되었습니다. 대시보드에서 확인해주세요.', runId);
 
     const state = useGenerationStore.getState();
     expect(state.status).toBe('completed');
@@ -122,10 +131,10 @@ describe('useGenerationStore', () => {
   it('fail 이후 늦게 도착한 completeGeneration은 실패를 성공으로 뒤집지 못한다', () => {
     const store = useGenerationStore.getState();
 
-    store.startGeneration();
-    store.failGeneration('코드 생성에 실패했습니다.');
+    const runId = store.startGeneration();
+    store.failGeneration('코드 생성에 실패했습니다.', runId);
 
-    store.completeGeneration('proj-late', 1);
+    store.completeGeneration('proj-late', 1, runId);
 
     const state = useGenerationStore.getState();
     expect(state.status).toBe('failed');
@@ -136,9 +145,9 @@ describe('useGenerationStore', () => {
   it('두 번째 completeGeneration은 첫 결과를 덮어쓰지 않는다', () => {
     const store = useGenerationStore.getState();
 
-    store.startGeneration();
-    store.completeGeneration('proj-first', 1);
-    store.completeGeneration('proj-second', 9);
+    const runId = store.startGeneration();
+    store.completeGeneration('proj-first', 1, runId);
+    store.completeGeneration('proj-second', 9, runId);
 
     const state = useGenerationStore.getState();
     expect(state.projectId).toBe('proj-first');
@@ -148,25 +157,27 @@ describe('useGenerationStore', () => {
   it('startGeneration은 터미널 상태에서도 열려 있어야 한다 (재시도 진입점)', () => {
     const store = useGenerationStore.getState();
 
-    store.startGeneration();
-    store.failGeneration('첫 시도 실패');
+    const runIdA = store.startGeneration();
+    store.failGeneration('첫 시도 실패', runIdA);
 
-    store.startGeneration();
+    const runIdB = store.startGeneration();
 
     const state = useGenerationStore.getState();
     expect(state.status).toBe('generating');
     expect(state.error).toBeNull();
     expect(state.progress).toBe(0);
+    expect(state.runId).toBe(runIdB);
+    expect(runIdB).not.toBe(runIdA);
 
     // 재시도 이후에는 다시 전이가 허용된다
-    store.updateProgress(50, '재시도 중');
+    store.updateProgress(50, '재시도 중', runIdB);
     expect(useGenerationStore.getState().progress).toBe(50);
   });
 
-  it('completeGeneration의 version 생략 시 null로 저장한다', () => {
+  it('completeGeneration의 version 생략(undefined) 시 null로 저장한다', () => {
     const store = useGenerationStore.getState();
-    store.startGeneration();
-    store.completeGeneration('proj-2');
+    const runId = store.startGeneration();
+    store.completeGeneration('proj-2', undefined, runId);
 
     const state = useGenerationStore.getState();
     expect(state.status).toBe('completed');
@@ -177,13 +188,107 @@ describe('useGenerationStore', () => {
 
   it('reset은 모든 필드를 초기값으로 되돌린다', () => {
     const store = useGenerationStore.getState();
-    store.startGeneration();
+    const runId = store.startGeneration();
     store.setGeneratingProjectId('proj-x');
-    store.updateProgress(50, '중간');
-    store.completeGeneration('proj-x', 1);
+    store.updateProgress(50, '중간', runId);
+    store.completeGeneration('proj-x', 1, runId);
 
     store.reset();
 
     expect(useGenerationStore.getState()).toMatchObject(initialState);
+    expect(useGenerationStore.getState().runId).toBeNull();
+  });
+
+  // ── runId 가드 (E8) ───────────────────────────────────────────────────────
+
+  it('startGeneration은 호출마다 다른 runId를 반환한다', () => {
+    const store = useGenerationStore.getState();
+    const a = store.startGeneration();
+    const b = store.startGeneration();
+    expect(a).not.toBe(b);
+    expect(useGenerationStore.getState().runId).toBe(b);
+  });
+
+  it('reset은 runId를 null로 비운다', () => {
+    const store = useGenerationStore.getState();
+    store.startGeneration();
+    expect(useGenerationStore.getState().runId).not.toBeNull();
+    store.reset();
+    expect(useGenerationStore.getState().runId).toBeNull();
+  });
+
+  it('stale runId 의 terminal 호출은 generating 중에도 무시된다', () => {
+    const store = useGenerationStore.getState();
+    const runId = store.startGeneration();
+    store.setGeneratingProjectId('proj-live');
+    store.updateProgress(30, '진행', runId);
+
+    store.completeGeneration('proj-stale', 9, 'not-the-active-run');
+    store.failGeneration('stale fail', 'also-stale');
+    store.updateProgress(99, 'stale progress', 'stale-run');
+
+    const state = useGenerationStore.getState();
+    expect(state.status).toBe('generating');
+    expect(state.runId).toBe(runId);
+    expect(state.progress).toBe(30);
+    expect(state.currentStep).toBe('진행');
+    expect(state.projectId).toBeNull();
+    expect(state.error).toBeNull();
+    expect(state.generatingProjectId).toBe('proj-live');
+  });
+
+  /**
+   * E8 회귀: 이전 → 재생성 시 이전 실행의 폴러가 새 실행 상태를 오염시키지 못한다.
+   * 실제 버그 경로 — 폴러가 fire-and-forget 으로 최대 5분 살아 있고,
+   * startGeneration 이 래치를 재개방한 뒤 stale complete/fail 이 도착한다.
+   */
+  it('이전 → 재생성 시 이전 실행의 폴러가 새 실행 상태를 오염시키지 못한다', () => {
+    const store = useGenerationStore.getState();
+
+    // Run A 시작 후 폴링 핸드오프 상태 (in-flight 폴러가 runIdA 를 캡처)
+    const runIdA = store.startGeneration();
+    store.setGeneratingProjectId('proj-a');
+    store.updateProgress(15, 'Run A 생성 중', runIdA);
+
+    // 사용자 '이전' — 세션 abort + store reset (handleResetMode 와 동일)
+    abortGenerationSession();
+    store.reset();
+    expect(useGenerationStore.getState().status).toBe('idle');
+    expect(useGenerationStore.getState().runId).toBeNull();
+
+    // Run B 시작 (새 runId)
+    const runIdB = store.startGeneration();
+    store.setGeneratingProjectId('proj-b');
+    store.updateProgress(20, 'Run B 생성 중', runIdB);
+    expect(runIdB).not.toBe(runIdA);
+
+    // Run A 폴러가 늦게 terminal 도착 — complete 경로
+    store.completeGeneration('proj-a', 1, runIdA);
+
+    let state = useGenerationStore.getState();
+    expect(state.status).toBe('generating');
+    expect(state.runId).toBe(runIdB);
+    expect(state.projectId).toBeNull();
+    expect(state.generatingProjectId).toBe('proj-b');
+    expect(state.progress).toBe(20);
+    expect(state.currentStep).toBe('Run B 생성 중');
+    expect(state.error).toBeNull();
+
+    // Run A 폴러 fail 경로도 무시
+    store.failGeneration('생성 시간이 초과되었습니다. 대시보드에서 확인해주세요.', runIdA);
+
+    state = useGenerationStore.getState();
+    expect(state.status).toBe('generating');
+    expect(state.runId).toBe(runIdB);
+    expect(state.error).toBeNull();
+    expect(state.generatingProjectId).toBe('proj-b');
+
+    // Run B 자신은 여전히 종료 가능
+    store.completeGeneration('proj-b', 2, runIdB);
+    state = useGenerationStore.getState();
+    expect(state.status).toBe('completed');
+    expect(state.projectId).toBe('proj-b');
+    expect(state.version).toBe(2);
+    expect(state.runId).toBe(runIdB);
   });
 });

--- a/src/stores/generationStore.ts
+++ b/src/stores/generationStore.ts
@@ -10,11 +10,14 @@ interface GenerationState {
   version: number | null;
   error: string | null;
   generatingProjectId: string | null;   // set when generation starts, before SSE
+  /** 생성 실행 단위 ID. startGeneration 이 민팅하며, stale 콜백 무시용. */
+  runId: string | null;
 
-  startGeneration: () => void;
-  updateProgress: (progress: number, step: string) => void;
-  completeGeneration: (projectId: string, version?: number) => void;
-  failGeneration: (error: string) => void;
+  /** 새 실행을 열고 runId 를 반환. 터미널 상태에서도 무조건 열린다(재시도 진입점). */
+  startGeneration: () => string;
+  updateProgress: (progress: number, step: string, runId: string) => void;
+  completeGeneration: (projectId: string, version: number | undefined, runId: string) => void;
+  failGeneration: (error: string, runId: string) => void;
   reset: () => void;
   setGeneratingProjectId: (id: string) => void;
 }
@@ -27,46 +30,82 @@ export const useGenerationStore = create<GenerationState>((set) => ({
   version: null,
   error: null,
   generatingProjectId: null,
+  runId: null,
 
   // startGeneration은 유일하게 무조건적이다 — 재시도의 진입점이므로 터미널 상태에서도 열려야 한다.
-  startGeneration: () =>
-    set({ status: 'generating', progress: 0, currentStep: '', error: null, version: null }),
+  startGeneration: () => {
+    const runId = crypto.randomUUID();
+    set({
+      status: 'generating',
+      progress: 0,
+      currentStep: '',
+      error: null,
+      version: null,
+      runId,
+    });
+    return runId;
+  },
 
-  // ── 터미널 래치 ───────────────────────────────────────────────────────────
-  // 아래 셋은 `generating`일 때만 상태를 바꾼다. **먼저 도착한 종료가 이긴다.**
+  // ── 터미널 래치 + runId 가드 ──────────────────────────────────────────────
+  // 아래 셋은 `status === 'generating' && state.runId === runId`일 때만 상태를 바꾼다.
+  // **먼저 도착한 종료가 이긴다** + **다른 실행의 콜백은 무시한다.**
   //
   // 생성은 SSE + 폴링 이중 경로로 돌고, 두 경로가 서로 다른 종료를 보고할 수 있다.
   // 가드가 없으면 늦게 도착한 쪽이 먼저 확정된 결과를 덮어써 **성공이 실패로 뒤집힌다.**
   //
-  // ⚠️ **아래 두 이유 때문에 이 가드는 계속 필요하다. 지우지 말 것.**
+  // ⚠️ **터미널 래치(`status === 'generating'`)를 지우지 말 것.**
   // (2026-08-01 적대적 검증 결과 — 당초 적었던 "SSE complete 직후 살아 있는 폴링" 시나리오는
   //  실제로는 도달 불가로 밝혀졌다. `reader.cancel()`이 대기 중인 read를 `{done:true}`로
   //  끝내므로 취소 뒤에 버퍼된 complete를 처리할 수 없다. 그 서술은 틀렸으니 근거로 삼지 말 것.)
   //
-  // 1. **cross-run 오염** — `AbortController`가 `runClientGeneration` 호출 로컬이라,
-  //    핸드오프된 폴러는 함수가 반환한 뒤에도 최대 5분 더 살아 있고 이를 끊을 수단이 없다.
-  //    사용자가 '이전'을 눌러 다시 생성하면 `startGeneration`이 래치를 무조건 재개방하므로,
-  //    **이전 실행의 폴러가 새 실행의 상태에 써 넣을 수 있다.**
-  // 2. **재생성 경로(`RePromptPanel`)는 이 스토어를 쓰지 않는다** — 로컬 `useState`라
-  //    이 안전벨트가 적용되지 않는다. 그쪽은 아직 보호가 없다.
+  // 1. **cross-run 오염 (E8 — `runId` 가 1차 방어)** — 핸드오프된 폴러는 함수가 반환한
+  //    뒤에도 최대 5분 더 살아 있을 수 있다. 사용자가 '이전' 후 다시 생성하면
+  //    `startGeneration`이 래치를 무조건 재개방하므로, **runId 가 없으면** 이전 실행의
+  //    폴러가 새 실행 상태에 써 넣는다. 세션 abort 는 네트워크를 끊는 2차 방어이며,
+  //    abort 가 누락돼도 runId 가 상태 오염을 막는다.
+  // 2. **재생성 경로(`RePromptPanel`)는 이 스토어를 쓰지 않는다 (E9, 아직 미보호)** —
+  //    로컬 `useState`라 이 안전벨트·runId 가 적용되지 않는다. 그쪽은 별도 PR.
   //
-  // 근본 해결은 컨트롤러를 호출 단위가 아니라 **생성 세션 단위**로 올려
-  // 새 `startGeneration`이 직전 세션을 끊게 하는 것이다(WBS E3 후속).
-  updateProgress: (progress, currentStep) =>
-    set((s) => (s.status === 'generating' ? { progress, currentStep } : s)),
-
-  completeGeneration: (projectId, version) =>
+  // 같은 실행 안에서 SSE/폴링이 경쟁 종료를 내는 경우(또는 방어적 중복 콜)에
+  // 터미널 래치가 여전히 먼저 도착한 쪽을 확정한다.
+  updateProgress: (progress, currentStep, runId) =>
     set((s) =>
-      s.status === 'generating'
-        ? { status: 'completed', progress: 100, projectId, version: version ?? null, generatingProjectId: null }
-        : s
+      s.status === 'generating' && s.runId === runId
+        ? { progress, currentStep }
+        : s,
     ),
 
-  failGeneration: (error) =>
-    set((s) => (s.status === 'generating' ? { status: 'failed', error, generatingProjectId: null } : s)),
+  completeGeneration: (projectId, version, runId) =>
+    set((s) =>
+      s.status === 'generating' && s.runId === runId
+        ? {
+            status: 'completed',
+            progress: 100,
+            projectId,
+            version: version ?? null,
+            generatingProjectId: null,
+          }
+        : s,
+    ),
+
+  failGeneration: (error, runId) =>
+    set((s) =>
+      s.status === 'generating' && s.runId === runId
+        ? { status: 'failed', error, generatingProjectId: null }
+        : s,
+    ),
 
   reset: () =>
-    set({ status: 'idle', progress: 0, currentStep: '', projectId: null, version: null, error: null, generatingProjectId: null }),
+    set({
+      status: 'idle',
+      progress: 0,
+      currentStep: '',
+      projectId: null,
+      version: null,
+      error: null,
+      generatingProjectId: null,
+      runId: null,
+    }),
 
   setGeneratingProjectId: (id) => set({ generatingProjectId: id }),
 }));


### PR DESCRIPTION
## 재현 경로 (실증)

1. 생성 → SSE가 폴링으로 핸드오프 → `runClientGeneration`은 반환하지만 **폴러는 최대 5분 더 살아 있고 끊을 수단이 없다**
2. **'이전' 버튼에 `disabled`가 없다** — 생성 중에도 눌린다 (`builder/page.tsx` ~709)
3. `handleResetMode` → `resetGeneration()` — **abort 없이** 스토어만 idle로 (~160)
4. 새 생성 → `startGeneration()`이 터미널 래치를 무조건 재개방
5. **이전 실행의 폴러가 새 실행 상태에 써 넣는다** — 보통 엉뚱한 `projectId`로

## 설계가 검토에서 바뀌었습니다

처음에는 "모듈 세션 `AbortController` 하나면 된다"로 잡았는데, 두 가지가 드러났습니다:

- **abort만으로는 부족합니다.** 놓치는 경로가 하나라도 있으면 그대로 오염됩니다
- **세션을 create와 regenerate가 공유하면 더 나쁩니다.** dashboard에서 regenerate를 시작할 때 builder의 폴링이 조용히 abort되면 스토어 전이가 없어 **`generating`에 영원히 갇힙니다**

그래서 두 층으로 나눴습니다.

### 1차 — `runId` (상태 오염 차단)

`startGeneration()`이 새 `runId`를 발급하고 **반환**합니다. 세 writer가 `status === 'generating'` **그리고** `runId` 일치일 때만 적용됩니다.

```ts
startGeneration: () => string;
updateProgress: (progress, step, runId) => void;
completeGeneration: (projectId, version, runId) => void;
failGeneration: (error, runId) => void;
```

**abort를 놓쳐도 오염되지 않습니다.**

### 2차 — 세션 abort (네트워크 중단)

`generationSession.ts` 모듈 싱글톤. 새 실행이 이전 세션을 끊고, `handleResetMode`가 '이전' 시점에 **즉시** 끊습니다(다음 생성까지 기다리지 않습니다).

> ⚠️ **이 세션을 regenerate와 공유하지 말 것** — 위 "영원히 갇힘" 이유를 파일 주석에 못박았습니다.

## 구현 주의점

`beginGenerationSession()`은 signal만 반환하므로, 실행별 abort(SSE terminal·바깥 catch)가 **새 세션을 죽이지 않도록** 세션 signal에 연결된 로컬 컨트롤러를 따로 둡니다. 바깥 catch는 로컬 컨트롤러만 abort하고 전역 `abortGenerationSession()`을 부르지 않습니다.

## 회귀 테스트가 실제 버그를 재현합니다

`이전 → 재생성 시 이전 실행의 폴러가 새 실행 상태를 오염시키지 못한다`

Run A 핸드오프 → abort+reset → Run B 시작 → **Run A의 늦은 `complete`/`fail`이 무시되고 `projectId`가 오염되지 않으며**(`proj-a`로 안 바뀜) Run B는 정상 종료됨을 단언합니다. 가드가 없으면 이 단언들이 실패합니다.

그 외: 낡은 runId 무시 · `startGeneration`이 매번 다른 id 반환 · `reset`이 runId 소거 · 세션 begin이 이전 signal abort · 실행별 runId 전달.

## 터미널 래치는 유지합니다

`runId`가 cross-run 구멍을 덮었지만 래치는 남깁니다 — **`RePromptPanel`이 이 스토어를 쓰지 않아 여전히 보호가 없습니다**(E9). 래치 주석의 존치 사유를 그렇게 갱신했습니다.

## 검증

전체 **183파일 / 2254테스트 통과**(182/2244 → +1파일 / +10건) · `pnpm type-check` 통과 · `pnpm lint` 0 errors.

## 이 PR 범위 밖

- `RePromptPanel` 미변경 (E9, 별도 PR)
- '이전' 버튼 `disabled` 추가 안 함 — abort+reset+`runId`로 구멍이 닫히므로 네비게이션을 막지 않습니다
- create/generate fetch 자체는 세션 abort 대상이 아닙니다(폴링 signal만). 중간 이탈 시 서버는 완료될 수 있으나 스토어는 `runId`로 보호됩니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)
