### PR TITLE
test: 단위 테스트가 구조적으로 못 잡는 결함 4종 E2E 확보 (E6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,11 @@ jobs:
 
       - name: Build application
         run: pnpm build
+        env:
+          # NEXT_PUBLIC_* is inlined at build time — must be present here, not only on the test step.
+          # Without NEXT_PUBLIC_ROOT_DOMAIN, middleware never inspects Host → subdomain rewrite is dead.
+          NEXT_PUBLIC_ROOT_DOMAIN: xzawed.xyz
+          NEXT_PUBLIC_AUTH_PROVIDER: local
 
       - name: Run E2E tests
         run: pnpm test:e2e
@@ -172,8 +177,13 @@ jobs:
           # (테스트 전용 값 — 프로덕션과 무관)
           DB_PROVIDER: sqlite
           SQLITE_PATH: /tmp/e2e-app.db
+          SQLITE_BACKUP_ENABLED: 'false'
           AUTH_SECRET: e2e-ci-secret-not-for-production
           AUTH_TRUST_HOST: 'true'
+          # http:// so Auth.js session cookies are not Secure-only against plain CI HTTP.
+          AUTH_URL: http://127.0.0.1:3000
+          NEXT_PUBLIC_ROOT_DOMAIN: xzawed.xyz
+          NEXT_PUBLIC_AUTH_PROVIDER: local
 
       - name: Upload Playwright report
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ coverage/
 # playwright
 playwright-report/
 test-results/
+e2e/.auth/
+e2e/fixtures.json
+.tmp/
 
 # drizzle-kit output: pg 경로는 재생성(미커밋); sqlite는 런타임 마이그레이션이라 커밋한다
 /drizzle/*

--- a/docs/reference/test-coverage-map.md
+++ b/docs/reference/test-coverage-map.md
@@ -38,7 +38,7 @@
 | `src/hooks/**` | — | +1 (`usePublish`) | 🟡 나머지 훅 공백 |
 | `src/app/(main)/**` 페이지 | 4 | 0 | 🔴 `builder/page.tsx` 862줄 포함 |
 | `src/templates/**` | 13 | 1 (레지스트리) | 🔴 개별 템플릿 계약 미검증 |
-| `e2e/` | — | 3 spec / 11 테스트 | 🔴 인증·생성·게시·서브도메인 전부 미커버 |
+| `e2e/` | — | pages 3 device × 기존 UI + **serving 1회** (setup·A–D) | 🟢 E6: 유령 세션·서빙 동등성·CSP 단일·서브도메인 패스스루 고정 |
 
 ---
 
@@ -108,7 +108,7 @@ grep "^SF:" coverage/lcov.info | tr '\\' '/' | grep '패턴'   # lcov는 백슬�
 |----|------|------------|------------|
 | **T1** | `src/app/(main)/builder/page.tsx` (862줄, 테스트 0) | 프로젝트 생성 → 생성 트리거 → SSE 리더 → 폴백 폴링 **오케스트레이션 전체가 이 파일에만** 있다. 폴링 함수 자체(`pollGenerationStatus`)는 테스트되지만 **조합**은 미검증 | 핸들러를 훅/순수함수로 추출 후 fetch·SSE·poll 주입형으로: ① SSE 성공 시 폴링 중단 ② SSE error → 폴백 전환 ③ 스트림 중도 종료 시 상태 확정 |
 | **T2** | `src/app/api/v1/projects/[id]/route.ts` | **DELETE가 프로젝트 영구 삭제 진입점**이고 앱 캐스케이드의 입구다. 서비스는 커버되나 라우트 인증 게이트·에러 매핑은 미검증 | GET·DELETE 각각 미인증 401 / 타인 소유 403 / 소유자 200 |
-| **T3** | E2E 전반 (`e2e/` 3 spec / 11 테스트) | 인증·빌더/생성·게시·서브도메인 서빙·프록시가 **전부 0**. [system-spec](../architecture/system-spec.md) 1.2(유령 세션)처럼 **단위 테스트가 구조적으로 못 잡는 결함**의 유일한 방어선 | request 레벨로 `/api/v1/preview/:id`와 `/site/:slug`의 HTML·CSP 동등성 비교. **서브도메인은 Host 헤더 주입으로 검증 가능**(판정은 middleware가 Host로 한다) |
+| **T3** | ~~E2E 전반~~ → ✅ **E6 완료** | 단위 테스트가 구조적으로 못 잡는 4종(§5)을 request-level E2E로 고정. `e2e/seed.mjs`가 SQLite 픽스처를 서버 기동 전 시드. CI는 **Build + E2E 양쪽**에 `NEXT_PUBLIC_ROOT_DOMAIN=xzawed.xyz` (빌드타임 인라인). Host는 `127.0.0.1` + `e2e/helpers/httpHost.ts`로 명시 주입(`slug.localhost` 불가) | `e2e/serving/*` 1회 프로젝트(setup storageState 의존). A 패스스루 · B 마커 동등성 · C CSP `headersArray` 1회 · D 유령 세션 401. pages/* 는 기존 device matrix 유지 |
 | **T4** | `PublishDialog` 실패 분기 | 기존 7개 테스트가 전부 정상 경로. slug reason 분기(`invalid`/`reserved`/`taken`), AbortError 무시, publish catch, 에러 렌더가 **전부 미실행** | reason별 메시지 + 게시 버튼 disabled 유지, publish reject 시 에러 렌더 |
 | **T5** | `src/templates/` 개별 11종 | 레지스트리는 "등록됨"만 검증. 소비처가 try/catch로 삼켜서 **깨져도 예외 없이 품질만 떨어진다** | `it.each`로 11종: `generate()`가 비지 않은 promptHint 반환 + `authType!=='none'`이면 프록시 경로 포함 |
 | **T6** | `PopularServiceSuggestions.tsx` (143줄) | useEffect가 자동 fetch하는데 MSW 핸들러가 없고 `onUnhandledRequest:'error'`라 **핸들러부터 추가하지 않으면 테스트 작성 자체가 막힌다** | `handlers.ts`에 엔드포인트 추가 → 로딩 / 빈 목록 / fetch 실패 3케이스 |
@@ -125,16 +125,16 @@ grep "^SF:" coverage/lcov.info | tr '\\' '/' | grep '패턴'   # lcov는 백슬�
 
 ---
 
-## 5. 구조적 한계 — 테스트로 못 잡는 것
+## 5. 구조적 한계 — 단위 테스트로 못 잡는 것 (E2E로 고정)
 
-아래는 단위 테스트를 아무리 늘려도 잡히지 않는다. **E2E(T3)가 유일한 방어선**이다.
+아래는 단위 테스트를 아무리 늘려도 잡히지 않는다. **E2E(T3/E6)가 유일한 방어선**이다.
 
-| 결함 | 왜 단위 테스트가 못 잡나 |
-|------|------------------------|
-| `getAuthUser`의 DB 행 확인 제거 (유령 세션) | **라우트 테스트가 `getAuthUser`를 통째로 모킹**한다 |
-| 미리보기 / 게시(직접) / 게시(서브도메인) 3경로 불일치 | 경로별 차이는 실제 서빙에서만 드러난다 |
-| CSP 2중 적용으로 인한 백지 | 헤더 병합은 HTTP 레이어에서 일어난다 |
-| 서브도메인 rewrite 예외 누락 | 미리보기는 apex라 정상 동작해 드러나지 않는다 (2026-07-28 실측 장애) |
+| 결함 | 왜 단위 테스트가 못 잡나 | E2E 스펙 |
+|------|------------------------|----------|
+| `getAuthUser`의 DB 행 확인 제거 (유령 세션) | **라우트 테스트가 `getAuthUser`를 통째로 모킹**한다 | `e2e/serving/ghost-session.spec.ts` — 로그인 후 `cascadeDeleteUser` → 동일 쿠키로 `GET /api/v1/projects` **401** (200+`[]`면 회귀) |
+| 미리보기 / 게시(직접) / 게시(서브도메인) 3경로 불일치 | 경로별 차이는 실제 서빙에서만 드러난다 | `e2e/serving/serving-equivalence.spec.ts` — 세 경로 모두 `E2E_FIXTURE_OK` 마커 (바이트 동등 아님) |
+| CSP 2중 적용으로 인한 백지 | 헤더 병합은 HTTP 레이어에서 일어난다 | `e2e/serving/csp.spec.ts` — `headersArray()`/`rawHeaders`로 CSP **정확히 1개**, CDN 호스트 포함. site `frame-ancestors 'none'` vs preview `'self'` |
+| 서브도메인 rewrite 예외 누락 | 미리보기는 apex라 정상 동작해 드러나지 않는다 (2026-07-28 실측 장애) | `e2e/serving/subdomain-passthrough.spec.ts` — `Host: e2e-fixture.xzawed.xyz` + `/api/v1/proxy` → 프록시 JSON 400. **fail-closed**: 서브도메인 `GET /` 바디에 픽스처 마커 필수 |
 
 ---
 
@@ -142,4 +142,5 @@ grep "^SF:" coverage/lcov.info | tr '\\' '/' | grep '패턴'   # lcov는 백슬�
 
 | 일자 | 변경 |
 |------|------|
+| 2026-08-01 | **E6/T3**: E2E serving 프로젝트 추가(유령 세션·서빙 동등성·CSP·서브도메인 패스스루). CI Build/E2E에 `NEXT_PUBLIC_ROOT_DOMAIN`, seed `e2e/seed.mjs`, `httpHost` Host 주입 |
 | 2026-07-31 | 최초 작성. 스토어 6종·`usePublish` 테스트 추가(+39), `(auth)` glob 버그 수정, 테스트가 있던 라우트 12경로·stores 편입, codecov↔sonar 비대칭 1건 해소 |

--- a/docs/superpowers/plans/2026-07-31-project-wbs.md
+++ b/docs/superpowers/plans/2026-07-31-project-wbs.md
@@ -124,7 +124,7 @@
 | E3 | builder 생성 핸들러 추출 + 테스트 (T1) — **아래 P0~P4로 분할**. P0은 완료 | L |
 | E4 | 라우트 테스트 (T2: `projects/[id]`, `popular-services`) | S |
 | E5 | 약한 테스트 보강 (T4 PublishDialog 실패 분기, T5 템플릿 11종 계약) | M |
-| E6 | **E2E 확장 (T3)** — 미리보기↔게시 동등성, Host 헤더 서브도메인, 인증·생성·게시 | L |
+| ~~E6~~ | ~~**E2E 확장 (T3)** — 미리보기↔게시 동등성, Host 헤더 서브도메인, 인증·생성·게시~~ | **완료** — `e2e/serving/*` 4계약(A 패스스루·B 마커 동등성·C CSP 1회·D 유령 세션 401) + seed/CI `NEXT_PUBLIC_ROOT_DOMAIN` 빌드타임 인라인. 생성 플로우는 ANTHROPIC 키 부재로 픽스처 시드로 대체 |
 | E7 | MSW 보강 — `onUnhandledRequest:'error'`가 미처리 요청 부재를 보증하지 못한다(MSW #946/#943) | S |
 | **E8** | **`AbortController`를 생성 세션 단위로 승격.** 현재는 `runClientGeneration` 호출 로컬이라, 핸드오프된 폴러가 함수 반환 후 최대 5분 더 살아 있고 끊을 수단이 없다. 사용자가 '이전' 버튼으로 재생성하면 `startGeneration`이 터미널 래치를 재개방하므로 **이전 실행의 폴러가 새 실행 상태에 써 넣을 수 있다**(cross-run 오염). 스토어/모듈 ref로 올려 새 `startGeneration`이 직전 세션을 abort하게 할 것 | M |
 | **E9** | ~~**`RePromptPanel`은 보호가 전혀 없다.**~~ | **완료** — `runClientRegeneration` + `regenerationSession` + 패널 로컬 terminal 가드 + 테스트. coverage exclude 3곳 제거 |
@@ -247,7 +247,7 @@ generate 경로(`RateLimitService.decrementDailyLimit`)는 `logger.warn`을 남�
    최대 테스트 공백이 같은 작업이고, P3에서 폴링 취소로 이중 경로를 근본 해결한다 (L)
 3. ~~**C2** — 오프-볼륨 DR 코드 시임~~ → ✅ 제로 계정 완화(admin download + off-site URL 시임) 완료. **남은 것**: Railway 볼륨 백업(오너·유료)과 **다운로드를 실제로 주기적으로 당기는 습관**(코드가 자동화할 수 없음)
 4. **D-a** — `operations.md` 재작성. 다음 작업자의 오독을 막는다 (M)
-5. **E6** — E2E 확장. 구조적 사각지대의 유일한 방어선 (L)
+5. ~~**E6** — E2E 확장~~ → ✅ **완료**. 구조적 사각지대 4종을 serving 1회 프로젝트로 고정
 
 > **관측 가능성이 좋아졌다.** `GET /api/v1/admin/debug` 하나로 모델 폴백(`models.*.fellBack`)과
 > 이메일 설정(`email.*`)을 Railway 콘솔 없이 확인할 수 있다. 로컬 `.env.local`의 `ADMIN_API_KEY`가

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,22 @@
+import { test as setup, expect } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { loadFixtures } from './helpers/loadFixtures';
+
+const storageStatePath = 'e2e/.auth/user.json';
+
+setup('authenticate as e2e owner via real login flow', async ({ page }) => {
+  const fixtures = loadFixtures();
+
+  await page.goto('/login');
+  await page.locator('#email').fill(fixtures.owner.email);
+  await page.locator('#password').fill(fixtures.owner.password);
+  await page.locator('button[type="submit"]').click();
+
+  // Successful credentials login assigns /dashboard.
+  await page.waitForURL(/\/dashboard/, { timeout: 30_000 });
+  await expect(page).toHaveURL(/\/dashboard/);
+
+  mkdirSync(dirname(storageStatePath), { recursive: true });
+  await page.context().storageState({ path: storageStatePath });
+});

--- a/e2e/helpers/httpHost.ts
+++ b/e2e/helpers/httpHost.ts
@@ -1,0 +1,101 @@
+/**
+ * Raw HTTP helper that sets `Host` explicitly.
+ *
+ * Playwright's `request` API may overwrite Host from the URL, so subdomain
+ * rewrite tests must not rely on it. Always hit 127.0.0.1 and pass Host.
+ */
+import http from 'node:http';
+
+export interface HostRequestOptions {
+  /** Hostname for the Host header (e.g. e2e-fixture.xzawed.xyz). */
+  host: string;
+  path: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  /** Default 127.0.0.1 */
+  address?: string;
+  /** Default 3000 */
+  port?: number;
+  timeoutMs?: number;
+}
+
+export interface HostResponse {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  /** Raw header list — preserves duplicate header names (CSP double-apply). */
+  rawHeaders: string[];
+  body: string;
+}
+
+export function requestWithHost(options: HostRequestOptions): Promise<HostResponse> {
+  const {
+    host,
+    path,
+    method = 'GET',
+    headers = {},
+    body,
+    address = '127.0.0.1',
+    port = 3000,
+    timeoutMs = 30_000,
+  } = options;
+
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: address,
+        port,
+        path,
+        method,
+        headers: {
+          ...headers,
+          host,
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer | string) => {
+          chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+        });
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers,
+            rawHeaders: res.rawHeaders,
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+      },
+    );
+
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error(`requestWithHost timeout after ${timeoutMs}ms`));
+    });
+    req.on('error', reject);
+
+    if (body !== undefined) {
+      req.write(body);
+    }
+    req.end();
+  });
+}
+
+/** Count occurrences of a header name in the rawHeaders array (case-insensitive). */
+export function countHeader(rawHeaders: string[], name: string): number {
+  const target = name.toLowerCase();
+  let count = 0;
+  for (let i = 0; i < rawHeaders.length; i += 2) {
+    if (rawHeaders[i].toLowerCase() === target) count += 1;
+  }
+  return count;
+}
+
+/** Collect all values for a header name from rawHeaders (case-insensitive). */
+export function getHeaderValues(rawHeaders: string[], name: string): string[] {
+  const target = name.toLowerCase();
+  const values: string[] = [];
+  for (let i = 0; i < rawHeaders.length; i += 2) {
+    if (rawHeaders[i].toLowerCase() === target) values.push(rawHeaders[i + 1]);
+  }
+  return values;
+}

