### PR TITLE
fix: HTTP 200에 숨은 공공데이터 에러를 잡는다 + 카탈로그 비활성화 수단 (사고 대응)

### DIFF
--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -50,6 +50,8 @@ curl -sS -H "Authorization: Bearer $ADMIN_API_KEY" \
 | **GET** `/api/v1/admin/qc-stats?days=7` | 기간 내 생성 수·실패 수·실성공률, 구조/모바일/렌더링 QC 평균, Stage 스킵·Quality Loop 지표, 흔한 QC 실패 항목 | 생성 품질·실패율 추이. Slack 생성 실패 경보 후 원인 파악 |
 | **GET** `/api/v1/admin/site-proxy-stats?limit=50` | 게시 사이트(익명) 프록시 프로젝트별 허용/차단. **`blockedByIp` vs `blockedByProject` 구분** | 429 민원, 한도 조정 근거 수집. 인메모리 → **재시작 시 0**. `trackedProjects: 0`이면 아직 집계 트래픽 없음([#216](https://github.com/xzawed/CustomWebService/issues/216) 트리거 미충족 — **임의로 한도 바꾸지 말 것**) |
 | **GET** `/api/v1/admin/keys-verify` | 활성·플랫폼 키 의존 API의 env 키를 **배포 런타임에서** 실호출 검증(키 값 비노출) | 키 의존 API 재활성화 직후, 401 의심. **로컬/`railway run`은 sealed env 미주입** — 배포 환경에서만 유효 |
+| **POST** `/api/v1/admin/catalog/activate` | 비활성 키 의존 API를 **라이브 키 검증 VALID 시에만** 활성화 | 키 발급·env 등록 후 카탈로그에 다시 노출. `dryRun`으로 후보 확인 가능 |
+| **POST** `/api/v1/admin/catalog/deactivate` | 지정 ID의 활성 API를 **키 검증 없이** 비활성화(`apiIds` 필수) | 장애·오시드·키 만료 API를 즉시 차단. `verificationStatus`는 보존. **생략=전부 끔 없음** |
 | **POST** `/api/v1/admin/verify-catalog` | 활성 API GET을 라이브 호출해 `verification_status` 갱신(`working/degraded→verified`, `broken→broken`, 변경 시에만 쓰기; `key_gated`/`unknown` 보존) | 카탈로그 이상 의심·시드 반영 후. **스케줄 없음 — 관리자 수동 트리거**(플래핑·무인 outbound 방지) |
 | **GET** `/api/v1/admin/catalog-dump` | 프로덕션 `api_catalog` 전체(활성·비활성) 안전 투영 + `summary.active`/`inactive` | “카탈로그가 몇 개?” **하드코딩 숫자를 믿지 말고 이 응답으로 확인**. 시드 JSON diff용 |
 | **POST** `/api/v1/admin/trigger-qc` | 특정 `projectId`에 Fast+Deep QC 재실행 | QC 디버깅. `ENABLE_RENDERING_QC` 꺼져 있으면 400 |

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1399,6 +1399,65 @@ Content-Type: application/json
 | `FORBIDDEN` | 403 | `Authorization` 헤더 누락 또는 잘못된 `ADMIN_API_KEY` |
 | `INVALID_INPUT` | 400 | 요청 본문 형식·Zod 검증 실패 |
 
+### POST /api/v1/admin/catalog/deactivate
+지정한 **활성** 카탈로그 API를 **라이브 키 검증 없이** 비활성화합니다. 업스트림 장애·키 미설정 상태에서도 문제 API를 즉시 끌 수 있어야 하므로 activate와 달리 키 검증을 하지 않습니다.
+
+> **왜 있는가:** 잘못 시드된 키리스 API·장애 업스트림·키 만료 API를 카탈로그·추천·프록시에서 빼는 쓰기 경로. `verificationStatus`는 보존해 "왜 껐는지" 증거를 남긴다.
+
+**Request:**
+```http
+POST /api/v1/admin/catalog/deactivate
+Authorization: Bearer <ADMIN_API_KEY>
+Content-Type: application/json
+```
+
+**Request Body:**
+```json
+{
+  "apiIds": ["uuid-1", "uuid-2"],
+  "dryRun": false
+}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| `apiIds` | string[] | **Y** | 대상 ID. **생략·빈 배열 불가** (실수로 전부 끄는 동작 없음) |
+| `dryRun` | boolean | N | `true`면 쓰지 않고 결과만 반환 (기본 `false`) |
+
+**동작:**
+- 대상: `apiIds`에 나열된 **활성** 행 (플랫폼 키 의존 여부·authType 무관 — 키리스도 가능)
+- 미존재 ID → `deactivated: false`, reason `존재하지 않는 API ID` (예외 없음)
+- 이미 비활성 → `deactivated: false`, reason `이미 비활성` (쓰기 없음)
+- `dryRun: true` → 쓰기 없음, reason `dryRun — 비활성화하지 않음`
+- 성공 시: `isActive=false` **만** (`verificationStatus` 미변경), `CATALOG_API_DEACTIVATED` 이벤트
+- **`verifyApiKey` 호출 없음**
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "dryRun": false,
+    "requested": 2,
+    "deactivated": 1,
+    "outcomes": [
+      {
+        "apiId": "uuid",
+        "name": "…",
+        "envVar": "API_KEY_…",
+        "deactivated": true,
+        "reason": "비활성화 완료"
+      }
+    ]
+  }
+}
+```
+
+| 에러 코드 | HTTP | 설명 |
+|-----------|------|------|
+| `FORBIDDEN` | 403 | `Authorization` 헤더 누락 또는 잘못된 `ADMIN_API_KEY` |
+| `INVALID_INPUT` | 400 | `apiIds` 누락·빈 배열·요청 본문 형식·Zod 검증 실패 |
+
 ### GET /api/v1/admin/feature-flags
 ### POST /api/v1/admin/feature-flags
 운영 킬스위치 조회·토글. env 변경(재배포) 없이 DB 값으로 생성·가입을 즉시 막을 수 있습니다. 알려진 플래그만 허용합니다(오타로 만든 행은 아무도 읽지 않아 "껐다"는 착각만 남김).

--- a/src/__tests__/api/admin-catalog-deactivate.test.ts
+++ b/src/__tests__/api/admin-catalog-deactivate.test.ts
@@ -1,0 +1,298 @@
+/**
+ * POST /api/v1/admin/catalog/deactivate — 라이브 키 검증 없이 활성 API 비활성화.
+ *
+ * 핵심 안전 속성:
+ * - apiIds 필수·비어 있으면 400
+ * - verifyApiKey를 절대 호출하지 않는다 (env 키 부재·업스트림 다운이어도 끌 수 있어야 함)
+ * - isActive만 false로, verificationStatus는 건드리지 않는다
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ApiCatalogItem } from '@/types/api';
+
+const findMany = vi.fn();
+const update = vi.fn();
+const verifyApiKey = vi.fn();
+const eventBusEmit = vi.fn();
+
+vi.mock('@/repositories/factory', () => ({
+  createCatalogRepository: vi.fn(() => ({ findMany, update })),
+}));
+
+// activate와 달리 deactivate는 keyCheck를 import하지 않는다.
+// 그래도 실수로 배선되면 실패하도록 모킹 스파이로 고정한다.
+vi.mock('@/lib/catalog/keyCheck', () => ({
+  verifyApiKey: (...args: unknown[]) => verifyApiKey(...args) as never,
+}));
+
+vi.mock('@/lib/events/eventBus', () => ({
+  eventBus: { emit: (...args: unknown[]) => eventBusEmit(...args) },
+}));
+
+const VALID_ADMIN_KEY = 'test-admin-secret-key';
+
+/** 활성 카탈로그 행 픽스처. */
+function makeActiveApi(overrides: Partial<ApiCatalogItem> = {}): ApiCatalogItem {
+  return {
+    id: 'api-active-keyed',
+    name: 'NASA APOD',
+    description: 'test',
+    category: 'science',
+    baseUrl: 'https://api.nasa.gov',
+    authType: 'api_key',
+    authConfig: { env_var: 'NASA_API_KEY', param_in: 'query', param_name: 'api_key' },
+    rateLimit: null,
+    isActive: true,
+    iconUrl: null,
+    docsUrl: null,
+    endpoints: [
+      {
+        path: '/planetary/apod',
+        method: 'GET',
+        description: 'APOD',
+        params: [],
+        responseExample: {},
+      },
+    ],
+    tags: [],
+    apiVersion: null,
+    deprecatedAt: null,
+    successorId: null,
+    corsSupported: true,
+    requiresProxy: true,
+    creditRequired: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    verificationStatus: 'broken',
+    ...overrides,
+  };
+}
+
+function makeReq(
+  key: string | null = VALID_ADMIN_KEY,
+  body?: unknown,
+  ip = '10.0.3.20',
+): Request {
+  const headers: Record<string, string> = {
+    'x-forwarded-for': ip,
+  };
+  if (key !== null) headers['Authorization'] = `Bearer ${key}`;
+
+  if (body === undefined) {
+    return new Request('http://localhost/api/v1/admin/catalog/deactivate', {
+      method: 'POST',
+      headers,
+    });
+  }
+
+  headers['Content-Type'] = 'application/json';
+  return new Request('http://localhost/api/v1/admin/catalog/deactivate', {
+    method: 'POST',
+    headers,
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+describe('POST /api/v1/admin/catalog/deactivate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env.ADMIN_API_KEY = VALID_ADMIN_KEY;
+    // env 키 없음 — 비활성화는 키와 무관해야 한다
+    delete process.env.NASA_API_KEY;
+    findMany.mockResolvedValue({ items: [], total: 0 });
+    update.mockResolvedValue(undefined);
+  });
+
+  it('Authorization 헤더 없음 → 403', async () => {
+    const { POST } = await import('@/app/api/v1/admin/catalog/deactivate/route');
+    const res = await POST(makeReq(null, { apiIds: ['api-x'] }));
+    expect(res.status).toBe(403);
+  });
+
+  it('잘못된 관리자 키 → 403', async () => {
+    const { POST } = await import('@/app/api/v1/admin/catalog/deactivate/route');
+    const res = await POST(makeReq('wrong-key', { apiIds: ['api-x'] }));
+    expect(res.status).toBe(403);
+  });
+
+  it('활성 API → isActive:false만 기록하고 verificationStatus는 건드리지 않는다', async () => {
+    const candidate = makeActiveApi({ verificationStatus: 'broken' });
+    findMany.mockResolvedValue({ items: [candidate], total: 1 });
+
+    const { POST } = await import('@/app/api/v1/admin/catalog/deactivate/route');
+    const res = await POST(makeReq(VALID_ADMIN_KEY, { apiIds: [candidate.id] }));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: {
+        deactivated: number;
+        requested: number;
+        outcomes: Array<{ apiId: string; deactivated: boolean; reason: string }>;
+      };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.requested).toBe(1);
+    expect(body.data.deactivated).toBe(1);
+    expect(body.data.outcomes[0]).toMatchObject({
+      apiId: candidate.id,
+      deactivated: true,
+    });
+    // isActive만 — verificationStatus 키 자체가 없어야 한다
+    expect(update).toHaveBeenCalledWith(candidate.id, { isActive: false });
+    expect(update.mock.calls[0]?.[1]).not.toHaveProperty('verificationStatus');
+    expect(eventBusEmit).toHaveBeenCalledWith({
+      type: 'CATALOG_API_DEACTIVATED',
+      payload: {
+        apiId: candidate.id,
+        apiName: candidate.name,
+        envVar: 'NASA_API_KEY',
+      },
+    });
+  });
+
+  it('env 키가 없어도 verifyApiKey를 호출하지 않는다', async () => {
+    const candidate = makeActiveApi();
+    findMany.mockResolvedValue({ items: [candidate], total: 1 });
+    expect(process.env.NASA_API_KEY).toBeUndefined();
+
+    const { POST } = await import('@/app/api/v1/admin/catalog/deactivate/route');
+    const res = await POST(makeReq(VALID_ADMIN_KEY, { apiIds: [candidate.id] }));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { deactivated: number } };
+    expect(body.data.deactivated).toBe(1);
+    expect(verifyApiKey).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  it('dryRun:true이면 repo.update·이벤트를 호출하지 않는다', async () => {
+    const candidate = makeActiveApi();
+    findMany.mockResolvedValue({ items: [candidate], total: 1 });
+
+    const { POST } = await import('@/app/api/v1/admin/catalog/deactivate/route');
+    const res = await POST(makeReq(VALID_ADMIN_KEY, { apiIds: [candidate.id], dryRun: true }));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        dryRun: boolean;
+        deactivated: number;
+        outcomes: Array<{ deactivated: boolean; reason: string }>;
+      };
+    };
+    expect(body.data.dryRun).toBe(true);
+    expect(body.data.deactivated).toBe(0);
+    expect(body.data.outcomes[0]?.deactivated).toBe(false);
+    expect(body.data.outcomes[0]?.reason).toMatch(/dryRun/);
+    expect(update).not.toHaveBeenCalled();
+    expect(eventBusEmit).not.toHaveBeenCalled();
+    expect(verifyApiKey).not.toHaveBeenCalled();
+  });
+
+  it('존재하지 않는 apiId는 예외 없이 outcome 행으로 보고한다', async () => {
+    findMany.mockResolvedValue({ items: [], total: 0 });
+
+    const { POST } = await import('@/app/api/v1/admin/catalog/deactivate/route');
+    const res = await POST(makeReq(VALID_ADMIN_KEY, { apiIds: ['no-such-id'] }));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        deactivated: number;
+        outcomes: Array<{ apiId: string; deactivated: boolean; reason: string }>;
+      };
+    };
+    expect(body.data.deactivated).toBe(0);
+    expect(body.data.outcomes[0]).toMatchObject({
+      apiId: 'no-such-id',
+      deactivated: false,
+    });
+    expect(body.data.outcomes[0]?.reason).toMatch(/존재하지 않/);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('이미 비활성인 API는 쓰기 없이 outcome만 반환한다', async () => {
+    const inactive = makeActiveApi({ id: 'api-inactive', isActive: false });
+    findMany.mockResolvedValue({ items: [inactive], total: 1 });
+
+    const { POST } = await import('@/app/api/v1/admin/catalog/deactivate/route');
+    const res = await POST(makeReq(VALID_ADMIN_KEY, { apiIds: [inactive.id] }));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        deactivated: number;
+        outcomes: Array<{ deactivated: boolean; reason: string }>;
+      };
+    };
+    expect(body.data.deactivated).toBe(0);
+    expect(body.data.outcomes[0]?.deactivated).toBe(false);
+    expect(body.data.outcomes[0]?.reason).toMatch(/이미 비활성/);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('키리스 활성 API도 비활성화 대상이다', async () => {
+    const keyless = makeActiveApi({
+      id: 'api-keyless',
+      name: 'Keyless API',
+      authType: 'none',
+      authConfig: {},
+      verificationStatus: 'verified',
+    });
+    findMany.mockResolvedValue({ items: [keyless], total: 1 });
+
+    const { POST } = await import('@/app/api/v1/admin/catalog/deactivate/route');
+    const res = await POST(makeReq(VALID_ADMIN_KEY, { apiIds: [keyless.id] }));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { deactivated: number; outcomes: Array<{ apiId: string; deactivated: boolean }> };
+    };
+    expect(body.data.deactivated).toBe(1);
+    expect(body.data.outcomes[0]?.apiId).toBe(keyless.id);
+    expect(update).toHaveBeenCalledWith(keyless.id, { isActive: false });
+  });
+
+  it('apiIds 생략·빈 배열은 400 ValidationError', async () => {
+    const { POST } = await import('@/app/api/v1/admin/catalog/deactivate/route');
+
+    const missing = await POST(makeReq(VALID_ADMIN_KEY, {}));
+    expect(missing.status).toBe(400);
+    const missingBody = (await missing.json()) as { success: boolean; error: { code: string } };
+    expect(missingBody.success).toBe(false);
+    expect(missingBody.error.code).toBe('INVALID_INPUT');
+
+    const empty = await POST(makeReq(VALID_ADMIN_KEY, { apiIds: [] }, '10.0.3.21'));
+    expect(empty.status).toBe(400);
+    const emptyBody = (await empty.json()) as { error: { code: string } };
+    expect(emptyBody.error.code).toBe('INVALID_INPUT');
+
+    expect(findMany).not.toHaveBeenCalled();
+    expect(verifyApiKey).not.toHaveBeenCalled();
+  });
+
+  it('OPTIONS 프리플라이트는 204 + 관리자 CORS 헤더를 반환한다', async () => {
+    const { OPTIONS } = await import('@/app/api/v1/admin/catalog/deactivate/route');
+    const res = await OPTIONS();
+    expect(res.status).toBe(204);
+    expect(res.headers.get('Access-Control-Allow-Methods')).toContain('POST');
+    expect(res.headers.get('Access-Control-Allow-Headers')).toContain('Authorization');
+  });
+
+  it('잘못된 JSON 본문은 검증 오류(4xx)를 반환하고 500이 아니다', async () => {
+    const { POST } = await import('@/app/api/v1/admin/catalog/deactivate/route');
+    const res = await POST(makeReq(VALID_ADMIN_KEY, '{', '10.0.3.77'));
+
+    expect(res.status).not.toBe(500);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      success: boolean;
+      error: { code: string; message: string };
+    };
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('INVALID_INPUT');
+    expect(findMany).not.toHaveBeenCalled();
+    expect(verifyApiKey).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/v1/admin/catalog/deactivate/route.ts
+++ b/src/app/api/v1/admin/catalog/deactivate/route.ts
@@ -1,0 +1,122 @@
+import { createCatalogRepository } from '@/repositories/factory';
+import { adminCorsHeaders, verifyAdminKey, withAdminCors } from '@/lib/utils/adminAuth';
+import { handleApiError, jsonResponse, ValidationError } from '@/lib/utils/errors';
+import { deactivateCatalogSchema } from '@/types/schemas';
+import { eventBus } from '@/lib/events/eventBus';
+import { logger } from '@/lib/utils/logger';
+
+// 배포 런타임에서 실행 (activate와 동일 — nodejs runtime 고정).
+export const runtime = 'nodejs';
+
+interface DeactivateOutcome {
+  apiId: string;
+  name: string;
+  envVar: string;
+  deactivated: boolean;
+  reason: string;
+}
+
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, { status: 204, headers: adminCorsHeaders });
+}
+
+/**
+ * POST /api/v1/admin/catalog/deactivate
+ *
+ * 지정한 활성 카탈로그 API를 **라이브 키 검증 없이** 비활성화한다.
+ * 업스트림 장애·키 미설정 상태에서도 오너가 잘못 시드된·문제가 된 API를 즉시 끌 수 있어야 한다.
+ *
+ * activate와 대칭이되 다음이 다르다:
+ * - `apiIds` 필수·비어 있으면 400 (omit=전부 끔 미구현 — 실수 방지)
+ * - 플랫폼 키 의존 여부와 무관 — 키리스 활성 API도 대상
+ * - `isActive: false`만 기록. `verificationStatus`는 건드리지 않음 (왜 껐는지 증거 보존)
+ *
+ * body: `{ apiIds: string[], dryRun?: boolean }`
+ */
+export async function POST(request: Request): Promise<Response> {
+  const res = await (async () => {
+    try {
+      verifyAdminKey(request);
+
+      let body: unknown = {};
+      try {
+        const text = await request.text();
+        if (text.trim()) body = JSON.parse(text);
+      } catch {
+        throw new ValidationError('잘못된 요청 형식입니다.');
+      }
+      const { apiIds, dryRun = false } = deactivateCatalogSchema.parse(body);
+
+      const repo = createCatalogRepository();
+      const { items } = await repo.findMany({}, { limit: 200, orderBy: 'name', orderDirection: 'asc' });
+      const byId = new Map(items.map((a) => [a.id, a]));
+
+      const outcomes: DeactivateOutcome[] = [];
+      for (const apiId of apiIds) {
+        const a = byId.get(apiId);
+        if (!a) {
+          outcomes.push({
+            apiId,
+            name: '(unknown)',
+            envVar: '(none)',
+            deactivated: false,
+            reason: '존재하지 않는 API ID',
+          });
+          continue;
+        }
+
+        const envVar = (a.authConfig?.env_var as string | undefined) ?? '(none)';
+
+        if (!a.isActive) {
+          outcomes.push({
+            apiId: a.id,
+            name: a.name,
+            envVar,
+            deactivated: false,
+            reason: '이미 비활성',
+          });
+          continue;
+        }
+
+        if (dryRun) {
+          outcomes.push({
+            apiId: a.id,
+            name: a.name,
+            envVar,
+            deactivated: false,
+            reason: 'dryRun — 비활성화하지 않음',
+          });
+          continue;
+        }
+
+        // verificationStatus는 보존 — 끈 이유(broken 등)를 남겨 둔다.
+        await repo.update(a.id, { isActive: false });
+        logger.warn('Catalog API deactivated by admin', { apiId: a.id, name: a.name, envVar });
+        eventBus.emit({
+          type: 'CATALOG_API_DEACTIVATED',
+          payload: { apiId: a.id, apiName: a.name, envVar },
+        });
+        outcomes.push({
+          apiId: a.id,
+          name: a.name,
+          envVar,
+          deactivated: true,
+          reason: '비활성화 완료',
+        });
+      }
+
+      return jsonResponse({
+        success: true,
+        data: {
+          dryRun,
+          requested: apiIds.length,
+          deactivated: outcomes.filter((o) => o.deactivated).length,
+          outcomes,
+        },
+      });
+    } catch (error) {
+      return handleApiError(error);
+    }
+  })();
+  return withAdminCors(res);
+}

