### PR TITLE
docs: 고아 자격증명 B0 종료 — 발견 기록은 남기고 상태만 갱신

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -147,6 +147,10 @@ for (const r of c) if (r.auth_config?.env_var)
 | `GITHUB_ORG` | **removed/unused** | 과거 GitHub 조직명. 남아 있으면 Railway 삭제 가능 |
 | `RAILWAY_TOKEN` | **removed/unused** | 과거 사용자 서비스 Railway 배포용. 남아 있으면 출처 폐기 후 삭제 가능 |
 | `MAX_DEPLOY_PER_DAY` | **removed/unused** | 과거 일일 외부 배포 한도. 무시됨 |
+| `AUTH_PROVIDER` | **removed/unused** | 과거 인증 provider 분기(`local`/`supabase`). 코드는 `NEXT_PUBLIC_AUTH_PROVIDER`만 읽는다 |
+
+> **2026-08-02 실측**: 위 변수와 Supabase 3종은 Railway에서 **전부 삭제 완료**(GitHub PAT는 출처 revoke 후).
+> `SENTRY_*`는 **애초에 설정된 적이 없다.** 재조사 불필요 — 경위: [incident-response.md](../security/incident-response.md)
 
 ---
 

--- a/docs/security/incident-response.md
+++ b/docs/security/incident-response.md
@@ -7,6 +7,8 @@
 > `GITHUB_TOKEN`(외부 deploy export 제거, 2026-08-01), Supabase `service_role` / `SUPABASE_*`(SQLite 컷오버),
 > `ADMIN_EMAIL`/`ADMIN_PASSWORD_HASH`(다중 사용자 전환).
 > **≠ 발견 시 내버려 둬도 된다**는 뜻이 아니다. 죽은 스택 키를 발견하면 아래 [고아 자격증명](#고아-자격증명orphan-credential)을 따른다.
+>
+> 위 목록은 **2026-08-02에 전부 폐기·삭제 완료**됐다(아래 사례 기록). 현재 Railway에 잔존하는 죽은 자격증명은 없다.
 
 ---
 
@@ -28,20 +30,33 @@
 
 값 자체는 이 문서에 **절대 적지 않는다.**
 
-### 프로덕션 실측 (2026-08-02)
+### 사례 기록 — 2026-08-02 (✅ 해소)
 
-SQLite 컷오버(2026-06-23) 후 약 6주, 외부 deploy 스택 제거(2026-08-01) 후에도 Railway에 다음이 **잔존**했다
-(길이 클래스만 — 원문 비기록):
+**교훈이 남아야 하므로 지운 게 아니라 상태만 갱신한다.**
 
-| 변수 | 길이/상태 클래스 | 조치 |
-|------|------------------|------|
-| `SUPABASE_SERVICE_ROLE_KEY` | **219자** (JWT형) | **출처 폐기 최우선** → 그 다음 Railway 삭제 |
-| `NEXT_PUBLIC_SUPABASE_URL` | 설정됨 | 죽은 스택 잔재 — 프로젝트 정리 후 Railway 삭제 |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | 설정됨 | 죽은 스택 잔재 — 출처 폐기 후 Railway 삭제 |
-| `GITHUB_TOKEN` | 설정됨 | **GitHub에서 revoke 후** Railway 삭제 |
-| `GITHUB_ORG` | 설정됨 | 조직명 잔재 — Railway 삭제 |
+SQLite 컷오버(2026-06-23) 후 **약 6주**, 외부 deploy 스택 제거(2026-08-01) 후에도 Railway에
+죽은 스택의 자격증명이 남아 있었다. 코드 참조는 0건이었지만 **자격증명은 코드가 아니라 사본이 있는 곳에서 산다.**
 
-오너 액션 순위: [WBS B0](../superpowers/plans/2026-07-31-project-wbs.md).
+| 변수 | 클래스 | 폐기 결과 |
+|------|--------|-----------|
+| `SUPABASE_SERVICE_ROLE_KEY` | **219자** (JWT형·RLS 우회) | Supabase **프로젝트가 이미 없음**(=키 무효) 확인 → Railway 삭제 |
+| `NEXT_PUBLIC_SUPABASE_URL` · `..._ANON_KEY` | 설정됨 | 동일 → Railway 삭제 |
+| `GITHUB_TOKEN` | 설정됨 | **GitHub에서 revoke 완료** → Railway 삭제 |
+| `GITHUB_ORG` | 설정됨 | 조직명 잔재 → Railway 삭제 |
+| `AUTH_PROVIDER` | 설정됨 | 분기 제거로 사문화(참조 3건은 전부 주석) → Railway 삭제 |
+
+Railway 변수 **67 → 61개**. 살아 있어야 하는 9개(`NEXT_PUBLIC_AUTH_PROVIDER`·`DB_PROVIDER`·
+`AUTH_URL`·`AUTH_SECRET`·`ANTHROPIC_API_KEY`·`SLACK_WEBHOOK_URL`·`RESEND_API_KEY`·
+`ENCRYPTION_KEY`·`ADMIN_API_KEY`)는 삭제 후 개별 확인했다.
+
+**이 사례에서 배울 것 3가지**
+
+1. **스택을 제거해도 자격증명은 따라 죽지 않는다.** 코드에서 `process.env` 참조가 0건이라는 것은
+   "앱이 안 쓴다"는 뜻이지 "키가 무효다"가 아니다. 스택 제거 PR의 체크리스트에 **자격증명 폐기**를 넣을 것
+2. **Supabase와 GitHub은 결론이 달랐다.** 전자는 프로젝트가 사라져 키가 자동 무효였지만,
+   후자는 **PAT가 GitHub에 그대로 살아 있어 별도 revoke가 필요**했다. "죽은 스택"이라고 뭉뚱그리지 말 것
+3. **삭제는 종료 코드가 아니라 대상 상태로 확인한다.** 첫 시도가 존재하지 않는 `--yes` 플래그로
+   6건 전부 실패했는데 종료 코드는 0이었다. **변수 개수를 다시 세어** 잡았다
 
 ---
 

--- a/docs/superpowers/plans/2026-07-31-project-wbs.md
+++ b/docs/superpowers/plans/2026-07-31-project-wbs.md
@@ -47,7 +47,7 @@
 
 | ID | 작업 | 크기 |
 |----|------|------|
-| **B0** | **Supabase/GitHub 고아 자격증명 폐기** — 2026-08-02 프로덕션 실측: Railway에 `SUPABASE_SERVICE_ROLE_KEY`(219자)·`NEXT_PUBLIC_SUPABASE_URL`·`NEXT_PUBLIC_SUPABASE_ANON_KEY`·`GITHUB_TOKEN`·`GITHUB_ORG` 잔존. SQLite 컷오버(2026-06-23) 후 ~6주. **출처에서 먼저 폐기**(Supabase 키/프로젝트·GitHub 토큰 revoke) → 그 다음 Railway 사본 삭제. Railway만 지우면 service_role JWT는 여전히 유효(RLS 우회). 값 비기록. 절차: [incident-response.md](../../security/incident-response.md) | S |
+| ~~**B0**~~ | ~~Supabase/GitHub 고아 자격증명 폐기~~ → ✅ **완료(2026-08-02)**. Supabase는 **프로젝트가 이미 없어** 키가 무효였고, **GitHub PAT는 오너가 revoke**했다. Railway 사본 6개 삭제(67→61). 사례·교훈 3가지: [incident-response.md](../../security/incident-response.md) | — |
 | ~~**B1**~~ | ~~`AUTH_URL=https://xzawed.xyz` Railway 등록~~ → ✅ **완료(2026-08-02 실측)**. Railway에 길이 18(`https://xzawed.xyz`)로 **이미 설정됨**. 문서 행은 ~~D-d~~에서 추가 | — |
 | ~~**B2**~~ | ~~`RESEND_API_KEY`·`EMAIL_FROM` 설정 여부 확인~~ → ✅ **해결(2026-07-31)**. 관측 수단(`GET /api/v1/admin/debug`의 `email.*`)을 만들어 프로덕션에서 확인한 결과 **`configured: true, fromSet: true, fromDomain: "xzawed.xyz"`** — 이메일은 정상 동작 중이고 우려했던 "신규 사용자가 제품을 못 쓰는 상태"는 아니다. 앞으로 이 항목은 Railway 콘솔 없이 엔드포인트로 상시 확인 가능 | — |
 | B3 | 키 의존 API 재활성화 — **한 줄 “24개”는 가짜 액션**. 정직 분할([developer-key ADR](../../decisions/2026-05-01-developer-key-api-reactivation.md)): **(a) 무료 키 후보(오너 ops)** data.go.kr 계열·NEIS·서울 오픈데이터·TourAPI·ECOS·KOPIS·Kakao·Unsplash Demo 등 가입·env 등록 가능 **(b) ToS 제외** TMDB(AI·ML 앱 금지)·RAWG(재배포 금지) — 플랫폼 키로 살리지 않음 **(c) 공유 플랫폼 키 부적합** OpenWeatherMap 등 free tier가 다중 사용자 프록시에 무너짐 → BYOK 또는 비활성 유지. **비용 제외가 아님** | M |
@@ -55,7 +55,7 @@
 | B5 | Unsplash Production 심사 (Demo 50건/시간 → Production 1,000건/시간) — **무료 심사**, 비용 제외 아님. 오너 ops | S |
 | ~~B6~~ | ~~`SONAR_TOKEN` 재발급~~ → ✅ **해결(2026-08-01 실측)**. `api/users/current`가 `isLoggedIn:true`(`xzawed-qYEqm@github`, Owners)를 반환한다. 감사 당시 `valid:false`였던 것은 이후 재발급됨.<br>**검증 방법 주의**: 공개 프로젝트라 `api/authentication/validate`는 **익명에도 `valid:true`**를 준다 — 토큰 유효성 판정에 쓰면 안 된다. 인증 필요 엔드포인트(`api/users/current`)로 확인할 것 | — |
 
-> ~~B2~~는 해결됨. **지금 최우선 오너 액션은 B0**(고아 자격증명 출처 폐기).
+> ~~B0~~·~~B1~~·~~B2~~ 모두 해결됨(2026-08-02). **남은 오너 액션은 B3(a)·B4·B5뿐**이고 전부 무료 키·심사다.
 
 ---
 


### PR DESCRIPTION
2026-08-02 오너 조치로 해소됐습니다.

| 대상 | 결론 |
|---|---|
| Supabase (`SERVICE_ROLE_KEY` 219자 · `URL` · `ANON_KEY`) | **프로젝트가 이미 없어** 키 무효 → Railway 사본 삭제 |
| `GITHUB_TOKEN` | **오너가 GitHub에서 revoke** → Railway 사본 삭제 |
| `GITHUB_ORG` · `AUTH_PROVIDER` | 사문화 → Railway 삭제 |

Railway 변수 **67 → 61개**. 살아 있어야 하는 9개(`NEXT_PUBLIC_AUTH_PROVIDER`·`DB_PROVIDER`·`AUTH_URL`·`AUTH_SECRET`·`ANTHROPIC_API_KEY`·`SLACK_WEBHOOK_URL`·`RESEND_API_KEY`·`ENCRYPTION_KEY`·`ADMIN_API_KEY`)는 삭제 후 개별 확인했습니다.

## 기록을 지우지 않은 이유

컷오버 후 **6주간 방치**됐다는 사실이 이 문서의 값어치입니다. 표를 지우면 "왜 이 절이 생겼는지"가 사라집니다. 상태만 ✅로 바꾸고 **교훈 3가지**를 명시했습니다.

**1. 스택을 제거해도 자격증명은 따라 죽지 않는다**
`process.env` 참조 0건은 "앱이 안 쓴다"는 뜻이지 **"키가 무효다"가 아닙니다.** 스택 제거 PR 체크리스트에 자격증명 폐기를 넣어야 합니다.

**2. Supabase와 GitHub은 결론이 달랐다**
전자는 프로젝트 소멸로 자동 무효였지만, 후자는 **PAT가 GitHub에 살아 있어 별도 revoke가 필요**했습니다. "죽은 스택"으로 뭉뚱그리면 놓칩니다.

**3. 삭제는 종료 코드가 아니라 대상 상태로 확인한다**
첫 시도가 존재하지 않는 `--yes` 플래그로 **6건 전부 실패**했는데 종료 코드는 **0**이었습니다. 변수 개수를 다시 세어 잡았습니다.

## 그 외

- **WBS B0 종료.** 남은 오너 액션은 B3(a)·B4·B5뿐이고 전부 무료 키·심사입니다
- `env-vars.md`에 `AUTH_PROVIDER` 행 추가 + 2026-08-02 실측 각주. **`SENTRY_*`는 애초에 설정된 적이 없다**는 사실도 명시해 재조사를 막았습니다
- 조건부 문구("남아 있으면")는 그대로 뒀습니다 — 다음에 또 발견될 수 있습니다

## 검증

상대 링크 **407개 전건 정상** · **시크릿 값 0건**(이름·길이 클래스만) · `src/` 무변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)