--- a/e2e/helpers/loadFixtures.ts
+++ b/e2e/helpers/loadFixtures.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface E2EFixtures {
+  marker: string;
+  draftMarker: string;
+  slug: string;
+  draftSlug: string;
+  rootDomain: string;
+  subdomainHost: string;
+  owner: { userId: string; email: string; password: string };
+  ghost: { userId: string; email: string; password: string };
+  publishedProjectId: string;
+  draftProjectId: string;
+  sqlitePath: string;
+  seededAt: string;
+  seedId: string;
+}
+
+export function loadFixtures(): E2EFixtures {
+  // process.cwd() is the repo root when Playwright runs tests.
+  const fixturesPath = join(process.cwd(), 'e2e', 'fixtures.json');
+  const raw = readFileSync(fixturesPath, 'utf8');
+  return JSON.parse(raw) as E2EFixtures;
+}

--- a/e2e/helpers/runCascadeDelete.mjs
+++ b/e2e/helpers/runCascadeDelete.mjs
@@ -1,0 +1,35 @@
+/**
+ * CLI: cascade-delete a user against SQLITE_PATH using the app's cascadeDeleteUser.
+ * Usage: node --import tsx e2e/helpers/runCascadeDelete.mjs <userId> <email> [name]
+ */
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+process.chdir(root);
+
+const userId = process.argv[2];
+const email = process.argv[3] ?? null;
+const name = process.argv[4] ?? null;
+
+if (!userId) {
+  console.error('usage: runCascadeDelete.mjs <userId> <email> [name]');
+  process.exit(2);
+}
+
+const sqlitePath = process.env.SQLITE_PATH;
+if (!sqlitePath) {
+  console.error('SQLITE_PATH is required');
+  process.exit(2);
+}
+
+const { createSqliteConnection } = await import('../../src/lib/db/sqlite/connection.ts');
+const { cascadeDeleteUser } = await import('../../src/lib/auth/deleteAccountCascade.ts');
+
+const { db, raw } = createSqliteConnection(sqlitePath);
+try {
+  cascadeDeleteUser(db, { userId, email, name });
+  console.log(`[e2e] cascadeDeleteUser ok userId=${userId}`);
+} finally {
+  raw.close();
+}