--- a/src/lib/catalog/healthCheck.test.ts
+++ b/src/lib/catalog/healthCheck.test.ts
@@ -214,6 +214,187 @@ describe('looksLikeErrorBody', () => {
     expect(looksLikeErrorBody('{"success":false}')).toBe(true);
     expect(looksLikeErrorBody('{"errors":[{"message":"bad"}]}')).toBe(true);
   });
+
+  // ── 분기 커버: 엔벨로프 불일치·경계 (CI codecov/patch) ───────────────────
+  it('파싱 불가 JSON({로 시작)은 throw 없이 폴스루한다', () => {
+    // looksLikeJson true → JSON.parse 실패 → 엔벨로프 null → REST false
+    expect(looksLikeErrorBody('{not-valid-json')).toBe(false);
+  });
+
+  it('JSON 배열 본문은 엔벨로프가 아니다', () => {
+    expect(looksLikeErrorBody('[1,2]')).toBe(false);
+  });
+
+  it('response만 있고 header가 없거나 객체가 아니면 엔벨로프 불일치', () => {
+    expect(looksLikeErrorBody(JSON.stringify({ response: { body: {} } }))).toBe(false);
+    expect(looksLikeErrorBody(JSON.stringify({ response: { header: null } }))).toBe(false);
+    expect(looksLikeErrorBody(JSON.stringify({ response: { header: 'x' } }))).toBe(false);
+    expect(looksLikeErrorBody(JSON.stringify({ response: { header: [] } }))).toBe(false);
+    expect(looksLikeErrorBody(JSON.stringify({ response: null }))).toBe(false);
+    expect(looksLikeErrorBody(JSON.stringify({ response: 'x' }))).toBe(false);
+  });
+
+  it('header.resultCode가 string/number가 아니면 엔벨로프로 보지 않는다', () => {
+    expect(
+      looksLikeErrorBody(
+        JSON.stringify({ response: { header: { resultCode: { nested: true } } } }),
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeErrorBody(JSON.stringify({ response: { header: { resultCode: null } } })),
+    ).toBe(false);
+    expect(
+      looksLikeErrorBody(JSON.stringify({ response: { header: { resultCode: ['01'] } } })),
+    ).toBe(false);
+    // 숫자 코드는 허용 — 허용목록 밖이면 에러
+    expect(
+      looksLikeErrorBody(JSON.stringify({ response: { header: { resultCode: 99 } } })),
+    ).toBe(true);
+    expect(
+      looksLikeErrorBody(JSON.stringify({ response: { header: { resultCode: 0 } } })),
+    ).toBe(true); // "0"은 허용목록에 없음 (00만 허용)
+  });
+
+  it('Shape A′ resultMsg가 빈 문자열·공백·비문자열이면 가드에 걸린다', () => {
+    expect(
+      looksLikeErrorBody(JSON.stringify({ header: { resultCode: '01', resultMsg: '' } })),
+    ).toBe(false);
+    expect(
+      looksLikeErrorBody(JSON.stringify({ header: { resultCode: '01', resultMsg: '   ' } })),
+    ).toBe(false);
+    expect(
+      looksLikeErrorBody(JSON.stringify({ header: { resultCode: '01', resultMsg: 123 } })),
+    ).toBe(false);
+    expect(looksLikeErrorBody(JSON.stringify({ header: null }))).toBe(false);
+    expect(looksLikeErrorBody(JSON.stringify({ header: 'x' }))).toBe(false);
+  });
+
+  it('Shape B: cmmMsgHeader만 있고 코드·errMsg 없으면 fail-closed true', () => {
+    expect(
+      looksLikeErrorBody(
+        JSON.stringify({ OpenAPI_ServiceResponse: { cmmMsgHeader: {} } }),
+      ),
+    ).toBe(true);
+  });
+
+  it('Shape B: errMsg가 빈 문자열이어도 fail-closed true', () => {
+    expect(
+      looksLikeErrorBody(
+        JSON.stringify({
+          OpenAPI_ServiceResponse: { cmmMsgHeader: { errMsg: '' } },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeErrorBody(
+        JSON.stringify({
+          OpenAPI_ServiceResponse: { cmmMsgHeader: { errMsg: '   ' } },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('Shape B: OpenAPI_ServiceResponse만 있고 cmmMsgHeader 없으면 엔벨로프 불일치', () => {
+    expect(
+      looksLikeErrorBody(JSON.stringify({ OpenAPI_ServiceResponse: { other: true } })),
+    ).toBe(false);
+    expect(
+      looksLikeErrorBody(JSON.stringify({ OpenAPI_ServiceResponse: null })),
+    ).toBe(false);
+    expect(
+      looksLikeErrorBody(JSON.stringify({ OpenAPI_ServiceResponse: 'x' })),
+    ).toBe(false);
+  });
+
+  it('Shape B: returnReasonCode 숫자 타입도 판정한다', () => {
+    expect(
+      looksLikeErrorBody(
+        JSON.stringify({
+          OpenAPI_ServiceResponse: { cmmMsgHeader: { returnReasonCode: 12 } },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeErrorBody(
+        JSON.stringify({
+          OpenAPI_ServiceResponse: { cmmMsgHeader: { returnReasonCode: 0 } },
+        }),
+      ),
+    ).toBe(true); // "0" ≠ "00"
+  });
+
+  it('XML: <response>에 <header> 없으면 엔벨로프 불일치', () => {
+    expect(looksLikeErrorBody('<response><body/></response>')).toBe(false);
+  });
+
+  it('XML: <header>에 <resultCode> 없으면 엔벨로프 불일치', () => {
+    expect(
+      looksLikeErrorBody('<response><header><resultMsg>X</resultMsg></header></response>'),
+    ).toBe(false);
+  });
+
+  it('XML: 닫히지 않은 태그는 extract 실패로 불일치', () => {
+    expect(looksLikeErrorBody('<header><resultCode>01</resultCode>')).toBe(false);
+    expect(
+      looksLikeErrorBody('<response><header><resultCode>01</resultCode></header>'),
+    ).toBe(false);
+  });
+
+  it('XML Shape A′: resultMsg 없으면 엄격 가드로 false', () => {
+    expect(
+      looksLikeErrorBody('<header><resultCode>01</resultCode></header>'),
+    ).toBe(false);
+    expect(
+      looksLikeErrorBody(
+        '<header><resultCode>01</resultCode><resultMsg></resultMsg></header>',
+      ),
+    ).toBe(false);
+  });
+
+  it('XML Shape A′: 허용 코드는 false', () => {
+    expect(
+      looksLikeErrorBody(
+        '<header><resultCode>00</resultCode><resultMsg>OK</resultMsg></header>',
+      ),
+    ).toBe(false);
+  });
+
+  it('XML Shape B: cmmMsgHeader만 있으면 fail-closed true', () => {
+    expect(
+      looksLikeErrorBody(
+        '<OpenAPI_ServiceResponse><cmmMsgHeader></cmmMsgHeader></OpenAPI_ServiceResponse>',
+      ),
+    ).toBe(true);
+  });
+
+  it('XML Shape B: 허용 returnReasonCode는 false', () => {
+    expect(
+      looksLikeErrorBody(
+        '<OpenAPI_ServiceResponse><cmmMsgHeader><returnReasonCode>00</returnReasonCode></cmmMsgHeader></OpenAPI_ServiceResponse>',
+      ),
+    ).toBe(false);
+  });
+
+  it('XML Shape B: OpenAPI_ServiceResponse만 있고 cmmMsgHeader 없으면 불일치', () => {
+    expect(
+      looksLikeErrorBody('<OpenAPI_ServiceResponse><other/></OpenAPI_ServiceResponse>'),
+    ).toBe(false);
+  });
+
+  it('JSON 허용 코드(false) 판정은 null이 아니므로 유지된다', () => {
+    // ?? 연산: false는 XML 폴스루 대상이 아님. 허용 코드 → false 그대로.
+    expect(
+      looksLikeErrorBody(
+        JSON.stringify({ response: { header: { resultCode: '00', resultMsg: 'NORMAL_SERVICE' } } }),
+      ),
+    ).toBe(false);
+    // 동시에 XML 성공 본문도 false (별도 경로, 동일 허용목록)
+    expect(
+      looksLikeErrorBody(
+        '<response><header><resultCode>000</resultCode><resultMsg>OK</resultMsg></header></response>',
+      ),
+    ).toBe(false);
+  });
 });
 
 describe('classifyResponse', () => {

--- a/src/lib/catalog/healthCheck.test.ts
+++ b/src/lib/catalog/healthCheck.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import {
   classifyResponse,
+  looksLikeErrorBody,
   summarizeApi,
   buildTestUrl,
   toVerificationStatus,
   SLOW_THRESHOLD_MS,
   type HealthStatus,
 } from './healthCheck';
+import { classifyKeyResponse } from './keyCheck';
 
 const base = {
   authType: 'none' as const,
@@ -15,6 +17,204 @@ const base = {
   bodyText: '{"results":[1,2,3]}',
   elapsedMs: 120,
 };
+
+describe('looksLikeErrorBody', () => {
+  // ── Shape A: response.header.resultCode ──────────────────────────────────
+  it('Shape A JSON 성공 코드(00)는 에러가 아니다', () => {
+    expect(
+      looksLikeErrorBody(
+        JSON.stringify({ response: { header: { resultCode: '00', resultMsg: 'NORMAL_SERVICE' } } }),
+      ),
+    ).toBe(false);
+  });
+
+  it('Shape A JSON 성공 코드(0000 / INFO-000)는 에러가 아니다', () => {
+    expect(
+      looksLikeErrorBody(JSON.stringify({ response: { header: { resultCode: '0000' } } })),
+    ).toBe(false);
+    expect(
+      looksLikeErrorBody(JSON.stringify({ response: { header: { resultCode: 'INFO-000' } } })),
+    ).toBe(false);
+  });
+
+  it('Shape A JSON 에러 코드(01)는 에러다', () => {
+    expect(
+      looksLikeErrorBody(
+        JSON.stringify({
+          response: { header: { resultCode: '01', resultMsg: 'APPLICATION_ERROR' } },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('Shape A JSON 미지 코드는 fail-closed로 에러다', () => {
+    expect(
+      looksLikeErrorBody(JSON.stringify({ response: { header: { resultCode: '99' } } })),
+    ).toBe(true);
+  });
+
+  it('Shape A XML 성공(00)은 에러가 아니고 에러 코드는 에러다', () => {
+    expect(
+      looksLikeErrorBody(
+        '<response><header><resultCode>00</resultCode><resultMsg>NORMAL_SERVICE</resultMsg></header><body/></response>',
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeErrorBody(
+        '<response><header><resultCode>30</resultCode><resultMsg>SERVICE_KEY_IS_NOT_REGISTERED_ERROR</resultMsg></header></response>',
+      ),
+    ).toBe(true);
+  });
+
+  // ── 허용 코드: 03 NO_DATA, 22 LIMIT_EXCEEDED ─────────────────────────────
+  it('resultCode 03(NO_DATA)은 에러가 아니다 (인증 성공·조회 결과 없음)', () => {
+    expect(
+      looksLikeErrorBody(JSON.stringify({ response: { header: { resultCode: '03' } } })),
+    ).toBe(false);
+  });
+
+  it('resultCode 22(LIMIT_EXCEEDED)는 에러가 아니다 (429는 별도 분류)', () => {
+    expect(
+      looksLikeErrorBody(JSON.stringify({ response: { header: { resultCode: '22' } } })),
+    ).toBe(false);
+  });
+
+  // ── Shape B: OpenAPI_ServiceResponse.cmmMsgHeader ────────────────────────
+  it('Shape B JSON returnReasonCode 에러는 에러다', () => {
+    expect(
+      looksLikeErrorBody(
+        JSON.stringify({
+          OpenAPI_ServiceResponse: {
+            cmmMsgHeader: { returnReasonCode: '30', errMsg: 'SERVICE ERROR' },
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('Shape B JSON 허용 코드(00)는 에러가 아니다', () => {
+    expect(
+      looksLikeErrorBody(
+        JSON.stringify({
+          OpenAPI_ServiceResponse: { cmmMsgHeader: { returnReasonCode: '00' } },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('Shape B XML returnReasonCode 에러는 에러다', () => {
+    expect(
+      looksLikeErrorBody(
+        '<OpenAPI_ServiceResponse><cmmMsgHeader><returnReasonCode>30</returnReasonCode><errMsg>SERVICE ERROR</errMsg></cmmMsgHeader></OpenAPI_ServiceResponse>',
+      ),
+    ).toBe(true);
+  });
+
+  it('Shape B XML errMsg만 있어도 인식된 엔벨로프면 에러다', () => {
+    expect(
+      looksLikeErrorBody(
+        '<OpenAPI_ServiceResponse><cmmMsgHeader><errMsg>SERVICE ERROR</errMsg></cmmMsgHeader></OpenAPI_ServiceResponse>',
+      ),
+    ).toBe(true);
+  });
+
+  // ── Shape A′: 최상위 header.resultCode + resultMsg (response 래퍼 없음) ──
+  it('Shape A′ JSON 에러 코드(01)는 에러다', () => {
+    expect(
+      looksLikeErrorBody(
+        JSON.stringify({ header: { resultCode: '01', resultMsg: 'APPLICATION_ERROR' } }),
+      ),
+    ).toBe(true);
+  });
+
+  it('Shape A′ XML 에러 코드는 에러다', () => {
+    expect(
+      looksLikeErrorBody(
+        '<header><resultCode>01</resultCode><resultMsg>APPLICATION_ERROR</resultMsg></header>',
+      ),
+    ).toBe(true);
+  });
+
+  // ── 실측 본문 픽스처 (2026-08-05 라이브 캡처) ────────────────────────────
+  it('실측 본문: 기상청 단기예보 APPLICATION_ERROR(01)은 에러로 잡는다', () => {
+    // 기상청 단기예보 — bad params, HTTP 200, response 래퍼 없음
+    expect(
+      looksLikeErrorBody('{"header":{"resultCode":"01","resultMsg":"APPLICATION_ERROR"}}'),
+    ).toBe(true);
+  });
+
+  it('실측 본문: 기상청 중기예보 DB_ERROR(02)은 에러로 잡는다', () => {
+    expect(
+      looksLikeErrorBody('{"header":{"resultCode":"02","resultMsg":"DB_ERROR"}}'),
+    ).toBe(true);
+  });
+
+  it('실측 본문: 에어코리아 INVALID_REQUEST_PARAMETER_ERROR(10)은 에러로 잡는다', () => {
+    expect(
+      looksLikeErrorBody(
+        '{"header":{"resultCode":"10","resultMsg":"INVALID_REQUEST_PARAMETER_ERROR"}}',
+      ),
+    ).toBe(true);
+  });
+
+  it('실측 본문: NO_DATA(03) response 래핑은 에러가 아니다', () => {
+    expect(
+      looksLikeErrorBody(
+        '{"response":{"header":{"resultCode":"03","resultMsg":"NO_DATA"}}}',
+      ),
+    ).toBe(false);
+  });
+
+  it('실측 본문: 국토부 전월세 XML 000+빈 items는 에러가 아니다 (성공·빈 결과)', () => {
+    // 국토부 전월세 — resultCode 000 허용목록, totalCount 0. codegen 유용성 문제는 Part 3.
+    expect(
+      looksLikeErrorBody(
+        '<response><header><resultCode>000</resultCode><resultMsg>OK</resultMsg></header><body><items/><totalCount>0</totalCount></body></response>',
+      ),
+    ).toBe(false);
+  });
+
+  it('실측 본문: 게이트웨이 OpenAPI_ServiceResponse returnReasonCode 12는 에러다', () => {
+    expect(
+      looksLikeErrorBody(
+        '{"OpenAPI_ServiceResponse":{"cmmMsgHeader":{"errMsg":"SERVICE ERROR","returnReasonCode":"12"}}}',
+      ),
+    ).toBe(true);
+  });
+
+  // ── 오탐 가드 ────────────────────────────────────────────────────────────
+  it('최상위 bare resultCode는 엔벨로프가 아니므로 에러로 보지 않는다', () => {
+    expect(looksLikeErrorBody('{"resultCode":"01"}')).toBe(false);
+  });
+
+  it('Shape A′ 가드: 최상위 header에 resultCode만 있고 resultMsg 없으면 false', () => {
+    expect(looksLikeErrorBody('{"header":{"resultCode":"01"}}')).toBe(false);
+  });
+
+  it('Shape A′ 가드: 관련 없는 최상위 header(title)는 false', () => {
+    expect(looksLikeErrorBody('{"header":{"title":"x"}}')).toBe(false);
+  });
+
+  it('기존 REST 성공 형태는 회귀 없이 false', () => {
+    expect(looksLikeErrorBody('{"result":"success"}')).toBe(false);
+    expect(looksLikeErrorBody('{"status":"success"}')).toBe(false);
+    expect(looksLikeErrorBody('{"error":false}')).toBe(false);
+    expect(looksLikeErrorBody('{"response":{}}')).toBe(false);
+  });
+
+  it('관련 없는 XML(마커 없음)은 false', () => {
+    expect(looksLikeErrorBody('<root><item>ok</item></root>')).toBe(false);
+  });
+
+  it('deprecation 텍스트는 여전히 에러다', () => {
+    expect(looksLikeErrorBody('This API version has been deprecated.')).toBe(true);
+  });
+
+  it('기존 REST 휴리스틱(success:false / errors[])은 유지된다', () => {
+    expect(looksLikeErrorBody('{"success":false}')).toBe(true);
+    expect(looksLikeErrorBody('{"errors":[{"message":"bad"}]}')).toBe(true);
+  });
+});
 
 describe('classifyResponse', () => {
   it('treats a valid 2xx JSON body as working', () => {
@@ -116,6 +316,50 @@ describe('classifyResponse', () => {
   it('classifies an unexpected 4xx (likely test-param mismatch) as unknown, not broken', () => {
     expect(classifyResponse({ ...base, httpStatus: 404, bodyText: 'Not Found' }).status).toBe('unknown');
   });
+
+  it('HTTP 200 + Shape A 에러 엔벨로프 → broken', () => {
+    expect(
+      classifyResponse({
+        ...base,
+        bodyText: JSON.stringify({
+          response: { header: { resultCode: '30', resultMsg: 'SERVICE_KEY_IS_NOT_REGISTERED_ERROR' } },
+        }),
+      }).status,
+    ).toBe('broken');
+  });
+
+  it('HTTP 200 + 실측 최상위 header APPLICATION_ERROR(01) → broken', () => {
+    expect(
+      classifyResponse({
+        ...base,
+        bodyText: '{"header":{"resultCode":"01","resultMsg":"APPLICATION_ERROR"}}',
+      }).status,
+    ).toBe('broken');
+  });
+});
+
+describe('classifyKeyResponse + data.go.kr 엔벨로프', () => {
+  it('HTTP 200 + Shape A 에러 엔벨로프 → INVALID', () => {
+    const body = JSON.stringify({
+      response: { header: { resultCode: '30', resultMsg: 'SERVICE_KEY_IS_NOT_REGISTERED_ERROR' } },
+    });
+    expect(classifyKeyResponse(200, body, false).verdict).toBe('INVALID');
+  });
+
+  it('HTTP 200 + Shape A NO_DATA(03) → VALID (키는 통과)', () => {
+    const body = JSON.stringify({ response: { header: { resultCode: '03' } } });
+    expect(classifyKeyResponse(200, body, false).verdict).toBe('VALID');
+  });
+
+  it('HTTP 200 + 실측 최상위 header APPLICATION_ERROR(01) → INVALID', () => {
+    expect(
+      classifyKeyResponse(
+        200,
+        '{"header":{"resultCode":"01","resultMsg":"APPLICATION_ERROR"}}',
+        false,
+      ).verdict,
+    ).toBe('INVALID');
+  });
 });
 
 describe('summarizeApi', () => {
@@ -189,5 +433,23 @@ describe('buildTestUrl', () => {
     });
     expect(url).toContain('latitude=37.5665');
     expect(url).toContain('longitude=126.9780');
+  });
+
+  it('공공데이터 공통 페이징/포맷 파라미터에 안전한 샘플을 채운다', () => {
+    const url = buildTestUrl('https://apis.data.go.kr/example', {
+      path: '/getItems',
+      parameters: {
+        pageNo: 'string',
+        numOfRows: 'string',
+        dataType: 'string',
+        MobileOS: 'string',
+        MobileApp: 'string',
+      },
+    });
+    expect(url).toContain('pageNo=1');
+    expect(url).toContain('numOfRows=1');
+    expect(url).toContain('dataType=JSON');
+    expect(url).toContain('MobileOS=ETC');
+    expect(url).toContain('MobileApp=CustomWebService');
   });
 });

--- a/src/lib/catalog/healthCheck.ts
+++ b/src/lib/catalog/healthCheck.ts
@@ -37,12 +37,173 @@ function looksLikeJson(bodyText: string): boolean {
   return t.startsWith('{') || t.startsWith('[');
 }
 
+/**
+ * data.go.kr 공공데이터 포털 성공/허용 코드.
+ * - 00 / 000 / 0000 / INFO-000: 정상
+ * - 03: NO_DATA — 인증은 성공, 조회 결과만 없음 (키 INVALID로 오판하지 않음)
+ * - 22: LIMIT_EXCEEDED — HTTP 429가 별도 RATE_LIMITED로 매핑되므로 본문만으로는 에러 아님
+ */
+const DATA_GO_KR_ALLOWLIST = new Set(['00', '000', '0000', 'INFO-000', '03', '22']);
+
+function isDataGoKrAllowlisted(code: string): boolean {
+  return DATA_GO_KR_ALLOWLIST.has(code.trim());
+}
+
+/**
+ * XML 태그 본문 추출 (정규식 미사용 — ReDoS 회피).
+ * 단순 `<tag>…</tag>` 형태만 지원 (속성·네임스페이스 접두사 없음 전제).
+ */
+function extractTagContent(xml: string, tagName: string): string | null {
+  const open = `<${tagName}>`;
+  const close = `</${tagName}>`;
+  const start = xml.indexOf(open);
+  if (start === -1) return null;
+  const contentStart = start + open.length;
+  const end = xml.indexOf(close, contentStart);
+  if (end === -1) return null;
+  return xml.slice(contentStart, end).trim();
+}
+
+/**
+ * header 객체가 data.go.kr resultCode 엔벨로프인지 판정.
+ * @param requireResultMsg true면 resultMsg도 필수 (최상위 bare header 오탐 방지)
+ * @returns true=에러, false=허용, null=필드 부족으로 불일치
+ */
+function classifyHeaderResultCode(
+  header: Record<string, unknown>,
+  requireResultMsg: boolean,
+): boolean | null {
+  const resultCode = header.resultCode;
+  if (typeof resultCode !== 'string' && typeof resultCode !== 'number') return null;
+  if (requireResultMsg) {
+    const resultMsg = header.resultMsg;
+    if (typeof resultMsg !== 'string' || resultMsg.trim() === '') return null;
+  }
+  return !isDataGoKrAllowlisted(String(resultCode));
+}
+
+/**
+ * data.go.kr 에러 엔벨로프 판정.
+ * @returns true=에러, false=허용(성공/NO_DATA/LIMIT), null=엔벨로프 불일치(REST 휴리스틱으로 폴스루)
+ *
+ * Shape A:  response.header.resultCode (JSON) / <response><header><resultCode> (XML)
+ * Shape A′: 최상위 header.resultCode + resultMsg (JSON) / 최상위 <header>… (XML)
+ *           — 기상청·에어코리아 에러가 response 래퍼 없이 header만 돌린다 (2026-08-05 실측)
+ * Shape B:  OpenAPI_ServiceResponse.cmmMsgHeader.returnReasonCode|errMsg (JSON/XML)
+ *
+ * 순서: A(래핑) → A′(비래핑) → B. 둘 다 있으면 래핑이 우선.
+ * bare top-level resultCode(header 없음)는 인식하지 않는다.
+ */
+function classifyDataGoKrEnvelope(bodyText: string): boolean | null {
+  // ── JSON 경로 ──────────────────────────────────────────────────────────────
+  if (looksLikeJson(bodyText)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(bodyText);
+    } catch {
+      parsed = null;
+    }
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const obj = parsed as Record<string, unknown>;
+
+      // Shape A: response.header.resultCode (resultMsg 불필요 — 중첩이 이미 식별력 있음)
+      const response = obj.response;
+      if (response !== null && typeof response === 'object' && !Array.isArray(response)) {
+        const header = (response as Record<string, unknown>).header;
+        if (header !== null && typeof header === 'object' && !Array.isArray(header)) {
+          const verdict = classifyHeaderResultCode(header as Record<string, unknown>, false);
+          if (verdict !== null) return verdict;
+        }
+      }
+
+      // Shape A′: 최상위 header.resultCode + resultMsg (둘 다 필수 — 오탐 가드)
+      const topHeader = obj.header;
+      if (topHeader !== null && typeof topHeader === 'object' && !Array.isArray(topHeader)) {
+        const verdict = classifyHeaderResultCode(topHeader as Record<string, unknown>, true);
+        if (verdict !== null) return verdict;
+      }
+
+      // Shape B: OpenAPI_ServiceResponse.cmmMsgHeader.returnReasonCode / errMsg
+      const svc = obj.OpenAPI_ServiceResponse;
+      if (svc !== null && typeof svc === 'object' && !Array.isArray(svc)) {
+        const cmm = (svc as Record<string, unknown>).cmmMsgHeader;
+        if (cmm !== null && typeof cmm === 'object' && !Array.isArray(cmm)) {
+          const cmmObj = cmm as Record<string, unknown>;
+          const reason = cmmObj.returnReasonCode;
+          if (typeof reason === 'string' || typeof reason === 'number') {
+            return !isDataGoKrAllowlisted(String(reason));
+          }
+          // 코드 없이 errMsg만 있으면 인식된 엔벨로프 → fail-closed
+          if (typeof cmmObj.errMsg === 'string' && cmmObj.errMsg.trim() !== '') {
+            return true;
+          }
+          // 엔벨로프 마커는 있으나 판정 필드 없음 → fail-closed
+          return true;
+        }
+      }
+    }
+  }
+
+  // ── XML 경로 (비-JSON early return 이전에 수행) ─────────────────────────────
+  // Shape A: <response>…<header>…<resultCode>…</resultCode>
+  const responseXml = extractTagContent(bodyText, 'response');
+  if (responseXml !== null) {
+    const headerXml = extractTagContent(responseXml, 'header');
+    if (headerXml !== null) {
+      const resultCode = extractTagContent(headerXml, 'resultCode');
+      if (resultCode !== null) {
+        return !isDataGoKrAllowlisted(resultCode);
+      }
+    }
+  }
+
+  // Shape A′: 최상위 <header>… (response 래퍼 없음). resultCode + resultMsg 둘 다 필수.
+  // response 래퍼가 이미 resultCode로 판정됐으면 위에서 반환했으므로 여기까지 오지 않는다.
+  // response 없이 header만 있거나, response에 resultCode가 없을 때만 도달.
+  if (responseXml === null) {
+    const topHeaderXml = extractTagContent(bodyText, 'header');
+    if (topHeaderXml !== null) {
+      const resultCode = extractTagContent(topHeaderXml, 'resultCode');
+      const resultMsg = extractTagContent(topHeaderXml, 'resultMsg');
+      if (resultCode !== null && resultMsg !== null && resultMsg !== '') {
+        return !isDataGoKrAllowlisted(resultCode);
+      }
+    }
+  }
+
+  // Shape B: <OpenAPI_ServiceResponse>…<cmmMsgHeader>…
+  const svcXml = extractTagContent(bodyText, 'OpenAPI_ServiceResponse');
+  if (svcXml !== null) {
+    const cmmXml = extractTagContent(svcXml, 'cmmMsgHeader');
+    if (cmmXml !== null) {
+      const reason = extractTagContent(cmmXml, 'returnReasonCode');
+      if (reason !== null) {
+        return !isDataGoKrAllowlisted(reason);
+      }
+      const errMsg = extractTagContent(cmmXml, 'errMsg');
+      if (errMsg !== null && errMsg !== '') {
+        return true;
+      }
+      return true;
+    }
+  }
+
+  return null;
+}
+
 /** 2xx 본문이 사실상 에러/폐기 응답인지 판정 (HTTP 200이 실패를 가리는 케이스 탐지). */
 export function looksLikeErrorBody(bodyText: string): boolean {
-  // 구조와 무관한 deprecation 텍스트 신호
+  // 1) 구조와 무관한 deprecation 텍스트 신호
   if (/has been deprecated|api version has been deprecated/i.test(bodyText)) return true;
 
+  // 2) data.go.kr 엔벨로프 (JSON 또는 XML) — 비-JSON early return 이전
+  const envelope = classifyDataGoKrEnvelope(bodyText);
+  if (envelope !== null) return envelope;
+
+  // 3) 비-JSON: deprecation·엔벨로프 외 신호 없음
   if (!looksLikeJson(bodyText)) return false;
+
+  // 4) 기존 REST JSON 휴리스틱
   let parsed: unknown;
   try {
     parsed = JSON.parse(bodyText);
@@ -87,8 +248,8 @@ export function classifyResponse(input: ClassifyInput): ClassifyResult {
     return { status: 'unknown', reason: `예상치 못한 4xx(${httpStatus})` };
   }
 
-  // 2xx/3xx 성공 경로 — content-type 무관하게 본문 에러/deprecation 신호 확인
-  // (looksLikeErrorBody는 비-JSON 본문이면 deprecation 텍스트만 검사하고 false 반환)
+  // 2xx/3xx 성공 경로 — content-type 무관하게 본문 에러/deprecation/공공데이터 엔벨로프 확인
+  // (looksLikeErrorBody: deprecation → data.go.kr JSON/XML 엔벨로프 → 비-JSON false → REST JSON 휴리스틱)
   if (looksLikeErrorBody(bodyText)) {
     return { status: 'broken', reason: `HTTP ${httpStatus}이나 본문이 에러/deprecation` };
   }
@@ -121,6 +282,9 @@ export function toVerificationStatus(status: HealthStatus): ApiVerificationStatu
   return null; // key_gated / unknown — 자동 판정 불가, 기존 값 보존
 }
 
+// knownSample은 key.toLowerCase()로 조회한다 — 키는 소문자로 등록.
+// 도메인 전용 좌표·관측소 파라미터(nx/ny/base_date 등)는 넣지 않는다.
+// 다른 API에서 의미가 달라 프로브를 오염시키므로 per-endpoint example_call 쪽이 맞다.
 const SAMPLE_VALUES: Record<string, string> = {
   name: 'korea',
   currency: 'USD',
@@ -151,6 +315,15 @@ const SAMPLE_VALUES: Record<string, string> = {
   lng: '126.978',
   latitude: '37.5665',
   longitude: '126.978',
+  // 공공데이터·관광 등 공통 페이징/포맷 파라미터 (제공자 간 의미가 분명한 것만)
+  pageno: '1',
+  numofrows: '1',
+  datatype: 'JSON',
+  returntype: 'json',
+  _type: 'json',
+  type: 'json',
+  mobileos: 'ETC',
+  mobileapp: 'CustomWebService',
 };
 
 // 키 인증용 파라미터는 테스트 쿼리에 넣지 않는다 (키리스로 호출해 401=key_gated 판정).

--- a/src/lib/catalog/healthCheck.ts
+++ b/src/lib/catalog/healthCheck.ts
@@ -45,8 +45,15 @@ function looksLikeJson(bodyText: string): boolean {
  */
 const DATA_GO_KR_ALLOWLIST = new Set(['00', '000', '0000', 'INFO-000', '03', '22']);
 
-function isDataGoKrAllowlisted(code: string): boolean {
-  return DATA_GO_KR_ALLOWLIST.has(code.trim());
+/** plain object만 통과. null·배열·원시값은 null. 중복 typeof 가드 제거용. */
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+/** 허용목록 밖 코드면 true(에러). 허용이면 false. */
+function verdictFromCode(code: string | number): boolean {
+  return !DATA_GO_KR_ALLOWLIST.has(String(code).trim());
 }
 
 /**
@@ -79,7 +86,110 @@ function classifyHeaderResultCode(
     const resultMsg = header.resultMsg;
     if (typeof resultMsg !== 'string' || resultMsg.trim() === '') return null;
   }
-  return !isDataGoKrAllowlisted(String(resultCode));
+  return verdictFromCode(resultCode);
+}
+
+/** Shape A: response.header.resultCode (resultMsg 불필요). */
+function classifyJsonShapeA(obj: Record<string, unknown>): boolean | null {
+  const response = asRecord(obj.response);
+  if (!response) return null;
+  const header = asRecord(response.header);
+  if (!header) return null;
+  return classifyHeaderResultCode(header, false);
+}
+
+/** Shape A′: 최상위 header.resultCode + resultMsg (둘 다 필수). */
+function classifyJsonShapeAPrime(obj: Record<string, unknown>): boolean | null {
+  const header = asRecord(obj.header);
+  if (!header) return null;
+  return classifyHeaderResultCode(header, true);
+}
+
+/**
+ * Shape B: OpenAPI_ServiceResponse.cmmMsgHeader.
+ * 엔벨로프가 매칭되면 코드/errMsg 유무와 무관하게 판정(미지·빈 필드 → fail-closed true).
+ */
+function classifyJsonShapeB(obj: Record<string, unknown>): boolean | null {
+  const svc = asRecord(obj.OpenAPI_ServiceResponse);
+  if (!svc) return null;
+  const cmm = asRecord(svc.cmmMsgHeader);
+  if (!cmm) return null;
+
+  const reason = cmm.returnReasonCode;
+  if (typeof reason === 'string' || typeof reason === 'number') {
+    return verdictFromCode(reason);
+  }
+  // 코드 없이 errMsg가 있든 없든 인식된 엔벨로프 → fail-closed
+  // (비어 있지 않은 errMsg도, 필드 부재도 동일하게 true)
+  return true;
+}
+
+/**
+ * JSON 본문의 data.go.kr 엔벨로프 판정.
+ * 순서: A → A′ → B. false(허용 코드)는 그대로 반환 — XML로 폴스루하지 않음.
+ */
+function classifyJsonEnvelope(bodyText: string): boolean | null {
+  if (!looksLikeJson(bodyText)) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch {
+    return null;
+  }
+
+  const obj = asRecord(parsed);
+  if (!obj) return null;
+
+  return classifyJsonShapeA(obj) ?? classifyJsonShapeAPrime(obj) ?? classifyJsonShapeB(obj);
+}
+
+/** Shape A XML: <response><header><resultCode>. */
+function classifyXmlShapeA(bodyText: string): boolean | null {
+  const responseXml = extractTagContent(bodyText, 'response');
+  if (responseXml === null) return null;
+  const headerXml = extractTagContent(responseXml, 'header');
+  if (headerXml === null) return null;
+  const resultCode = extractTagContent(headerXml, 'resultCode');
+  if (resultCode === null) return null;
+  return verdictFromCode(resultCode);
+}
+
+/**
+ * Shape A′ XML: 최상위 <header> (response 래퍼 없을 때만).
+ * resultCode + resultMsg 둘 다 필수.
+ */
+function classifyXmlShapeAPrime(bodyText: string): boolean | null {
+  // response 래퍼가 있으면 최상위 header로 보지 않는다 (중첩 header 오탐 방지)
+  if (extractTagContent(bodyText, 'response') !== null) return null;
+
+  const headerXml = extractTagContent(bodyText, 'header');
+  if (headerXml === null) return null;
+  const resultCode = extractTagContent(headerXml, 'resultCode');
+  const resultMsg = extractTagContent(headerXml, 'resultMsg');
+  if (resultCode === null || resultMsg === null || resultMsg === '') return null;
+  return verdictFromCode(resultCode);
+}
+
+/** Shape B XML: <OpenAPI_ServiceResponse><cmmMsgHeader>… fail-closed. */
+function classifyXmlShapeB(bodyText: string): boolean | null {
+  const svcXml = extractTagContent(bodyText, 'OpenAPI_ServiceResponse');
+  if (svcXml === null) return null;
+  const cmmXml = extractTagContent(svcXml, 'cmmMsgHeader');
+  if (cmmXml === null) return null;
+
+  const reason = extractTagContent(cmmXml, 'returnReasonCode');
+  if (reason !== null) return verdictFromCode(reason);
+  // errMsg 유무와 무관 — 인식된 엔벨로프면 fail-closed
+  return true;
+}
+
+/**
+ * XML 본문의 data.go.kr 엔벨로프 판정.
+ * 순서: A → A′ → B.
+ */
+function classifyXmlEnvelope(bodyText: string): boolean | null {
+  return classifyXmlShapeA(bodyText) ?? classifyXmlShapeAPrime(bodyText) ?? classifyXmlShapeB(bodyText);
 }
 
 /**
@@ -91,104 +201,12 @@ function classifyHeaderResultCode(
  *           — 기상청·에어코리아 에러가 response 래퍼 없이 header만 돌린다 (2026-08-05 실측)
  * Shape B:  OpenAPI_ServiceResponse.cmmMsgHeader.returnReasonCode|errMsg (JSON/XML)
  *
- * 순서: A(래핑) → A′(비래핑) → B. 둘 다 있으면 래핑이 우선.
+ * 순서: JSON 전체 → XML 전체. JSON이 false(허용)면 XML로 넘어가지 않는다(?? 연산).
  * bare top-level resultCode(header 없음)는 인식하지 않는다.
  */
 function classifyDataGoKrEnvelope(bodyText: string): boolean | null {
-  // ── JSON 경로 ──────────────────────────────────────────────────────────────
-  if (looksLikeJson(bodyText)) {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(bodyText);
-    } catch {
-      parsed = null;
-    }
-    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      const obj = parsed as Record<string, unknown>;
-
-      // Shape A: response.header.resultCode (resultMsg 불필요 — 중첩이 이미 식별력 있음)
-      const response = obj.response;
-      if (response !== null && typeof response === 'object' && !Array.isArray(response)) {
-        const header = (response as Record<string, unknown>).header;
-        if (header !== null && typeof header === 'object' && !Array.isArray(header)) {
-          const verdict = classifyHeaderResultCode(header as Record<string, unknown>, false);
-          if (verdict !== null) return verdict;
-        }
-      }
-
-      // Shape A′: 최상위 header.resultCode + resultMsg (둘 다 필수 — 오탐 가드)
-      const topHeader = obj.header;
-      if (topHeader !== null && typeof topHeader === 'object' && !Array.isArray(topHeader)) {
-        const verdict = classifyHeaderResultCode(topHeader as Record<string, unknown>, true);
-        if (verdict !== null) return verdict;
-      }
-
-      // Shape B: OpenAPI_ServiceResponse.cmmMsgHeader.returnReasonCode / errMsg
-      const svc = obj.OpenAPI_ServiceResponse;
-      if (svc !== null && typeof svc === 'object' && !Array.isArray(svc)) {
-        const cmm = (svc as Record<string, unknown>).cmmMsgHeader;
-        if (cmm !== null && typeof cmm === 'object' && !Array.isArray(cmm)) {
-          const cmmObj = cmm as Record<string, unknown>;
-          const reason = cmmObj.returnReasonCode;
-          if (typeof reason === 'string' || typeof reason === 'number') {
-            return !isDataGoKrAllowlisted(String(reason));
-          }
-          // 코드 없이 errMsg만 있으면 인식된 엔벨로프 → fail-closed
-          if (typeof cmmObj.errMsg === 'string' && cmmObj.errMsg.trim() !== '') {
-            return true;
-          }
-          // 엔벨로프 마커는 있으나 판정 필드 없음 → fail-closed
-          return true;
-        }
-      }
-    }
-  }
-
-  // ── XML 경로 (비-JSON early return 이전에 수행) ─────────────────────────────
-  // Shape A: <response>…<header>…<resultCode>…</resultCode>
-  const responseXml = extractTagContent(bodyText, 'response');
-  if (responseXml !== null) {
-    const headerXml = extractTagContent(responseXml, 'header');
-    if (headerXml !== null) {
-      const resultCode = extractTagContent(headerXml, 'resultCode');
-      if (resultCode !== null) {
-        return !isDataGoKrAllowlisted(resultCode);
-      }
-    }
-  }
-
-  // Shape A′: 최상위 <header>… (response 래퍼 없음). resultCode + resultMsg 둘 다 필수.
-  // response 래퍼가 이미 resultCode로 판정됐으면 위에서 반환했으므로 여기까지 오지 않는다.
-  // response 없이 header만 있거나, response에 resultCode가 없을 때만 도달.
-  if (responseXml === null) {
-    const topHeaderXml = extractTagContent(bodyText, 'header');
-    if (topHeaderXml !== null) {
-      const resultCode = extractTagContent(topHeaderXml, 'resultCode');
-      const resultMsg = extractTagContent(topHeaderXml, 'resultMsg');
-      if (resultCode !== null && resultMsg !== null && resultMsg !== '') {
-        return !isDataGoKrAllowlisted(resultCode);
-      }
-    }
-  }
-
-  // Shape B: <OpenAPI_ServiceResponse>…<cmmMsgHeader>…
-  const svcXml = extractTagContent(bodyText, 'OpenAPI_ServiceResponse');
-  if (svcXml !== null) {
-    const cmmXml = extractTagContent(svcXml, 'cmmMsgHeader');
-    if (cmmXml !== null) {
-      const reason = extractTagContent(cmmXml, 'returnReasonCode');
-      if (reason !== null) {
-        return !isDataGoKrAllowlisted(reason);
-      }
-      const errMsg = extractTagContent(cmmXml, 'errMsg');
-      if (errMsg !== null && errMsg !== '') {
-        return true;
-      }
-      return true;
-    }
-  }
-
-  return null;
+  // ?? : null만 우측으로 폴스루. false(허용 코드)는 그대로 유지.
+  return classifyJsonEnvelope(bodyText) ?? classifyXmlEnvelope(bodyText);
 }
 
 /** 2xx 본문이 사실상 에러/폐기 응답인지 판정 (HTTP 200이 실패를 가리는 케이스 탐지). */

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -66,11 +66,15 @@ export type DomainEvent =
         finalMobileScore: number;
       };
     }
-  // 관리자 조작 2종. payload에 userId/projectId를 넣지 않는다 —
+  // 관리자 조작. payload에 userId/projectId를 넣지 않는다 —
   // persist()가 그 키를 FK 컬럼으로 추출하는데 관리자 조작엔 대응하는 행이 없다.
   | { type: 'FEATURE_FLAG_CHANGED'; payload: { flag: string; enabled: boolean } }
   | {
       type: 'CATALOG_API_ACTIVATED';
+      payload: { apiId: string; apiName: string; envVar: string };
+    }
+  | {
+      type: 'CATALOG_API_DEACTIVATED';
       payload: { apiId: string; apiName: string; envVar: string };
     };
 

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -99,6 +99,17 @@ export const activateCatalogSchema = z.object({
   dryRun: z.boolean().optional(),
 });
 
+/**
+ * 카탈로그 비활성화. activate와 형태는 비슷하지만 **생략 의미가 다르다**.
+ * - `apiIds` 필수·비어 있으면 안 됨 (omit=전부 끔 은 구현하지 않음 — 실수 방지)
+ * - 라이브 키 검증 없음 (업스트림 다운이어도 끌 수 있어야 함)
+ */
+export const deactivateCatalogSchema = z.object({
+  apiIds: z.array(z.string().min(1)).min(1),
+  /** true면 DB에 쓰지 않고 대상·결과만 돌려준다. */
+  dryRun: z.boolean().optional(),
+});
+
 // ── 인증 ──────────────────────────────────────────────────────────────────────
 // z.string().email()는 Zod v4에서 deprecated → z.string().trim().toLowerCase().pipe(z.email()) 사용
 const emailField = z.string().trim().toLowerCase().pipe(z.email());


### PR DESCRIPTION
## 무슨 일이 있었나

data.go.kr 키 10개를 등록하고 검증 통과한 6개를 활성화했는데, **그중 4개는 실제로 동작하지 않는 상태로 사용자에게 노출**됐다. 활성화 게이트가 **인증 성공만 보고 본문에 담긴 에러를 못 봤기 때문**이다.

`looksLikeErrorBody()`는 일반 REST 형태(`success:false`·`error`·`errors[]`)만 알고, **비-JSON 본문은 아예 검사하지 않고 `false`를 반환**했다. 공공데이터 API는 **HTTP 200에 에러를 담아 보내고 기본 응답이 XML**이라 전부 통과했다.

## 합성 테스트 2433건이 통과하는 동안 실제 본문은 새어나갔다

1차 구현은 봉투 2형태를 잡았고 전체 테스트가 초록이었다. 그런데 **실측 본문을 판정기에 직접 통과시키니 잡아야 할 4건이 그대로 통과**했다.

원인은 형태가 하나 더 있었기 때문이다 (2026-08-05 실측):

```
성공            {"response":{"header":{"resultCode":"00",...},"body":{...}}}
NO_DATA         {"response":{"header":{"resultCode":"03","resultMsg":"NO_DATA"}}}
게이트웨이 에러    {"OpenAPI_ServiceResponse":{"cmmMsgHeader":{"returnReasonCode":"12"}}}
에러 ← 누락      {"header":{"resultCode":"01","resultMsg":"APPLICATION_ERROR"}}
```

**에러 응답은 `response` 래퍼 없이 `header`가 최상위로 온다.** 성공과 에러의 구조가 다른 비대칭이라 문서로는 알 수 없고 실제 호출로만 드러난다. 그래서 **실측 본문을 그대로 픽스처로 박아 두었다.**

### 라이브 재검증 (11/11)

| 케이스 | 이전 | 지금 |
|---|---|---|
| 기상청 단기·중기, 에어코리아 (카탈로그 정의) | `VALID` ❌ | **`INVALID`** ✅ |
| TourAPI KorService1(폐기) · TAGO(미승인) | ERROR/INVALID | 동일 |
| 정상 호출 5건 | `VALID` | `VALID` (**오탐 0**) |

### 판정 규칙

- 허용: `00` · `000` · `0000` · `INFO-000` · **`03`(NO_DATA)** · **`22`(한도)**
  → 03/22를 에러로 처리하면 **멀쩡한 키를 INVALID로 오판**한다. 인증은 성공했고 결과만 없거나 한도에 걸린 것이다. 429는 이미 `RATE_LIMITED`로 따로 매핑된다.
- 봉투 안의 그 외 코드(미지 코드 포함) → **fail-closed**
- 최상위 `header` 형태는 `resultCode`와 `resultMsg`를 **둘 다** 요구한다 — `response` 아래 중첩된 형태는 구조 자체가 특징적이지만 최상위 `header`는 무관한 API와 충돌할 여지가 있어 더 엄격하게 잡는다

> 국토부 전월세를 "에러"로 본 초기 판단은 **틀렸다.** 잘못된 파라미터에도 `resultCode=000`(OK) + 빈 결과를 준다. 에러가 아닌 게 맞고, 그건 카탈로그 품질 문제라 다음 PR의 몫이다.

## 비활성화 수단 (신규)

`is_active`를 `false`로 되돌리는 경로가 **아예 없어서 잘못 켠 것을 끌 방법이 없었다.**

`POST /api/v1/admin/catalog/deactivate` — `activate`와 **의도적으로 다르게** 만든 지점:

| | activate | deactivate |
|---|---|---|
| 라이브 키 검증 | **필수** | **안 함** — 끄는 건 fail-safe 방향이라 업스트림이 죽어도 꺼야 한다 |
| `apiIds` 생략 | 전체 후보 | **400** — 끄는 쪽에 "생략=전체"를 두면 오타 하나로 카탈로그가 통째로 꺼진다 |
| `verificationStatus` | `verified`로 설정 | **건드리지 않음** — 왜 껐는지 증거로 남긴다 |
| 대상 | 플랫폼 키 보유분 | **모든 활성 행** — 잘못 시드된 키리스 API도 꺼야 한다 |

## SAMPLE_VALUES

제공자 간 의미가 분명한 공통 파라미터만 추가했다(`pageNo`·`numOfRows`·`dataType`·`returnType`·`_type`·`type`·`MobileOS`·`MobileApp`).

`nx`·`base_date`·`tmFc` 같은 도메인 전용 값은 **넣지 않았다** — 전역 표라서 다른 API에서 의미가 달라지면 그 API의 프로브를 오염시킨다. 그런 값은 엔드포인트별 `example_call`이 맞는 자리다(다음 PR).

## 검증

| 항목 | 결과 |
|---|---|
| **라이브 본문 11건** | **전건 일치** (새어나간 3건 INVALID 전환 · 정상 5건 오탐 0) |
| `pnpm lint` | 0 errors |
| `pnpm type-check` | 통과 |
| `pnpm test` | **194 파일 2445 테스트 전건 통과** |

## 다음 (별도 PR)

TourAPI → `KorService2`, 기상청·에어코리아 `example_call` 추가, 식약처 폐기 표기, **`ensureCatalog` 구조 동기화**.

> ⚠️ `apiCatalog.json`만 고치면 **프로덕션은 안 바뀐다.** `ensureCatalogEntries`는 신규 삽입 + `['Dog API','Lorem Picsum']` 2건 패치가 전부다. 구조 동기화가 없으면 TourAPI는 배포 후에도 `KorService1`에 머문다. (`is_active`는 절대 동기화 대상이 아니다 — 재배포가 관리자 결정을 되돌리면 안 된다.)

## 협업

설계·실측·라이브 검증·최종 리뷰는 Claude, 구현은 Grok Build(subscription). Grok이 계획 단계에서 제 명세의 구멍 2건(프로브가 parameters 값을 안 씀 · JSON 편집이 프로덕션에 도달 안 함)을 잡아냈고, 반대로 1차 구현이 실제 본문을 놓친 것은 Claude의 라이브 검증이 잡았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)