### PR TITLE
fix: data.go.kr 카탈로그 6건 실측 정정 + 부팅 시 구조 동기화 (식약처 폐기)

### DIFF
--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -413,12 +413,29 @@ drizzle/sqlite/
 2. **`seedCatalog(db)`** — `src/data/apiCatalog.json`(프로덕션 카탈로그 미러)을 빈
    `api_catalog`에만 일괄 삽입. id·created_at은 프로덕션 값 그대로 유지(FK 일관성)
 3. **`seedFeatureFlags(db)`** — `src/data/featureFlags.json`을 빈 `feature_flags`에만 삽입
-4. **`ensureCatalogEntries(db)`** — 이미 시드된 DB에 번들 JSON의 **신규 행 삽입** + 잘못 broken/비활성으로 기록된 키리스 API 정정(멱등). `seedCatalog`는 빈 테이블에만 동작하므로 프로덕션 갱신에 필수
+4. **`ensureCatalogEntries(db)`** — 이미 시드된 DB에 번들 JSON의 **신규 행 삽입** + 잘못 broken/비활성으로 기록된 키리스 API 이름 정정(Dog API·Lorem Picsum) + **id 화이트리스트 구조 패치**(멱등). `seedCatalog`는 빈 테이블에만 동작하므로 프로덕션 갱신에 필수
 5. **`ensureFeatureFlags(db)`** — 번들 화이트리스트에 없는 죽은 플래그 행 삭제 + 누락 플래그만 삽입. **기존 `enabled`는 덮어쓰지 않음**(§3.9)
+
+#### `ensureCatalogEntries` 구조 패치 (`STRUCTURAL_PATCH_IDS`)
+
+번들 JSON만 고쳐도 **이미 채워진 프로덕션 행은 그대로**다(`seedCatalog`는 빈 테이블만 삽입).
+data.go.kr 등 구조 정정이 필요한 id는 `ensureCatalog.ts`의 `STRUCTURAL_PATCH_IDS`에
+명시하고, 부팅 시 아래 **구조 필드만** 번들 값으로 맞춘다:
+
+| 동기화 | 비동기화 (절대 덮어쓰지 않음) |
+|--------|-------------------------------|
+| `base_url`, `endpoints`, `deprecated_at`, `description` | **`is_active`**, **`verification_status`** |
+
+- **왜 `is_active`를 빼는가:** 재배포가 번들의 `is_active`로 기존 행을 덮어쓰면
+  오퍼레이터의 활성/비활성 판단이 조용히 롤백된다. `ensureFeatureFlags`가 기존 행의
+  `enabled`를 덮어쓰지 않는 것과 **같은 전례**.
+- 목록은 명시·최소 — 전체 테이블 덮어쓰기 금지. 값이 이미 일치하면 no-op
+  (`corrected`에 포함되지 않음). 반환 형태는 `{ inserted, corrected }`
+  (이름 정정 + 구조 패치 합산).
 
 > **`seedAdminUser`는 제거됨**: 공개 다중 사용자 전환(2026-06-24)으로 env 단일 관리자 시드가 불필요해졌다. 신규 환경은 `/signup`으로 첫 사용자를 생성한다.
 
-> `src/data/apiCatalog.json`은 프로덕션 `api_catalog` 미러(손편집 금지). `featureFlags.json`은 살아 있는 킬스위치 화이트리스트 출처(§3.9). 빈 테이블 시드는 `seed*`만, 이미 채워진 DB 동기화는 `ensure*`가 담당한다.
+> `src/data/apiCatalog.json`은 프로덕션 `api_catalog` 미러(손편집 금지). 구조 정정이 프로덕션에 도달하려면 JSON 수정 **과** `STRUCTURAL_PATCH_IDS` 등록이 둘 다 필요하다. `featureFlags.json`은 살아 있는 킬스위치 화이트리스트 출처(§3.9). 빈 테이블 시드는 `seed*`만, 이미 채워진 DB 동기화는 `ensure*`가 담당한다.
 
 ### 연결 설정 (pragma)
 

