### PR TITLE
fix: DB_PROVIDER 부팅 게이트 완화 — env 하나로 전면 장애가 나지 않게 (C5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,8 @@
 # =============================================================================
 
 # === 데이터베이스 (임베디드 SQLite) ===
-# getSqliteDb() 가 DB_PROVIDER === 'sqlite' 일 때만 연결한다.
-# 미설정·다른 값 → 모든 DB 접근 throw (src/lib/db/sqlite/connection.ts:36-39)
+# 선택 — 미설정이면 sqlite로 동작한다(부팅 경고 1회). 'sqlite' 외의 값만 throw.
+# 명시를 권장하지만 이 변수를 잃었다고 서비스가 죽지는 않는다 (assertSqliteEnv).
 DB_PROVIDER=sqlite
 # SQLITE_PATH=./data/app.db              # 선택 (기본: /data/app.db — 로컬은 쓰기 가능한 경로 권장)
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ pnpm test:coverage     # 📊 커버리지 리포트
 ```bash
 pnpm install                         # 의존성 설치
 cp .env.example .env.local           # 환경변수 템플릿 복사
-# .env.local 필수 칸 채우기 (아래 표 + DB_PROVIDER=sqlite)
+# .env.local 필수 칸 채우기 (아래 표)
 pnpm dev                             # 개발 서버 (Turbopack)
 # 브라우저: http://localhost:3000/signup 에서 계정 생성
 ```
@@ -192,7 +192,6 @@ pnpm dev                             # 개발 서버 (Turbopack)
 
 | 변수 | 설명 |
 |------|------|
-| `DB_PROVIDER` | **`sqlite` 고정.** 미설정·다른 값이면 DB 연결 throw |
 | `AUTH_SECRET` | Auth.js JWT 서명 (`openssl rand -base64 32`) |
 | `AUTH_TRUST_HOST` | 프록시/커스텀 도메인 뒤 `true` |
 | `NEXT_PUBLIC_AUTH_PROVIDER` | `local` (클라이언트 빌드타임 상수) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -182,6 +182,7 @@
 | [2026-07-30-suggestion-daily-quota-separation.md](decisions/2026-07-30-suggestion-daily-quota-separation.md) | AI 추천 일일 쿼터 분리 |
 | [2026-08-01-remove-external-deploy-stack.md](decisions/2026-08-01-remove-external-deploy-stack.md) | 외부 deploy export 스택 제거 |
 | [2026-08-01-remove-unused-sentry-scaffolding.md](decisions/2026-08-01-remove-unused-sentry-scaffolding.md) | 미사용 Sentry 스캐폴딩 제거 (C4(b)) |
+| [2026-08-01-db-provider-boot-gate.md](decisions/2026-08-01-db-provider-boot-gate.md) | `DB_PROVIDER` 부팅 게이트 완화 (C5) |
 
 ---
 

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -465,8 +465,9 @@ COMMIT
   (IRepository seam — Provider 추상화는 이 seam만 유지)
 - **구현**: [`src/repositories/sqlite/`](../../src/repositories/sqlite/) **9종**이 **유일** 구현
   (User, Project, Code, Catalog, UserApiKey, RateLimit, Event, AuthToken, **GenerationLock**)
-- **팩토리**: 레포 팩토리는 무인자다. DB provider 분기는 없으며, `getSqliteDb()`가
-  `process.env.DB_PROVIDER`를 직접 읽어 `'sqlite'`가 아니면 throw하는 부팅 가드만 남아 있다.
+- **팩토리**: 레포 팩토리는 무인자다. DB provider 분기는 없다. `getSqliteDb()`는 `assertSqliteEnv()`로
+  환경만 검사한다 — `DB_PROVIDER` 미설정은 sqlite로 취급(경고 1회), `'sqlite'` 외의 값만 throw
+  (2026-08-01 이전엔 미설정도 throw여서 env 하나로 전면 장애였다 — [ADR](../decisions/2026-08-01-db-provider-boot-gate.md)).
   (상수만 반환하던 `getDbProvider()`와 `lib/config/providers.ts`는 2026-07-10 죽은 코드 정리로 삭제됨.)
 - **소유권 검증**: RLS가 없으므로 레포/서비스 계층의 앱 레벨 `assertOwner` 검증으로
   `user_id` 일치를 강제한다.

--- a/docs/decisions/2026-08-01-db-provider-boot-gate.md
+++ b/docs/decisions/2026-08-01-db-provider-boot-gate.md
@@ -1,0 +1,119 @@
+# `DB_PROVIDER` 부팅 게이트 완화 — 미설정을 장애로 취급하지 않는다
+
+- 날짜: 2026-08-01
+- 상태: 채택
+- 관련: WBS C5, [2026-06-23 SQLite 컷오버 ADR](2026-06-23-sqlite-cutover-and-supabase-removal.md)
+
+## 배경
+
+`getSqliteDb()`는 `process.env.DB_PROVIDER !== 'sqlite'`이면 throw했다. 이중 스택
+(supabase/postgres/sqlite) 시절의 스위치인데, 2026-06-23 컷오버로 **분기할 대상이 사라진 뒤에도
+문자열 검사만 남아** 있었다.
+
+문제는 이게 **단일 스택에서 가장 위험한 단일 지점**이었다는 것이다.
+
+- `getSqliteDb()`는 레포 팩토리 9개 전부와 `instrumentation.ts` 부팅 훅이 호출한다
+- 폴백할 다른 provider가 없다 — throw는 곧 **전면 장애**다
+- env 문자열 하나를 잃으면 그렇게 된다
+
+게다가 문서가 오히려 **반대로** 적혀 있었다. `env-vars.md`가 "`DB_PROVIDER` 분기는 모두 제거됨"이라
+단언했고 `.env.example`엔 언급조차 없었는데, `development.md`는 `cp .env.example .env.local`을
+안내했다. **문서를 따라 재구축하면 모든 DB 접근이 크래시했다.** 볼륨 손실 시 복구가 사람 손에
+달린 서비스에서 이건 치명적이다.
+
+## 검토한 안
+
+| 안 | 미설정 | 잘못된 값 | 판정 |
+|---|---|---|---|
+| A. 검사 전면 제거 | sqlite | sqlite (조용히) | 오설정을 삼킨다 |
+| **B. 미설정 허용 + 잘못된 값 throw** | sqlite | throw | 채택 (아래 조건부) |
+| C. 그대로 두고 문서만 수정 | throw | throw | 지뢰 존치 |
+
+A는 오설정을 조용히 넘긴다. C는 문서를 고쳐도 지뢰가 남는다. B를 택했다.
+
+### 다만 B를 그대로 쓰면 안 됐다 — 적대적 검토가 잡은 것
+
+B의 부작용은 **테스트 안전망 상실**이다. 단위 테스트는 `DB_PROVIDER`를 설정하지 않으므로,
+지금까지는 실수로 실제(모킹되지 않은) `getSqliteDb()`를 호출하면 **우연히** 게이트가 막아 줬다.
+미설정을 허용하면 그 우연이 사라진다.
+
+"경로가 없어 어차피 실패한다"는 반론은 **틀렸다**. 러너 이미지가 `mkdir -p /data`로
+**항상 쓰기 가능한 디렉터리를 만든다**(`Dockerfile`). 즉 컨테이너 안에서는 기본 경로가
+조용히 열린다.
+
+→ 그래서 우연한 방어를 **명시적 방어로 승격**했다: 테스트 환경에서 `SQLITE_PATH`가 없으면 throw.
+
+## 결정
+
+`assertSqliteEnv()` (`src/lib/db/sqlite/connection.ts`):
+
+| 조건 | 동작 |
+|---|---|
+| `DB_PROVIDER` 미설정·빈 문자열 | sqlite로 연결 + **경고 1회**(`logger.warn`) |
+| `DB_PROVIDER='sqlite'` | 정상 |
+| 그 외 값 | **throw** (값을 메시지에 담는다) |
+| `NODE_ENV==='test'` + `SQLITE_PATH` 미설정 | **throw** — 실제 파일 DB 사고 방지 |
+
+경고를 남기는 이유: 미설정으로도 동작하지만 **의도한 상태는 아니다.** 조용히 넘기면
+"왜 기본 경로로 떴는지" 알 방법이 없다.
+
+## 수용한 잔여 위험 (숨기지 않는다)
+
+**볼륨 미마운트 + `DB_PROVIDER` 미설정이 겹치면** 빈 임시 DB로 떠서 정상처럼 보인다.
+이전에는 이 이중 결함이 throw로 막혔다.
+
+다만 **볼륨만 사라진 경우(env 정상)는 이전에도 막지 못했다** — 이미지가 `/data`를 만들기 때문에
+`bootstrapSqlite`가 새 DB에 마이그레이션·시드를 돌리고 뜬다. 즉 이 fail-open은 원래 있었고,
+이번 변경은 조합 하나를 추가했을 뿐이다. 단일 결함(env만 상실, 볼륨 정상)이 훨씬 흔하고
+그쪽을 고치는 이득이 크다고 판단했다.
+
+> **관련해 별개로 확인된 사실**: 공개 `GET /api/v1/health`는 **DB를 전혀 건드리지 않고**
+> `{status:'ok'}`를 반환한다(`health/route.ts`). Railway 헬스체크가 이 경로이므로
+> **"배포 성공 + health 200"은 DB가 올바르다는 증거가 아니다.** DB를 실제로 확인하려면
+> `?detailed=true` + `ADMIN_API_KEY`로 `checks.database`를 봐야 한다. 이 사실은 이번 변경과
+> 무관하게 원래 성립한다.
+
+## 검증 (실측)
+
+| 검증 | 결과 |
+|---|---|
+| 단위 — 미설정·빈 문자열·잘못된 값·테스트 경로 누락 4분기 | 통과 (`connection.test.ts`) |
+| 전체 스위트 (env 둘 다 비운 셸) | **186파일 / 2295테스트 통과** |
+| standalone 부팅, `DB_PROVIDER` **미설정** | 기동 + `checks.database: ok` + 경고 로그 확인 |
+| 같은 DB로 **재부팅** 시 기존 데이터 보존 | 마커 사용자 1명 → `totalUsers: 1` 유지 |
+| standalone, `DB_PROVIDER=postgres` | **서버가 뜨지 않는다** — 아래 상세 |
+
+`pnpm build` 통과는 이 변경의 증거가 되지 못한다(빌드는 DB를 열지 않는다). 그래서
+**상세 health로 DB 실접근**까지 확인했다.
+
+### 잘못된 값일 때 무슨 일이 일어나는가 (기전을 정확히)
+
+health 라우트는 DB 예외를 **catch해서 200 + `status:'unhealthy'`**를 반환한다
+(`health/route.ts` — 500이 아니다). 하지만 실측하면 **공개 health까지 500**이다.
+이유는 라우트가 아니라 부팅이다:
+
+```
+Failed to prepare server Error: An error occurred while loading instrumentation hook:
+DB_PROVIDER="postgres"는 지원하지 않습니다. ...
+```
+
+`instrumentation.ts`의 `register()`가 throw하면 **Next가 서버 준비 자체에 실패**해 모든 요청이
+500이 된다. 요청이 라우트에 도달하지 못하므로 catch도 관여하지 않는다.
+
+**이게 원하는 성질이다**: 오설정은 조용히 degraded로 뜨는 게 아니라 **아예 뜨지 않는다** →
+Railway 헬스체크(공개 경로)가 잡아내 배포가 실패한다. 볼륨 손실은 이 성질을 갖지 못한다는 점과
+대비된다(아래 잔여 위험 절).
+
+### 마커 테스트가 증명하는 범위 (과장하지 않는다)
+
+프로브는 `SQLITE_PATH`를 명시했다. 따라서 이 테스트가 증명하는 것은
+**"`DB_PROVIDER` 미설정이 경로 선택이나 기존 DB 재사용을 바꾸지 않는다"**이지,
+"기본 경로 `/data/app.db`가 올바르게 잡힌다"가 아니다. 경로는 provider와 무관하게
+언제나 `getSqlitePath()`가 정한다.
+
+## 결과
+
+- env 문자열 하나를 잃어도 서비스가 죽지 않는다
+- 오설정(`postgres` 등)은 여전히 값과 함께 즉시 드러난다
+- 테스트가 실제 파일 DB를 여는 사고는 **우연이 아니라 명시적 가드**로 막힌다
+- Railway의 `DB_PROVIDER=sqlite`는 **그대로 둔다** — 코드 기본값과 env 정리를 같은 변경에 묶지 않는다

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -4,7 +4,7 @@
 >
 > **Railway 설정 상태** 컬럼: ✅ 설정됨 / ❌ 미설정 / ➖ 해당 없음 (선택 변수)
 >
-> **아키텍처(2026-06-23 컷오버 + 2026-06-24 다중 사용자 전환):** DB는 **임베디드 SQLite**(better-sqlite3, WAL, Railway 영속 볼륨 단일 인스턴스), 인증은 **Auth.js v5 Credentials + JWT 무상태**. 공개 셀프서비스 회원가입, DB 사용자별 scrypt 인증, 이메일 인증 게이트(Resend). Supabase·온프레미스 Postgres·OAuth(Google/GitHub)·**`AUTH_PROVIDER` 다중 분기**·env 단일 관리자(`ADMIN_EMAIL`/`ADMIN_PASSWORD_HASH`/`ADMIN_USER_ID`)는 제거됨. **단, `DB_PROVIDER` 환경변수 자체는 살아 있다** — `getSqliteDb()`가 `DB_PROVIDER === 'sqlite'`일 때만 연결을 열고, 미설정·다른 값이면 throw한다(`src/lib/db/sqlite/connection.ts:36-39`). 과거 이중 스택 스위치 분기(supabase/postgres/sqlite 선택)는 제거됐고, 지금은 **필수 게이트 문자열**로만 남았다. 컷오버 배경: [docs/decisions/2026-06-23-sqlite-cutover-and-supabase-removal.md](../decisions/2026-06-23-sqlite-cutover-and-supabase-removal.md). 다중 사용자 전환: [docs/decisions/2026-06-24-public-signup-multi-user-auth.md](../decisions/2026-06-24-public-signup-multi-user-auth.md).
+> **아키텍처(2026-06-23 컷오버 + 2026-06-24 다중 사용자 전환):** DB는 **임베디드 SQLite**(better-sqlite3, WAL, Railway 영속 볼륨 단일 인스턴스), 인증은 **Auth.js v5 Credentials + JWT 무상태**. 공개 셀프서비스 회원가입, DB 사용자별 scrypt 인증, 이메일 인증 게이트(Resend). Supabase·온프레미스 Postgres·OAuth(Google/GitHub)·**`AUTH_PROVIDER` 다중 분기**·env 단일 관리자(`ADMIN_EMAIL`/`ADMIN_PASSWORD_HASH`/`ADMIN_USER_ID`)는 제거됨. **`DB_PROVIDER` 환경변수는 남아 있으나 2026-08-01부터 필수가 아니다** — 미설정이면 sqlite로 동작하고(경고 1회), `'sqlite'` 외의 값만 throw한다(`assertSqliteEnv()`). 단일 스택에서 env 문자열 하나를 잃었다고 전면 장애가 나던 것을 없앤 조치다: [ADR](../decisions/2026-08-01-db-provider-boot-gate.md). 컷오버 배경: [docs/decisions/2026-06-23-sqlite-cutover-and-supabase-removal.md](../decisions/2026-06-23-sqlite-cutover-and-supabase-removal.md). 다중 사용자 전환: [docs/decisions/2026-06-24-public-signup-multi-user-auth.md](../decisions/2026-06-24-public-signup-multi-user-auth.md).
 
 ---
 
@@ -14,7 +14,7 @@
 
 | 변수 | 기본값 | Railway | 설명 |
 |------|--------|---------|------|
-| `DB_PROVIDER` | _(없음 — 필수)_ | ✅ `sqlite` | **필수.** `getSqliteDb()` 게이트. 값이 정확히 `sqlite`가 아니면 연결 생성 시 throw: `getSqliteDb()는 DB_PROVIDER=sqlite 환경에서만 사용할 수 있습니다.` (`src/lib/db/sqlite/connection.ts:36-39`). 미설정·오타·`postgres` 등 과거 값 → **모든 DB 접근 크래시**. 과거 이중 스택 스위치용이었으나 현재는 이 문자열 검사만 남음(분기 제거 ≠ 변수 제거) |
+| `DB_PROVIDER` | `sqlite` (미설정 시 기본) | ✅ `sqlite` | **선택.** 과거 이중 스택 스위치의 잔재. **미설정·빈 문자열이면 sqlite로 동작**하고 부팅 시 경고 1회를 남긴다. `'sqlite'` 외의 값은 **throw**(오설정을 조용히 삼키지 않는다). 로직: `assertSqliteEnv()`(`src/lib/db/sqlite/connection.ts`). 명시 설정을 권장하지만 **이 변수를 잃었다고 서비스가 죽지는 않는다**(2026-08-01 이전엔 죽었다 — [ADR](../decisions/2026-08-01-db-provider-boot-gate.md)) |
 | `SQLITE_PATH` | `/data/app.db` | ➖ | SQLite DB 파일 경로. Railway 영속 볼륨 마운트 경로(`/data`)에 위치. 로컬 개발 시 별도 경로로 오버라이드 가능 |
 
 ### 자동 백업 (P6.3)

--- a/docs/superpowers/plans/2026-07-31-project-wbs.md
+++ b/docs/superpowers/plans/2026-07-31-project-wbs.md
@@ -68,7 +68,7 @@
 | C2 (선택 습관) | admin download를 **가끔** 로컬에 받는 것 — **구현 과제가 아닌 선택적 운영 습관**. 자동화·강제 스케줄 없음. 안 해도 백로그 미완이 아니다 | — | 오너 선택 |
 | C3 | `adminAuth`의 `LRUMap` 안티패턴 정리 — [SDD 4.1](../../architecture/system-spec.md)이 금지한 "활성 윈도 evict" 패턴의 유일한 예외 | S | 없음 |
 | C4 | **쪼개서 볼 것**: (a) Sentry SaaS 도입 → ❌ **제외(2026-08-01)** (유료·Slack-only 결정 유지) (b) ~~미사용 `@sentry/nextjs` 의존성 + config 3파일 **삭제 정리**~~ → ✅ **완료(2026-08-01)** — [ADR](../../decisions/2026-08-01-remove-unused-sentry-scaffolding.md) | S | — |
-| C5 | `DB_PROVIDER` 부팅 가드 — 단일 스택인데 잔존하며 **env를 잃으면 전면 장애인데 문서 근거가 없다** | S | 없음 |
+| ~~C5~~ | ~~`DB_PROVIDER` 부팅 가드~~ → ✅ **완료(2026-08-01)**. 미설정을 sqlite로 취급(경고 1회)·잘못된 값만 throw·테스트에서 `SQLITE_PATH` 강제. 단순 제거가 아닌 이유(이미지가 `/data`를 항상 만들어 테스트 안전망이 사라진다)와 수용한 잔여 위험은 [ADR](../../decisions/2026-08-01-db-provider-boot-gate.md) | — | — |
 | C6 | 인메모리 런타임 상태 8곳(단일 인스턴스 전제) — **스케일 트리거 제품 결정**. 진짜 멀티 인스턴스는 공유 상태용 **유료 인프라**가 필요하므로 “열린 인프라 작업”이 아님. 현 규모에선 무해 | L | 멀티 인스턴스 전환 **결정 시** |
 | C7 | Supabase 시대 1회성 SQL 4개 정리 | S | 없음 |
 | C8 | `countries.json` 갱신이 완전 수동 (자동 갱신·신선도 검사 없음) | S | 없음 |
@@ -121,7 +121,7 @@
 | ~~**D-e**~~ | ~~`deployment.md` Supabase·Sentry 잔재~~ → ✅ **완료(2026-08-01 문서 정리)**. 카탈로그/키 검증도 관리자 엔드포인트로 교체 | — |
 | ~~D-b~~ | ~~`development.md` Supabase 시그니처~~ → ✅ **완료(2026-08-01)**. 무인자 factory로 정정. `testing.md` 잔재는 별도 | — |
 | ~~D-c~~ | ~~플래키 followups plan의 stale quirk~~ → ✅ **해당 plan 삭제(2026-08-01)**. `failed` 즉시 terminal 실패는 코드·`CLAUDE.md` 폴링 절이 진실원 | — |
-| D-d | `AUTH_URL`·`DB_PROVIDER` env 문서화 (둘 다 `env-vars.md`에 행이 없다) | S |
+| D-d | ~~`DB_PROVIDER` env 문서화~~ → ✅ **완료(2026-08-01)** — `env-vars.md`에 행 추가 + 동작 변경([ADR](../../decisions/2026-08-01-db-provider-boot-gate.md)). **`AUTH_URL`은 아직 행 없음** — 그것만 남았다 | S |
 
 ---
 

--- a/src/lib/db/sqlite/connection.test.ts
+++ b/src/lib/db/sqlite/connection.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { eq } from 'drizzle-orm';
 import type DatabaseType from 'better-sqlite3';
+import { logger } from '@/lib/utils/logger';
 import {
   createSqliteConnection,
   runSqliteMigrations,
@@ -93,6 +94,55 @@ describe('getSqliteRawConnection', () => {
 
     const conn = getSqliteRawConnection();
     expect(conn.open).toBe(true);
+  });
+
+  // DB_PROVIDER 게이트 (WBS C5). 과거엔 미설정이면 무조건 throw라, env 문자열 하나를 잃으면
+  // 모든 DB 접근이 죽었다. 단일 스택이므로 미설정은 sqlite로 취급하되, 잘못된 값과
+  // 테스트 경로 누락은 계속 막는다.
+  it('DB_PROVIDER 미설정이어도 sqlite로 연결한다 (env 하나로 전면 장애가 나지 않는다)', () => {
+    delete process.env.DB_PROVIDER;
+    process.env.SQLITE_PATH = ':memory:';
+
+    const conn = getSqliteRawConnection();
+    expect(conn.open).toBe(true);
+  });
+
+  it('미설정으로 연결하면 경고를 남긴다 — 조용히 넘어가면 왜 기본값으로 떴는지 알 수 없다', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      delete process.env.DB_PROVIDER;
+      process.env.SQLITE_PATH = ':memory:';
+
+      getSqliteDb();
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toMatch(/DB_PROVIDER/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('DB_PROVIDER 빈 문자열도 미설정과 같게 취급한다', () => {
+    process.env.DB_PROVIDER = '';
+    process.env.SQLITE_PATH = ':memory:';
+
+    expect(getSqliteRawConnection().open).toBe(true);
+  });
+
+  it('지원하지 않는 DB_PROVIDER 값은 값을 담아 throw한다 (오설정을 삼키지 않는다)', () => {
+    process.env.DB_PROVIDER = 'postgres';
+    process.env.SQLITE_PATH = ':memory:';
+
+    expect(() => getSqliteDb()).toThrow(/postgres/);
+  });
+
+  // 이 테스트는 가드 자체와 함께 "vitest에서 NODE_ENV==='test'"라는 전제도 고정한다.
+  // 전제가 깨지면 가드가 조용히 무력화되므로 여기서 빨갛게 드러나야 한다.
+  it('테스트 환경에서 SQLITE_PATH가 없으면 throw한다 (실제 파일 DB 사고 방지)', () => {
+    expect(process.env.NODE_ENV).toBe('test');
+    delete process.env.DB_PROVIDER;
+    delete process.env.SQLITE_PATH;
+
+    expect(() => getSqliteDb()).toThrow(/SQLITE_PATH/);
   });
 
   it('foreign_keys 제약을 강제한다 (존재하지 않는 user_id)', () => {

--- a/src/lib/db/sqlite/connection.ts
+++ b/src/lib/db/sqlite/connection.ts
@@ -1,6 +1,7 @@
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { logger } from '@/lib/utils/logger';
 import * as schema from './schema';
 
 export type SqliteDb = ReturnType<typeof drizzle<typeof schema>>;
@@ -31,12 +32,52 @@ export function createSqliteConnection(path: string): { db: SqliteDb; raw: Datab
   return { db, raw };
 }
 
-/** DB_PROVIDER=sqlite 환경의 싱글톤 연결. */
+let _warnedDefaultProvider = false;
+
+/**
+ * 연결을 열기 전 환경을 검사한다.
+ *
+ * `DB_PROVIDER`는 과거 이중 스택(supabase/postgres/sqlite) 스위치의 잔재다. 단일 스택이 된
+ * 지금은 분기할 대상이 없으므로 **미설정을 장애로 취급하지 않는다** — env 문자열 하나를 잃었다고
+ * 모든 DB 접근이 죽는 것이 이 서비스의 가장 위험한 단일 지점이었다(WBS C5).
+ *
+ * - 미설정·빈 문자열 → sqlite (부팅 1회 경고)
+ * - `'sqlite'`       → 정상
+ * - 그 외 값         → throw. 오설정을 조용히 삼키면 의도와 다른 스택으로 뜬 줄 모른다
+ *
+ * 테스트 환경에서 `SQLITE_PATH`가 없으면 throw한다. 예전에는 `DB_PROVIDER`가 테스트에
+ * 설정돼 있지 않다는 **우연** 덕분에 실수로 실제 파일 DB를 여는 사고가 막혀 있었는데,
+ * 위에서 미설정을 허용하면 그 우연이 사라진다. "경로가 없어 어차피 실패한다"에는 기댈 수 없다 —
+ * 러너 이미지가 `mkdir -p /data`로 **항상 쓰기 가능한 디렉터리를 만든다**(Dockerfile).
+ */
+function assertSqliteEnv(): void {
+  const provider = process.env.DB_PROVIDER?.trim();
+
+  if (provider && provider !== 'sqlite') {
+    throw new Error(
+      `DB_PROVIDER="${provider}"는 지원하지 않습니다. 이 서비스는 SQLite 단일 스택입니다 ('sqlite' 또는 미설정).`,
+    );
+  }
+
+  if (process.env.NODE_ENV === 'test' && !process.env.SQLITE_PATH) {
+    throw new Error(
+      '테스트에서는 SQLITE_PATH를 명시해야 합니다(예: ":memory:"). ' +
+        '기본 경로로 실제 파일 DB를 여는 사고를 막습니다.',
+    );
+  }
+
+  if (!provider && !_warnedDefaultProvider) {
+    _warnedDefaultProvider = true;
+    logger.warn('DB_PROVIDER 미설정 — sqlite 기본값으로 연결합니다', {
+      sqlitePath: getSqlitePath(),
+    });
+  }
+}
+
+/** SQLite 싱글톤 연결. 환경 검사는 `assertSqliteEnv()` 참조. */
 export function getSqliteDb(): SqliteDb {
   if (_db) return _db;
-  if (process.env.DB_PROVIDER !== 'sqlite') {
-    throw new Error('getSqliteDb()는 DB_PROVIDER=sqlite 환경에서만 사용할 수 있습니다.');
-  }
+  assertSqliteEnv();
   const { db, raw } = createSqliteConnection(getSqlitePath());
   _db = db;
   _raw = raw;
@@ -71,4 +112,6 @@ export function resetSqliteConnection(): void {
     _raw = null;
   }
   _db = null;
+  // 경고 1회 플래그도 함께 되돌린다. 아니면 테스트 순서에 따라 경고 단언이 흔들린다.
+  _warnedDefaultProvider = false;
 }


### PR DESCRIPTION
## 문제

`getSqliteDb()`는 `DB_PROVIDER !== 'sqlite'`면 throw했습니다. 이중 스택 시절의 스위치인데, 컷오버로 **분기할 대상이 사라진 뒤에도 문자열 검사만** 남아 있었습니다.

이게 단일 스택에서 **가장 위험한 단일 지점**이었습니다 — 레포 팩토리 9개와 부팅 훅이 전부 이 함수를 거치고 폴백할 provider가 없으니, env 문자열 하나를 잃으면 전면 장애입니다.

게다가 문서가 **반대로** 적혀 있었습니다. `env-vars.md`는 "분기는 모두 제거됨"이라 단언했고 `.env.example`엔 언급조차 없었는데 `development.md`는 `cp .env.example .env.local`을 안내했습니다 — **문서를 따라 재구축하면 모든 DB 접근이 크래시**했습니다.

## 왜 단순 제거가 아닌가

적대적 검토가 **제 전제 하나를 무너뜨렸습니다.** "미설정을 허용해도 경로가 없어 어차피 실패한다"고 봤는데, [`Dockerfile:63`](Dockerfile#L63)이 `mkdir -p /data`로 **항상 쓰기 가능한 디렉터리를 만듭니다.** 컨테이너 안에서는 기본 경로가 조용히 열립니다.

그리고 지금까지 단위 테스트가 실수로 실제 DB를 여는 사고는 "테스트에 `DB_PROVIDER`가 없다"는 **우연** 덕에 막혀 있었습니다. 미설정을 허용하면 그 우연이 사라집니다.

→ **우연한 방어를 명시적 방어로 승격**했습니다.

## `assertSqliteEnv()`

| 조건 | 동작 |
|---|---|
| 미설정·빈 문자열 | sqlite 연결 + **경고 1회** |
| `'sqlite'` | 정상 |
| 그 외 값 | **throw** (값을 메시지에 담음) |
| `NODE_ENV==='test'` + `SQLITE_PATH` 미설정 | **throw** |

경고를 남기는 이유: 동작은 하되 **의도한 상태는 아닙니다.** 조용히 넘기면 왜 기본값으로 떴는지 알 수 없습니다.

## 검증 — `pnpm build` 통과는 증거가 못 됩니다

빌드는 DB를 열지 않습니다. 그래서 전부 실측했습니다.

| 검증 | 결과 |
|---|---|
| 단위 5분기 + `NODE_ENV==='test'` **전제 자체를 고정하는 canary** | 통과 |
| 전체 스위트 (env 둘 다 비운 셸) | **186파일 / 2296테스트** |
| standalone, `DB_PROVIDER` **미설정** | 기동 + **`checks.database: ok`** + 경고 확인 |
| 같은 DB **재부팅** | 마커 사용자 `totalUsers: 1` **보존** |
| standalone, `DB_PROVIDER=postgres` | **서버가 아예 뜨지 않음** ↓ |

공개 health는 DB를 건드리지 않으므로 증거가 되지 못합니다 — **상세 health로 DB 실접근**까지 확인했습니다.

### 잘못된 값일 때의 기전 (정확히)

health 라우트는 DB 예외를 catch해 200 `unhealthy`를 반환합니다. 그런데 실측하면 **공개 health까지 500**입니다. 라우트가 아니라 부팅이 원인입니다:

```
Failed to prepare server Error: An error occurred while loading instrumentation hook:
DB_PROVIDER="postgres"는 지원하지 않습니다...
```

`register()`가 throw하면 **Next가 서버 준비 자체에 실패**해 요청이 라우트에 도달하지 못합니다. **이게 원하는 성질입니다** — 오설정은 조용히 degraded로 뜨는 게 아니라 아예 뜨지 않아 **Railway 헬스체크가 잡아냅니다.**

## 수용한 잔여 위험 (숨기지 않음)

볼륨 미마운트 **+** `DB_PROVIDER` 미설정이 겹치면 빈 임시 DB로 뜹니다. 다만 **볼륨만 사라진 경우(env 정상)는 이전에도 막지 못했습니다** — 이미지가 `/data`를 만들기 때문입니다. 이번 변경은 조합 하나를 추가했을 뿐이고, 훨씬 흔한 단일 결함(env만 상실)을 고치는 이득이 큽니다.

> 별개로 확인된 사실도 ADR에 적었습니다: 공개 `GET /api/v1/health`는 **DB를 전혀 건드리지 않으므로** "배포 성공 + health 200"은 DB가 올바르다는 증거가 아닙니다.

Railway의 `DB_PROVIDER=sqlite`는 **그대로 둡니다** — 코드 기본값과 env 정리를 같은 변경에 묶지 않습니다. 이 배포는 정상 경로에서 **동작 무변경**입니다.

배경: [ADR](docs/decisions/2026-08-01-db-provider-boot-gate.md) · WBS C5

🤖 Generated with [Claude Code](https://claude.com/claude-code)