--- a/e2e/seed.mjs
+++ b/e2e/seed.mjs
@@ -1,0 +1,184 @@
+/**
+ * E2E SQLite seed — runs before `pnpm start` (see playwright.config webServer.command).
+ *
+ * Deletes SQLITE_PATH (+ wal/shm), bootstraps with the app's own bootstrapSqlite
+ * (same migrations as prod), inserts fixture rows, closes the connection, writes
+ * e2e/fixtures.json for specs.
+ *
+ * Invoked as: node --import tsx e2e/seed.mjs
+ * (tsx so we can import app TS modules + @/ path aliases.)
+ */
+import { existsSync, unlinkSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { randomUUID } from 'node:crypto';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+// Ensure path aliases and relative migration folder resolve from repo root.
+process.chdir(root);
+
+const sqlitePath = process.env.SQLITE_PATH ?? join(root, '.tmp', 'e2e-app.db');
+process.env.SQLITE_PATH = sqlitePath;
+// bootstrap path does not require DB_PROVIDER, but keep env consistent for any helpers.
+process.env.DB_PROVIDER = process.env.DB_PROVIDER ?? 'sqlite';
+
+const { createSqliteConnection } = await import('../src/lib/db/sqlite/connection.ts');
+const { bootstrapSqlite } = await import('../src/lib/db/sqlite/bootstrap.ts');
+const { hashPassword } = await import('../src/lib/auth/password.ts');
+const schema = await import('../src/lib/db/sqlite/schema.ts');
+
+function removeIfExists(path) {
+  if (existsSync(path)) unlinkSync(path);
+}
+
+mkdirSync(dirname(sqlitePath), { recursive: true });
+removeIfExists(sqlitePath);
+removeIfExists(`${sqlitePath}-wal`);
+removeIfExists(`${sqlitePath}-shm`);
+
+const MARKER = 'E2E_FIXTURE_OK';
+const DRAFT_MARKER = 'E2E_DRAFT_SECRET';
+const SLUG = 'e2e-fixture';
+const DRAFT_SLUG = 'e2e-draft';
+const ROOT_DOMAIN = process.env.NEXT_PUBLIC_ROOT_DOMAIN ?? 'xzawed.xyz';
+
+const ownerUserId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const ghostUserId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const publishedProjectId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const draftProjectId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const publishedCodeId = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+const draftCodeId = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+
+const ownerEmail = 'e2e-owner@example.com';
+const ownerPassword = 'E2eOwnerPass!234';
+const ghostEmail = 'e2e-ghost@example.com';
+const ghostPassword = 'E2eGhostPass!234';
+
+const now = new Date().toISOString();
+const ownerHash = hashPassword(ownerPassword);
+const ghostHash = hashPassword(ghostPassword);
+
+const { db, raw } = createSqliteConnection(sqlitePath);
+try {
+  bootstrapSqlite(db);
+
+  db.insert(schema.users)
+    .values([
+      {
+        id: ownerUserId,
+        email: ownerEmail,
+        name: 'E2E Owner',
+        email_verified: now,
+        password_hash: ownerHash,
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        id: ghostUserId,
+        email: ghostEmail,
+        name: 'E2E Ghost',
+        email_verified: now,
+        password_hash: ghostHash,
+        created_at: now,
+        updated_at: now,
+      },
+    ])
+    .run();
+
+  db.insert(schema.projects)
+    .values([
+      {
+        id: publishedProjectId,
+        user_id: ownerUserId,
+        name: 'E2E Published Fixture',
+        context: 'e2e published site',
+        status: 'published',
+        current_version: 1,
+        slug: SLUG,
+        published_at: now,
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        id: draftProjectId,
+        user_id: ownerUserId,
+        name: 'E2E Draft Fixture',
+        context: 'e2e draft site',
+        status: 'draft',
+        current_version: 1,
+        slug: DRAFT_SLUG,
+        published_at: null,
+        created_at: now,
+        updated_at: now,
+      },
+    ])
+    .run();
+
+  const publishedHtml = `<!DOCTYPE html><html><head><title>E2E Fixture</title></head><body><main data-e2e="${MARKER}"><h1>${MARKER}</h1><p>Published fixture body.</p></main></body></html>`;
+  const draftHtml = `<!DOCTYPE html><html><body><div>${DRAFT_MARKER}</div></body></html>`;
+
+  db.insert(schema.generatedCodes)
+    .values([
+      {
+        id: publishedCodeId,
+        project_id: publishedProjectId,
+        version: 1,
+        code_html: publishedHtml,
+        code_css: '/* e2e */',
+        code_js: `console.log('${MARKER}');`,
+        framework: 'vanilla',
+        ai_provider: 'e2e',
+        ai_model: 'fixture',
+        created_at: now,
+      },
+      {
+        id: draftCodeId,
+        project_id: draftProjectId,
+        version: 1,
+        code_html: draftHtml,
+        code_css: '',
+        code_js: '',
+        framework: 'vanilla',
+        ai_provider: 'e2e',
+        ai_model: 'fixture',
+        created_at: now,
+      },
+    ])
+    .run();
+} finally {
+  raw.close();
+}
+
+const fixtures = {
+  marker: MARKER,
+  draftMarker: DRAFT_MARKER,
+  slug: SLUG,
+  draftSlug: DRAFT_SLUG,
+  rootDomain: ROOT_DOMAIN,
+  subdomainHost: `${SLUG}.${ROOT_DOMAIN}`,
+  owner: {
+    userId: ownerUserId,
+    email: ownerEmail,
+    password: ownerPassword,
+  },
+  ghost: {
+    userId: ghostUserId,
+    email: ghostEmail,
+    password: ghostPassword,
+  },
+  publishedProjectId,
+  draftProjectId,
+  sqlitePath,
+  seededAt: now,
+  // unused but kept so tests can assert stable ids
+  seedId: randomUUID(),
+};
+
+const fixturesPath = join(__dirname, 'fixtures.json');
+writeFileSync(fixturesPath, `${JSON.stringify(fixtures, null, 2)}\n`, 'utf8');
+
+console.log(`[e2e/seed] seeded ${sqlitePath}`);
+console.log(`[e2e/seed] wrote ${fixturesPath}`);
+console.log(`[e2e/seed] slug=${SLUG} marker=${MARKER}`);

--- a/e2e/serving/csp.spec.ts
+++ b/e2e/serving/csp.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * C. CSP — exactly one Content-Security-Policy header on site/subdomain/preview.
+ * Use raw headers (headersArray / rawHeaders), not collapsed object form.
+ */
+import { test, expect } from '@playwright/test';
+import { countHeader, getHeaderValues, requestWithHost } from '../helpers/httpHost';
+import { loadFixtures } from '../helpers/loadFixtures';
+// 소스에서 직접 가져온다 — 목록을 복사해 두면 CDN이 추가돼도 테스트가 눈치채지 못한다.
+// cdn.ts 는 import 가 없는 순수 상수 파일이라 상대경로로 그대로 로드된다.
+import {
+  SITE_FONT_CDNS,
+  SITE_SCRIPT_CDNS,
+  SITE_STYLE_CDNS,
+} from '../../src/lib/constants/cdn';
+
+const CDN_HOSTS = [
+  ...SITE_SCRIPT_CDNS,
+  ...SITE_STYLE_CDNS,
+  ...SITE_FONT_CDNS,
+] as const;
+
+test.describe('C. CSP single-header contract', () => {
+  test('published-direct has exactly one CSP including CDN hosts and frame-ancestors none', async ({
+    request,
+  }) => {
+    const fixtures = loadFixtures();
+    const res = await request.get(`/site/${fixtures.slug}`);
+    expect(res.status()).toBe(200);
+
+    // Playwright APIResponse.headersArray() preserves duplicates.
+    const cspHeaders = res.headersArray().filter((h) => h.name.toLowerCase() === 'content-security-policy');
+    expect(cspHeaders, 'exactly one CSP header on /site').toHaveLength(1);
+
+    const csp = cspHeaders[0].value;
+    for (const host of CDN_HOSTS) {
+      expect(csp, `CSP must allow ${host}`).toContain(host);
+    }
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).not.toContain("frame-ancestors 'self'");
+  });
+
+  test('published-subdomain has exactly one CSP with CDN hosts', async () => {
+    const fixtures = loadFixtures();
+    const res = await requestWithHost({
+      host: fixtures.subdomainHost,
+      path: '/',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toContain(fixtures.marker);
+
+    expect(countHeader(res.rawHeaders, 'content-security-policy')).toBe(1);
+    const [csp] = getHeaderValues(res.rawHeaders, 'content-security-policy');
+    for (const host of CDN_HOSTS) {
+      expect(csp).toContain(host);
+    }
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+
+  test("preview CSP is single, includes CDNs, and uses frame-ancestors 'self'", async ({
+    request,
+  }) => {
+    const fixtures = loadFixtures();
+    const res = await request.get(`/api/v1/preview/${fixtures.publishedProjectId}`);
+    expect(res.status()).toBe(200);
+
+    const cspHeaders = res.headersArray().filter((h) => h.name.toLowerCase() === 'content-security-policy');
+    expect(cspHeaders, 'exactly one CSP on preview').toHaveLength(1);
+
+    const csp = cspHeaders[0].value;
+    for (const host of CDN_HOSTS) {
+      expect(csp).toContain(host);
+    }
+    // Intentional difference vs site — do not force equality.
+    expect(csp).toContain("frame-ancestors 'self'");
+    expect(csp).not.toContain("frame-ancestors 'none'");
+  });
+});

--- a/e2e/serving/ghost-session.spec.ts
+++ b/e2e/serving/ghost-session.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * D. Ghost session — getAuthUser DB row check.
+ *
+ * Log in as ghost user → cascadeDeleteUser (prod semantics) → same cookie on
+ * GET /api/v1/projects must be 401 (not 200 + []).
+ *
+ * Do NOT assert middleware page gates — middleware is JWT-only by design.
+ */
+import { test, expect } from '@playwright/test';
+import { spawnSync } from 'node:child_process';
+import { loadFixtures } from '../helpers/loadFixtures';
+
+test.describe('D. ghost session', () => {
+  // Independent of owner storageState — uses ghost fixture credentials.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('deleted user with live JWT gets 401 on GET /api/v1/projects', async ({ page }) => {
+    const fixtures = loadFixtures();
+
+    await page.goto('/login');
+    await page.locator('#email').fill(fixtures.ghost.email);
+    await page.locator('#password').fill(fixtures.ghost.password);
+    await page.locator('button[type="submit"]').click();
+    await page.waitForURL(/\/dashboard/, { timeout: 30_000 });
+
+    // Sanity: session is valid before delete.
+    const before = await page.request.get('/api/v1/projects');
+    expect(before.status()).toBe(200);
+
+    // Production cascade delete via a second SQLite connection (FK-safe).
+    // Hand-rolled DELETE FROM users would hit FK constraints.
+    // Run out-of-process so app TS + @/ aliases resolve via tsx (same as seed).
+    const sqlitePath = process.env.SQLITE_PATH ?? fixtures.sqlitePath;
+    const del = spawnSync(
+      process.execPath,
+      [
+        '--import',
+        'tsx',
+        'e2e/helpers/runCascadeDelete.mjs',
+        fixtures.ghost.userId,
+        fixtures.ghost.email,
+        'E2E Ghost',
+      ],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, SQLITE_PATH: sqlitePath, DB_PROVIDER: 'sqlite' },
+      },
+    );
+    expect(del.status, `cascade delete failed: ${del.stderr || del.stdout}`).toBe(0);
+
+    // Same browser cookie jar — JWT still present, users row gone.
+    const after = await page.request.get('/api/v1/projects');
+    expect(
+      after.status(),
+      'ghost session must be 401; 200+[] means getAuthUser DB check was removed',
+    ).toBe(401);
+
+    const body = await after.json();
+    expect(body).toMatchObject({
+      success: false,
+      error: { code: 'AUTH_REQUIRED' },
+    });
+    // Explicit contrast: must not look like an empty project list success.
+    expect(body).not.toMatchObject({ success: true, data: [] });
+  });
+});