--- a/src/data/apiCatalog.json
+++ b/src/data/apiCatalog.json
@@ -987,7 +987,7 @@
   {
     "id": "f45de6c5-95e6-4c4a-989e-c60b060a9c7c",
     "name": "식약처 식품영양성분",
-    "description": "식품의약품안전처 식품 영양성분 데이터. 식품명으로 열량·단백질·지방·탄수화물 등 조회. (공공데이터포털 키 필요)",
+    "description": "식품의약품안전처 식품 영양성분 데이터. 식품명으로 열량·단백질·지방·탄수화물 등 조회. (공공데이터포털 키 필요) ⚠️ 2026-08-05 실측: 업스트림 FoodNtrIrdntInfoService1이 NO_OPENAPI_SERVICE_ERROR(code 12)로 폐기됨. 후속 서비스 후보 6종을 프로브했으나 모두 code 12 — 대체 API 없음. 행은 이력 보존을 위해 삭제하지 않음.",
     "category": "health",
     "base_url": "https://apis.data.go.kr/1471000/FoodNtrIrdntInfoService1",
     "auth_type": "api_key",
@@ -1025,7 +1025,7 @@
       "data.go.kr"
     ],
     "api_version": null,
-    "deprecated_at": null,
+    "deprecated_at": "2026-08-05T00:00:00.000Z",
     "successor_id": null,
     "cors_supported": false,
     "requires_proxy": true,
@@ -1640,7 +1640,7 @@
   {
     "id": "17665554-5a7c-4df0-91a7-826dab855f05",
     "name": "국토부 아파트 전월세",
-    "description": "국토교통부 아파트 전·월세 실거래 데이터. 지역코드·기간으로 임대 계약 내역 조회. (공공데이터포털 키 필요)",
+    "description": "국토교통부 아파트 전·월세 실거래 데이터. 지역코드·기간으로 임대 계약 내역 조회. ⚠️ 응답은 XML 전용 — `_type`/`dataType`을 무시하며 res.json() 호출 금지. DOMParser 등으로 XML 파싱 필수. (공공데이터포털 키 필요)",
     "category": "public",
     "base_url": "https://apis.data.go.kr/1613000/RTMSDataSvcAptRent",
     "auth_type": "api_key",
@@ -1660,12 +1660,12 @@
         "method": "GET",
         "parameters": {
           "pageNo": "1",
-          "LAWD_CD": "법정동코드 앞 5자리 (예: 11680=강남구)",
+          "LAWD_CD": "법정동코드 앞 5자리 (예: 11680=강남구). ⚠️ 잘못된 코드도 resultCode 000 + 빈 <items/> 를 반환하므로 오류 없이 결과가 비어 보일 수 있다.",
           "DEAL_YMD": "계약연월 YYYYMM",
           "numOfRows": "10"
         },
-        "description": "아파트 전월세 실거래 조회",
-        "exampleCall": "const res = await fetch('/api/v1/proxy?apiId=<이 API ID>&proxyPath=%2FgetRTMSDataSvcAptRent&LAWD_CD=11680&DEAL_YMD=202504&pageNo=1&numOfRows=10');\nconst data = await res.json();\nconst items = data.response.body.items.item; // [{aptNm, deposit, monthlyRent, excluUseAr}]",
+        "description": "아파트 전월세 실거래 조회 (응답 XML 전용 — res.json() 금지)",
+        "example_call": "/getRTMSDataSvcAptRent?LAWD_CD=11680&DEAL_YMD=202607&pageNo=1&numOfRows=10",
         "responseDataPath": "response.body.items.item"
       }
     ],