--- a/e2e/serving/serving-equivalence.spec.ts
+++ b/e2e/serving/serving-equivalence.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * B. Serving equivalence — preview / published-direct / published-subdomain
+ * must all include the same fixture marker (not byte equality; headers differ).
+ *
+ * Cheap extras: unauthenticated preview → 401; draft /site does not leak marker.
+ */
+import { test, expect } from '@playwright/test';
+import { requestWithHost } from '../helpers/httpHost';
+import { loadFixtures } from '../helpers/loadFixtures';
+
+test.describe('B. serving equivalence', () => {
+  test('published-direct, published-subdomain, and preview share the fixture marker', async ({
+    request,
+  }) => {
+    const fixtures = loadFixtures();
+
+    const direct = await request.get(`/site/${fixtures.slug}`);
+    expect(direct.status()).toBe(200);
+    const directBody = await direct.text();
+    expect(directBody).toContain(fixtures.marker);
+
+    const subdomain = await requestWithHost({
+      host: fixtures.subdomainHost,
+      path: '/',
+    });
+    expect(subdomain.status).toBe(200);
+    expect(subdomain.body).toContain(fixtures.marker);
+
+    const preview = await request.get(`/api/v1/preview/${fixtures.publishedProjectId}`);
+    expect(preview.status()).toBe(200);
+    const previewBody = await preview.text();
+    expect(previewBody).toContain(fixtures.marker);
+
+    // Marker equality (not byte equality) — intentional header diffs allowed.
+    const extractMarker = (html: string): string => {
+      const idx = html.indexOf(fixtures.marker);
+      expect(idx, 'marker must appear').toBeGreaterThanOrEqual(0);
+      return fixtures.marker;
+    };
+    expect(extractMarker(directBody)).toBe(extractMarker(subdomain.body));
+    expect(extractMarker(directBody)).toBe(extractMarker(previewBody));
+  });
+
+  test('unauthenticated preview returns 401', async ({ browser }) => {
+    const fixtures = loadFixtures();
+    const context = await browser.newContext({ storageState: undefined });
+    const page = await context.newPage();
+    const res = await page.request.get(`/api/v1/preview/${fixtures.publishedProjectId}`);
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      success: false,
+      error: { code: 'AUTH_REQUIRED' },
+    });
+    await context.close();
+  });
+
+  test('draft project /site/{slug} does not leak generated marker', async ({ request }) => {
+    const fixtures = loadFixtures();
+    const res = await request.get(`/site/${fixtures.draftSlug}`);
+    // Site route returns preparingHtml with 200 for non-published.
+    expect(res.status()).toBe(200);
+    const body = await res.text();
+    expect(body).not.toContain(fixtures.draftMarker);
+    expect(body).not.toContain(fixtures.marker);
+  });
+});