@@ -1817,9 +1817,9 @@
   {
     "id": "c76876b5-a4d8-49cf-a0c9-0240daf3eb5e",
     "name": "한국관광공사 TourAPI",
-    "description": "전국 관광지, 맛집, 숙박, 축제 정보. 여행 계획 세울 때 지역별 볼거리·먹거리를 찾아보세요.",
+    "description": "전국 관광지, 맛집, 숙박, 축제 정보. 여행 계획 세울 때 지역별 볼거리·먹거리를 찾아보세요. KorService1은 폐기(NO_OPENAPI_SERVICE_ERROR code 12) — KorService2를 사용한다.",
     "category": "tourism",
-    "base_url": "https://apis.data.go.kr/B551011/KorService1",
+    "base_url": "https://apis.data.go.kr/B551011/KorService2",
     "auth_type": "api_key",
     "auth_config": {
       "env_var": "API_KEY_TOURAPI",
@@ -1833,21 +1833,36 @@
     "docs_url": "https://api.visitkorea.or.kr/",
     "endpoints": [
       {
-        "path": "/areaBasedList1",
+        "path": "/areaBasedList2",
         "method": "GET",
         "parameters": {
-          "areaCode": "string",
-          "contentTypeId": "string"
+          "MobileOS": "필수. 클라이언트 OS 구분 (예: ETC). 생략 시 실패",
+          "MobileApp": "필수. 앱 이름 (예: CustomWebService). 생략 시 실패",
+          "_type": "필수. 응답 형식 — 반드시 json. 생략 시 실패",
+          "numOfRows": "한 페이지 결과 수",
+          "pageNo": "페이지 번호",
+          "areaCode": "지역 코드 (예: 1=서울)",
+          "contentTypeId": "콘텐츠 유형 (예: 12=관광지)",
+          "arrange": "정렬 (A=제목순 등)"
         },
-        "description": "지역 기반 관광지 목록"
+        "description": "지역 기반 관광지 목록 (KorService2)",
+        "example_call": "/areaBasedList2?MobileOS=ETC&MobileApp=CustomWebService&_type=json&numOfRows=10&pageNo=1&areaCode=1&contentTypeId=12&arrange=A",
+        "responseDataPath": "response.body.items.item"
       },
       {
-        "path": "/searchKeyword1",
+        "path": "/searchKeyword2",
         "method": "GET",
         "parameters": {
-          "keyword": "string"
+          "MobileOS": "필수. 클라이언트 OS 구분 (예: ETC). 생략 시 실패",
+          "MobileApp": "필수. 앱 이름 (예: CustomWebService). 생략 시 실패",
+          "_type": "필수. 응답 형식 — 반드시 json. 생략 시 실패",
+          "numOfRows": "한 페이지 결과 수",
+          "pageNo": "페이지 번호",
+          "keyword": "검색 키워드 (예: 경복궁)"
         },
-        "description": "키워드 검색"
+        "description": "키워드 검색 (KorService2)",
+        "example_call": "/searchKeyword2?MobileOS=ETC&MobileApp=CustomWebService&_type=json&numOfRows=10&pageNo=1&keyword=경복궁",
+        "responseDataPath": "response.body.items.item"
       }
     ],
     "tags": [
@@ -2368,12 +2383,17 @@
         "path": "/getVilageFcst",
         "method": "GET",
         "parameters": {
-          "nx": "number",
-          "ny": "number",
-          "base_date": "string",
-          "base_time": "string"
+          "nx": "격자 X 좌표",
+          "ny": "격자 Y 좌표",
+          "base_date": "발표 일자 YYYYMMDD. ⚠️ 예시 날짜를 그대로 복사하지 말 것 — 런타임에 오늘/어제 날짜를 계산해 넣는다. 지난(또는 미발표) 날짜를 쓰면 NO_DATA(03)이 반환되어 검증은 통과해도 사용자 화면에 데이터가 없다.",
+          "base_time": "발표 시각 — 고정 슬롯만 허용: 0200, 0500, 0800, 1100, 1400, 1700, 2000, 2300",
+          "dataType": "필수. JSON을 받으려면 반드시 JSON (미지정 시 XML 응답)",
+          "pageNo": "페이지 번호",
+          "numOfRows": "한 페이지 결과 수 (단기예보는 1000 권장)"
         },
-        "description": "동네 예보 조회 (3시간 단위)"
+        "description": "동네 예보 조회 (3시간 단위)",
+        "example_call": "/getVilageFcst?nx=60&ny=127&base_date=20260804&base_time=0500&dataType=JSON&pageNo=1&numOfRows=1000",
+        "responseDataPath": "response.body.items.item"
       }
     ],
     "tags": [
@@ -2417,10 +2437,15 @@
         "path": "/getMidTa",
         "method": "GET",
         "parameters": {
-          "tmFc": "string",
-          "regId": "string"
+          "regId": "예보구역코드 (예: 11B10101=서울)",
+          "tmFc": "발표시각 YYYYMMDD0600 또는 YYYYMMDD1800. ⚠️ 반드시 과거 슬롯 — 오늘 슬롯은 NO_DATA(03). 예시 시각을 그대로 복사하지 말고 런타임에 가장 최근 과거 슬롯을 계산한다. 지난 날짜로 검증은 통과해도 사용자 화면에 데이터가 없을 수 있다. ⚠️ example_call의 날짜가 만료돼 보여도 지우지 말 것 — tmFc를 빼면 resultCode 11(필수 파라미터 누락)이라 키 검증이 실패해 활성화 자체가 불가능해진다. 만료된 예시를 남기면 03(NO_DATA·허용)이라 활성화는 되고, 실제 호출은 런타임 계산값을 쓴다.",
+          "dataType": "필수. JSON을 받으려면 반드시 JSON (미지정 시 XML 응답)",
+          "pageNo": "페이지 번호",
+          "numOfRows": "한 페이지 결과 수"
         },
-        "description": "중기 기온 예보 조회"
+        "description": "중기 기온 예보 조회",
+        "example_call": "/getMidTa?regId=11B10101&tmFc=202608040600&dataType=JSON&pageNo=1&numOfRows=10",
+        "responseDataPath": "response.body.items.item"
       }
     ],
     "tags": [
@@ -2464,10 +2489,16 @@
         "path": "/getMsrstnAcctoRltmMesureDnsty",
         "method": "GET",
         "parameters": {
-          "dataTerm": "string",
-          "stationName": "string"
+          "stationName": "측정소명 (예: 종로구)",
+          "dataTerm": "조회기간 (DAILY 등)",
+          "returnType": "필수. 생략 시 HTTP 504. 반드시 json",
+          "pageNo": "필수. 생략 시 HTTP 504",
+          "ver": "선택. API 버전 (예: 1.0)",
+          "numOfRows": "선택. 한 페이지 결과 수"
         },
-        "description": "측정소별 실시간 대기질 조회"
+        "description": "측정소별 실시간 대기질 조회",
+        "example_call": "/getMsrstnAcctoRltmMesureDnsty?stationName=종로구&dataTerm=DAILY&returnType=json&ver=1.0&pageNo=1&numOfRows=10",
+        "responseDataPath": "response.body.items"
       }
     ],
     "tags": [

--- a/src/lib/db/sqlite/ensureCatalog.test.ts
+++ b/src/lib/db/sqlite/ensureCatalog.test.ts
@@ -3,11 +3,14 @@ import type Database from 'better-sqlite3';
 import { eq } from 'drizzle-orm';
 import { createSqliteConnection, runSqliteMigrations, type SqliteDb } from '@/lib/db/sqlite/connection';
 import * as schema from '@/lib/db/sqlite/schema';
-import { ensureCatalogEntries } from './ensureCatalog';
+import { ensureCatalogEntries, listStructuralPatchIds } from './ensureCatalog';
 import catalogData from '@/data/apiCatalog.json';
 
 type InsertRow = typeof schema.apiCatalog.$inferInsert;
 const rows = catalogData as unknown as InsertRow[];
+
+const TOUR_API_ID = 'c76876b5-a4d8-49cf-a0c9-0240daf3eb5e';
+const FOOD_NTR_ID = 'f45de6c5-95e6-4c4a-989e-c60b060a9c7c';
 
 describe('ensureCatalogEntries', () => {
   let db: SqliteDb;
@@ -55,9 +58,138 @@ describe('ensureCatalogEntries', () => {
     expect(row?.verification_status).toBe('verified');
   });
 
-  it('이미 verified·active면 정정하지 않는다 (corrected=0)', () => {
-    ensureCatalogEntries(db); // 번들 JSON의 Dog/Lorem은 이미 verified+active로 삽입됨
+  it('이미 verified·active면 이름 정정하지 않는다 (corrected=0, 구조도 일치)', () => {
+    ensureCatalogEntries(db); // 번들 JSON 전체가 올바른 상태로 삽입됨
     const r = ensureCatalogEntries(db);
     expect(r.corrected).toBe(0);
+  });
+
+  it('구조 패치: 구 base_url이면 첫 부팅에 반영하고 두 번째 부팅은 no-op', () => {
+    const tour = rows.find((x) => x.id === TOUR_API_ID)!;
+    db.insert(schema.apiCatalog)
+      .values({
+        ...tour,
+        base_url: 'https://apis.data.go.kr/B551011/KorService1',
+        endpoints: [{ path: '/areaBasedList1', method: 'GET' }],
+        description: '구 설명',
+      })
+      .run();
+
+    const r1 = ensureCatalogEntries(db);
+    expect(r1.corrected).toBeGreaterThanOrEqual(1);
+
+    const after = db
+      .select()
+      .from(schema.apiCatalog)
+      .where(eq(schema.apiCatalog.id, TOUR_API_ID))
+      .get();
+    expect(after?.base_url).toBe(tour.base_url);
+    expect(after?.description).toBe(tour.description);
+    expect(JSON.stringify(after?.endpoints)).toBe(JSON.stringify(tour.endpoints));
+
+    const r2 = ensureCatalogEntries(db);
+    expect(r2.corrected).toBe(0);
+  });
+
+  it('구조 패치가 is_active·verification_status를 덮어쓰지 않는다 — 재배포가 오퍼레이터 판단을 롤백하면 안 됨', () => {
+    const tour = rows.find((x) => x.id === TOUR_API_ID)!;
+    // 번들 JSON의 TourAPI는 is_active:false / unverified 이지만,
+    // 오퍼레이터가 활성화·verified로 둔 상태를 재배포가 되돌려서는 안 된다.
+    db.insert(schema.apiCatalog)
+      .values({
+        ...tour,
+        base_url: 'https://apis.data.go.kr/B551011/KorService1',
+        is_active: true,
+        verification_status: 'verified',
+      })
+      .run();
+
+    ensureCatalogEntries(db);
+
+    const after = db
+      .select()
+      .from(schema.apiCatalog)
+      .where(eq(schema.apiCatalog.id, TOUR_API_ID))
+      .get();
+    expect(after?.base_url).toBe(tour.base_url);
+    expect(after?.is_active).toBe(true);
+    expect(after?.verification_status).toBe('verified');
+  });
+
+  it('폐기 항목(식약처)의 deprecated_at만 반영하고 is_active는 보존한다', () => {
+    const food = rows.find((x) => x.id === FOOD_NTR_ID)!;
+    db.insert(schema.apiCatalog)
+      .values({
+        ...food,
+        deprecated_at: null,
+        description: '구 설명',
+        is_active: true, // 번들은 false — 구조 패치가 이걸 건드리면 회귀
+        verification_status: 'broken',
+      })
+      .run();
+
+    ensureCatalogEntries(db);
+
+    const after = db
+      .select()
+      .from(schema.apiCatalog)
+      .where(eq(schema.apiCatalog.id, FOOD_NTR_ID))
+      .get();
+    expect(after?.deprecated_at).toBe('2026-08-05T00:00:00.000Z');
+    expect(after?.description).toBe(food.description);
+    expect(after?.is_active).toBe(true);
+    expect(after?.verification_status).toBe('broken');
+  });
+});
+
+describe('apiCatalog data.go.kr 구조 정정 (시드 데이터 회귀 방지)', () => {
+  it('6개 대상 항목이 기대 base_url·example_call·deprecated_at 을 갖는다', () => {
+    const byId = new Map(
+      (catalogData as { id: string }[]).map((r) => [r.id, r as Record<string, unknown>]),
+    );
+
+    expect(listStructuralPatchIds()).toHaveLength(6);
+
+    const tour = byId.get(TOUR_API_ID)!;
+    expect(tour.base_url).toBe('https://apis.data.go.kr/B551011/KorService2');
+    const tourEndpoints = tour.endpoints as { path: string; example_call?: string }[];
+    expect(tourEndpoints.map((e) => e.path)).toEqual(['/areaBasedList2', '/searchKeyword2']);
+    expect(tourEndpoints[0]?.example_call).toContain('MobileOS=ETC');
+    expect(tourEndpoints[0]?.example_call).toContain('_type=json');
+    expect(tourEndpoints[1]?.example_call).toContain('keyword=경복궁');
+
+    const shortFcst = byId.get('7cb8f428-e284-4eee-944a-af47274662d2')!;
+    const shortEp = (shortFcst.endpoints as { example_call?: string; responseDataPath?: string }[])[0];
+    expect(shortEp?.example_call).toBe(
+      '/getVilageFcst?nx=60&ny=127&base_date=20260804&base_time=0500&dataType=JSON&pageNo=1&numOfRows=1000',
+    );
+    expect(shortEp?.responseDataPath).toBe('response.body.items.item');
+
+    const midFcst = byId.get('00412c2b-6c17-4b23-9a3d-46b7004285e4')!;
+    const midEp = (midFcst.endpoints as { example_call?: string; responseDataPath?: string }[])[0];
+    expect(midEp?.example_call).toBe(
+      '/getMidTa?regId=11B10101&tmFc=202608040600&dataType=JSON&pageNo=1&numOfRows=10',
+    );
+    expect(midEp?.responseDataPath).toBe('response.body.items.item');
+
+    const air = byId.get('c84860a1-336c-45f1-b1df-00f25bd810bd')!;
+    const airEp = (air.endpoints as { example_call?: string; responseDataPath?: string }[])[0];
+    expect(airEp?.example_call).toBe(
+      '/getMsrstnAcctoRltmMesureDnsty?stationName=종로구&dataTerm=DAILY&returnType=json&ver=1.0&pageNo=1&numOfRows=10',
+    );
+    expect(airEp?.responseDataPath).toBe('response.body.items');
+
+    const molit = byId.get('17665554-5a7c-4df0-91a7-826dab855f05')!;
+    expect(String(molit.description)).toMatch(/XML/);
+    const molitEp = (molit.endpoints as { example_call?: string }[])[0];
+    expect(molitEp?.example_call).toBe(
+      '/getRTMSDataSvcAptRent?LAWD_CD=11680&DEAL_YMD=202607&pageNo=1&numOfRows=10',
+    );
+
+    const food = byId.get(FOOD_NTR_ID)!;
+    expect(food.deprecated_at).toBe('2026-08-05T00:00:00.000Z');
+    expect(food.successor_id).toBeNull();
+    expect(food.is_active).toBe(false);
+    expect(String(food.description)).toMatch(/폐기|code 12|대체/);
   });
 });

--- a/src/lib/db/sqlite/ensureCatalog.ts
+++ b/src/lib/db/sqlite/ensureCatalog.ts
@@ -13,13 +13,110 @@ import catalogData from '@/data/apiCatalog.json';
  *  2) 라이브로 동작하지만 broken/비활성으로 잘못 기록된 키리스 API를 정정한다
  *     (Dog API, Lorem Picsum → is_active=true, verification_status=verified).
  *     이미 올바른 상태면 갱신하지 않는다(향후 헬스체크 갱신과 충돌 최소화).
+ *  3) id 화이트리스트의 **구조 필드만** 번들 JSON과 맞춘다
+ *     (`base_url` · `endpoints` · `deprecated_at` · `description`).
  *
  * 멱등: 두 번째 호출부턴 inserted=0, corrected=0.
  */
 const CORRECTIONS = ['Dog API', 'Lorem Picsum'];
 
+/**
+ * data.go.kr 등 구조 정정이 필요한 카탈로그 id 목록(명시·최소).
+ * 값은 번들 JSON에서 읽어 오며, 전체 테이블 덮어쓰기는 하지 않는다.
+ *
+ * ⚠️ is_active·verification_status 는 절대 건드리지 않는다.
+ * 재배포가 is_active를 덮어쓰면 오퍼레이터의 활성/비활성 판단이 조용히 롤백된다.
+ * ensureFeatureFlags가 기존 행의 enabled를 덮어쓰지 않는 것과 같은 전례.
+ */
+const STRUCTURAL_PATCH_IDS: readonly string[] = [
+  'c76876b5-a4d8-49cf-a0c9-0240daf3eb5e', // 한국관광공사 TourAPI → KorService2
+  '7cb8f428-e284-4eee-944a-af47274662d2', // 기상청 단기예보 (example_call·파라미터 제약)
+  '00412c2b-6c17-4b23-9a3d-46b7004285e4', // 기상청 중기예보 (tmFc 과거 슬롯)
+  'c84860a1-336c-45f1-b1df-00f25bd810bd', // 에어코리아 (returnType·pageNo 필수)
+  '17665554-5a7c-4df0-91a7-826dab855f05', // 국토부 아파트 전월세 (XML 전용)
+  'f45de6c5-95e6-4c4a-989e-c60b060a9c7c', // 식약처 식품영양성분 (폐기)
+];
+
+type CatalogSeedRow = typeof schema.apiCatalog.$inferInsert;
+
+type StructuralFields = {
+  base_url: string | null;
+  endpoints: unknown[] | null;
+  deprecated_at: string | null;
+  description: string | null;
+};
+
+function pickStructural(row: CatalogSeedRow): StructuralFields {
+  return {
+    base_url: row.base_url ?? null,
+    endpoints: (row.endpoints as unknown[] | null | undefined) ?? null,
+    deprecated_at: row.deprecated_at ?? null,
+    description: row.description ?? null,
+  };
+}
+
+function sameStructural(
+  desired: StructuralFields,
+  current: {
+    base_url: string | null;
+    endpoints: unknown;
+    deprecated_at: string | null;
+    description: string | null;
+  },
+): boolean {
+  return (
+    (desired.base_url ?? null) === (current.base_url ?? null) &&
+    (desired.deprecated_at ?? null) === (current.deprecated_at ?? null) &&
+    (desired.description ?? null) === (current.description ?? null) &&
+    JSON.stringify(desired.endpoints ?? null) === JSON.stringify(current.endpoints ?? null)
+  );
+}
+
+/**
+ * STRUCTURAL_PATCH_IDS 대상 행의 구조 필드만 번들과 동기화한다.
+ * is_active / verification_status 는 읽지도·쓰지도 않는다.
+ */
+function applyStructuralPatches(db: SqliteDb, rows: CatalogSeedRow[]): number {
+  const byId = new Map(rows.filter((r) => typeof r.id === 'string').map((r) => [r.id as string, r]));
+  let patched = 0;
+
+  for (const id of STRUCTURAL_PATCH_IDS) {
+    const seed = byId.get(id);
+    if (!seed) continue;
+
+    const current = db
+      .select({
+        base_url: schema.apiCatalog.base_url,
+        endpoints: schema.apiCatalog.endpoints,
+        deprecated_at: schema.apiCatalog.deprecated_at,
+        description: schema.apiCatalog.description,
+      })
+      .from(schema.apiCatalog)
+      .where(eq(schema.apiCatalog.id, id))
+      .get();
+    if (!current) continue;
+
+    const desired = pickStructural(seed);
+    if (sameStructural(desired, current)) continue;
+
+    // is_active·verification_status 를 set에 넣지 않는다 — 오퍼레이터 판단을 보존.
+    db.update(schema.apiCatalog)
+      .set({
+        base_url: desired.base_url,
+        endpoints: desired.endpoints,
+        deprecated_at: desired.deprecated_at,
+        description: desired.description,
+      })
+      .where(eq(schema.apiCatalog.id, id))
+      .run();
+    patched += 1;
+  }
+
+  return patched;
+}
+
 export function ensureCatalogEntries(db: SqliteDb): { inserted: number; corrected: number } {
-  const rows = catalogData as unknown as (typeof schema.apiCatalog.$inferInsert)[];
+  const rows = catalogData as unknown as CatalogSeedRow[];
 
   const existingIds = new Set(
     db
@@ -47,5 +144,13 @@ export function ensureCatalogEntries(db: SqliteDb): { inserted: number; correcte
     )
     .run();
 
-  return { inserted: missing.length, corrected: res.changes ?? 0 };
+  const nameCorrected = res.changes ?? 0;
+  const structuralCorrected = applyStructuralPatches(db, rows);
+
+  return { inserted: missing.length, corrected: nameCorrected + structuralCorrected };
+}
+
+/** 테스트·문서용: 구조 패치 대상 id 목록 */
+export function listStructuralPatchIds(): readonly string[] {
+  return STRUCTURAL_PATCH_IDS;
 }


### PR DESCRIPTION
사고 대응 2단계. [#270](https://github.com/xzawed/CustomWebService/pull/270)이 게이트를 고쳤고, 이 PR은 **게이트가 걸러낸 실제 불일치**를 고친다.

모든 값은 2026-08-05에 **실제 API를 호출해** 확인했다.

## 카탈로그 6건

| API | 문제 | 조치 | 확인 |
|---|---|---|---|
| **TourAPI** | `KorService1` **폐기**(code 12) | `KorService2` + `areaBasedList2`/`searchKeyword2`, 필수 `MobileOS`·`MobileApp`·`_type` 선언 | 431건 · 10건 |
| **기상청 단기예보** | `dataType` 미선언 → **XML로 응답** | 선언 추가 | 907건 |
| **기상청 중기예보** | `tmFc` 제약 미기재 | 과거 `0600`/`1800` 슬롯만 유효함을 명시 | — (아래) |
| **에어코리아** | `returnType`·`pageNo` 미선언 → **HTTP 504** | 둘 다 필수로 명시 | 23건 |
| **국토부 전월세** | **XML 전용**인데 미기재 | `res.json()` 금지 명시 + 잘못된 `LAWD_CD`가 `000`+빈결과로 조용히 넘어가는 함정 기록 | 981건 |
| **식약처** | 서비스 폐기(code 12), 후속 6종 프로브 전부 12 | `deprecated_at` 설정 (오너 결정) | — |

`example_call`은 **61개 중 1개뿐**이었다. 이 값은 프로브(`buildTestUrl`이 최우선 반영)와 생성 프롬프트(`★ exampleCall (그대로 사용하라)`)가 **함께** 쓰므로 검증과 코드 생성이 동시에 개선된다. 6개 중 5개는 `example_call`을 그대로 호출해 **데이터까지** 확인했다.

## 중기예보의 만료된 예시 날짜는 의도된 것이다

`tmFc`는 최근 슬롯만 유효해 **어떤 고정 날짜도 하루면 만료**된다. 실제로 어제 검증한 슬롯이 오늘 `NO_DATA(03)`가 됐다.

그렇다고 빼면 안 된다 — 실측 확인:

```
tmFc 없이 호출 → {"header":{"resultCode":"11","resultMsg":"NO_MANDATORY_REQUEST_PARAMETERS_ERROR"}}
```

`11`은 허용목록에 없어 **키 검증이 실패하고 활성화 자체가 불가능**해진다. 만료된 예시를 남기면 `03`(NO_DATA·허용)이라 활성화는 되고, 실제 호출은 AI가 런타임에 계산한 값을 쓴다.

→ 나중에 "만료됐으니 지우자"가 나오지 않도록 **파라미터 설명에 못박았다.**

## 부팅 시 구조 동기화 — 이게 없으면 프로덕션은 안 바뀐다

`apiCatalog.json`은 **시드일 뿐**이다. `seedCatalog`는 빈 테이블에서만 돌고 `ensureCatalogEntries`는 신규 삽입 + `['Dog API','Lorem Picsum']` 이름 보정이 전부다. **JSON만 고치면 기존 프로덕션 행은 그대로 `KorService1`에 머문다.**

`STRUCTURAL_PATCH_IDS`(6건)에 대해 `base_url`·`endpoints`·`deprecated_at`·`description`만 번들과 동기화한다.

> ⚠️ **`is_active`·`verification_status`는 읽지도 쓰지도 않는다.** 재배포가 오퍼레이터의 활성/비활성 판단을 조용히 되돌리면 안 된다. `ensureFeatureFlags`가 `enabled`를 덮어쓰지 않는 것과 **같은 이유**이며, 회귀 테스트로 고정했다.

기존 Dog/Picsum 보정 블록(`is_active: true`를 쓰는 유일한 곳)은 손대지 않았다.

## 검증

| 항목 | 결과 |
|---|---|
| `example_call` 라이브 호출 | **5/6 데이터 확인** (중기예보는 위 사유로 `03`) |
| JSON 변경 범위 | **61 → 61개, 정확히 6개 엔트리만** |
| `ensureCatalog` 회귀 | 2차 부팅 no-op · 번들과 달라도 `is_active`/`verification_status` 보존 |
| `pnpm lint` / `type-check` | 0 errors / 통과 |
| `pnpm test` | **194 파일 2467 테스트 전건 통과** |

## 배포 후 절차

1. 부팅 시 구조 패치가 적용된다 (로그의 `corrected` 확인)
2. `GET /admin/keys-verify?includeInactive=true` — **강화된 게이트로** 재검증
3. 통과한 것만 `POST /admin/catalog/activate`

TAGO·아파트 실거래가는 `code 30`(키 미승인)이라 **코드로 해결할 수 없다** — data.go.kr 활용신청이 필요하다.

## 협업

설계·실측·라이브 검증·최종 리뷰는 Claude, 구현은 Grok Build(subscription).

🤖 Generated with [Claude Code](https://claude.com/claude-code)