--- a/e2e/serving/subdomain-passthrough.spec.ts
+++ b/e2e/serving/subdomain-passthrough.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * A. Subdomain passthrough — 2026-07-28 outage class.
+ *
+ * Host: e2e-fixture.xzawed.xyz + GET /api/v1/proxy?... must reach the proxy
+ * route (JSON error is fine), not site HTML and not a rewrite 404.
+ *
+ * Fail-closed: first assertion requires the fixture marker on subdomain GET /
+ * so a dead rewrite (landing HTML) fails the suite rather than passing vacuously.
+ */
+import { test, expect } from '@playwright/test';
+import { requestWithHost } from '../helpers/httpHost';
+import { loadFixtures } from '../helpers/loadFixtures';
+
+test.describe('A. subdomain passthrough', () => {
+  test('subdomain Host rewrite serves fixture marker (fail-closed gate)', async () => {
+    const fixtures = loadFixtures();
+    const res = await requestWithHost({
+      host: fixtures.subdomainHost,
+      path: '/',
+    });
+
+    expect(res.status, 'subdomain site should be 200').toBe(200);
+    // If NEXT_PUBLIC_ROOT_DOMAIN is missing or Host is ignored, we get the
+    // landing page — which must not pass.
+    expect(
+      res.body,
+      'body must contain fixture marker; landing HTML means rewrite did not fire',
+    ).toContain(fixtures.marker);
+    expect(res.body).not.toMatch(/무료로 시작하기/);
+  });
+
+  test('GET /api/v1/proxy under subdomain Host reaches proxy route (not site HTML)', async () => {
+    const fixtures = loadFixtures();
+    // Missing apiId/proxyPath → proxy validation 400 JSON. Proves passthrough.
+    const res = await requestWithHost({
+      host: fixtures.subdomainHost,
+      path: '/api/v1/proxy',
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.headers['content-type'] ?? '').toMatch(/json/i);
+
+    let json: unknown;
+    expect(() => {
+      json = JSON.parse(res.body);
+    }).not.toThrow();
+
+    expect(json).toMatchObject({
+      success: false,
+      error: expect.objectContaining({
+        code: expect.any(String),
+        message: expect.any(String),
+      }),
+    });
+
+    // Must not be rewritten to /site/{slug}/api/... HTML.
+    expect(res.body).not.toContain(fixtures.marker);
+    expect(res.body).not.toMatch(/<!DOCTYPE html>/i);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,23 @@
 import { defineConfig, devices } from '@playwright/test';
+import path from 'node:path';
+
+const e2eSqlitePath =
+  process.env.SQLITE_PATH ?? path.join(process.cwd(), '.tmp', 'e2e-app.db');
+const rootDomain = process.env.NEXT_PUBLIC_ROOT_DOMAIN ?? 'xzawed.xyz';
+
+/** Env shared by webServer (seed + start) and tests. */
+const e2eEnv: Record<string, string> = {
+  ...process.env,
+  DB_PROVIDER: 'sqlite',
+  SQLITE_PATH: e2eSqlitePath,
+  SQLITE_BACKUP_ENABLED: 'false',
+  AUTH_SECRET: process.env.AUTH_SECRET ?? 'e2e-ci-secret-not-for-production',
+  AUTH_TRUST_HOST: 'true',
+  // http:// so Auth.js does not force Secure cookies against plain localhost.
+  AUTH_URL: process.env.AUTH_URL ?? 'http://127.0.0.1:3000',
+  NEXT_PUBLIC_ROOT_DOMAIN: rootDomain,
+  NEXT_PUBLIC_AUTH_PROVIDER: process.env.NEXT_PUBLIC_AUTH_PROVIDER ?? 'local',
+};
 
 export default defineConfig({
   testDir: './e2e',
@@ -10,26 +29,47 @@ export default defineConfig({
     ? [['github'], ['html', { open: 'never' }]]
     : 'list',
   use: {
-    baseURL: 'http://localhost:3000',
+    // 127.0.0.1 matches AUTH_URL / Host helper (avoid localhost subdomain quirks).
+    baseURL: 'http://127.0.0.1:3000',
     trace: 'on-first-retry',
   },
   projects: [
     {
+      name: 'setup',
+      testMatch: /auth\.setup\.ts/,
+    },
+    {
+      // Request-level serving contracts — run once (not × device matrix).
+      name: 'serving',
+      testMatch: /serving\/.*\.spec\.ts/,
+      dependencies: ['setup'],
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'e2e/.auth/user.json',
+      },
+    },
+    {
       name: 'mobile',
+      testMatch: /pages\/.*\.spec\.ts|health\.spec\.ts/,
       use: { ...devices['iPhone 14'] },
     },
     {
       name: 'tablet',
+      testMatch: /pages\/.*\.spec\.ts|health\.spec\.ts/,
       use: { ...devices['iPad Mini'] },
     },
     {
       name: 'desktop',
+      testMatch: /pages\/.*\.spec\.ts|health\.spec\.ts/,
       use: { ...devices['Desktop Chrome'] },
     },
   ],
   webServer: {
-    command: 'pnpm start',
-    port: 3000,
+    // Seed before start so fixtures exist regardless of Playwright hook semantics.
+    command: 'node --import tsx e2e/seed.mjs && pnpm start',
+    url: 'http://127.0.0.1:3000/api/v1/health',
     reuseExistingServer: !process.env.CI,
+    env: e2eEnv,
+    timeout: 120_000,
   },
 });


### PR DESCRIPTION
## 배경

`test-coverage-map.md` §5가 열거한 결함들은 **단위 테스트가 원리적으로 못 잡습니다** — 테스트가 바로 그 실패할 대상을 모킹하기 때문입니다. E2E가 유일한 방어선입니다.

## ⚠️ 착수 전에 막힌 것부터 고쳤습니다

이걸 안 고쳤으면 **테스트가 통과하면서 아무것도 증명하지 못했을** 것입니다:

| 문제 | 조치 |
|---|---|
| **`NEXT_PUBLIC_ROOT_DOMAIN`이 `ci.yml`에 0건** → 미들웨어가 Host를 아예 안 봄 → **서브도메인 rewrite가 죽어 있음** | 추가 |
| **Build 단계에 `env:` 블록 자체가 없음** — `NEXT_PUBLIC_*`은 빌드 타임 인라인이라 테스트 단계에만 넣으면 소용없음 | **build·e2e 양쪽**에 설정 |
| 미들웨어가 `localhost`·`127.0.0.1`을 명시적으로 배제 → `slug.localhost` 불가 | `Host: e2e-fixture.xzawed.xyz` + `node:http` 헬퍼 (Playwright `request`가 Host를 덮어쓸 수 있음) |
| `/tmp`에 백업 스케줄러 실행 | `SQLITE_BACKUP_ENABLED=false` |

## 픽스처는 부팅 전에 시딩

CI에 `ANTHROPIC_API_KEY`가 없어 실제 생성이 불가능합니다. `webServer.command`를 `node e2e/seed.mjs && pnpm start`로 두어 순서를 확정하고, **앱 자신의 `bootstrapSqlite`**로 마이그레이션한 뒤 사용자·게시 프로젝트·생성 코드를 넣고 연결을 닫습니다.

비밀번호는 앱의 `hashPassword`를 그대로 쓰고 **실제 로그인 폼**으로 세션을 얻습니다. JWT를 손으로 만들지 않습니다 — 쿠키 이름·청킹·시크릿 처리가 현실과 어긋납니다.

## 네 가지 테스트

| 테스트 | 무엇을 잡는가 |
|---|---|
| **A. 서브도메인 패스스루** | `SUBDOMAIN_PASSTHROUGH_PREFIXES` 제거 → 게시 사이트의 API 호출 전부 404 (**2026-07-28 실제 장애**) |
| **B. 서빙 동등성** | 미리보기 / 게시(직접) / 게시(서브도메인) 세 경로 분기 |
| **C. CSP 단일 헤더** | 2중 적용 → CDN 전부 차단 → 백지. **`headersArray()`로 검사** — 객체 형태는 중복을 합쳐 버려 버그를 숨깁니다 |
| **D. 유령 세션** | `getAuthUser`의 DB 행 확인 제거 → 삭제된 계정 JWT가 살아남. **401이어야 하고 `200 + []`이면 실패** |

D는 프로덕션과 같은 `cascadeDeleteUser` 의미로 삭제합니다(맨 `DELETE FROM users`는 FK에 막힘). **미들웨어 페이지 게이트는 단언하지 않습니다** — 미들웨어는 의도적으로 JWT 전용이라 잘못된 계층입니다.

덤: 비인증 미리보기 401, draft 프로젝트가 생성물을 노출하지 않음.

## ✅ fail-closed를 증명했습니다

**통과하는 테스트가 사실은 아무것도 검증하지 않는 것**이 이 작업의 진짜 위험입니다. 루트 도메인을 어긋나게 해 rewrite가 발동하지 않게 만든 뒤 실행했더니 3건이 빨개졌습니다:

```
Error: body must contain fixture marker; landing HTML means rewrite did not fire
```

복구하니 다시 green(10/10). 프록시 도달 여부만 보는 검사는 apex에서도 통과하므로, **마커 게이트가 실제로 닫히는 쪽**입니다.

## CDN 목록은 소스에서 가져옵니다

초안은 CSP 테스트에 CDN 호스트를 복사해 뒀는데, 그러면 **CDN이 추가돼도 테스트가 눈치채지 못합니다.** `cdn.ts`가 import 없는 순수 상수 파일이라 상대경로로 그대로 로드됩니다 — 복사본을 없앴습니다.

## 비용

요청 레벨 스펙은 **한 프로젝트에서만** 돕니다(기존 UI 스펙은 device 3종 유지). `setup`(로그인·storageState) → `serving` 의존 관계로 분리했습니다.

e2e **11 → 43테스트**, 로컬 setup+serving **10건 10.7초**.

## 검증

`pnpm test:e2e` 로컬 통과 · `pnpm type-check` 통과 · `pnpm lint` 0 errors · 단위 **186파일 / 2291테스트** 변동 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
