### PR TITLE
fix: 불안정 API 정리 — 실측 기반 폐기·엔드포인트 제거·캐시 TTL 부여

### DIFF
--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -424,14 +424,30 @@ data.go.kr 등 구조 정정이 필요한 id는 `ensureCatalog.ts`의 `STRUCTURA
 
 | 동기화 | 비동기화 (절대 덮어쓰지 않음) |
 |--------|-------------------------------|
-| `base_url`, `endpoints`, `deprecated_at`, `description` | **`is_active`**, **`verification_status`** |
+| `base_url`, `endpoints`, `deprecated_at`, `description`, **`cache_ttl_seconds`** | **`is_active`**, **`verification_status`** |
 
 - **왜 `is_active`를 빼는가:** 재배포가 번들의 `is_active`로 기존 행을 덮어쓰면
   오퍼레이터의 활성/비활성 판단이 조용히 롤백된다. `ensureFeatureFlags`가 기존 행의
   `enabled`를 덮어쓰지 않는 것과 **같은 전례**.
+- **왜 `cache_ttl_seconds`를 넣는가:** 프록시 응답 캐시 TTL은 코드/시드 소유 설정이다.
+  번들에만 넣고 구조 패치에서 빼면 이미 채워진 프로덕션 행에 TTL이 **영원히 반영되지 않는다**
+  (2026-08-05 실측: ZenQuotes·에어코리아 TTL 부여가 이 경로 없이는 silent no-op).
 - 목록은 명시·최소 — 전체 테이블 덮어쓰기 금지. 값이 이미 일치하면 no-op
   (`corrected`에 포함되지 않음). 반환 형태는 `{ inserted, corrected }`
   (이름 정정 + 구조 패치 합산).
+
+##### 폐기(deprecation)는 2단계 — `deprecated_at` 만으로는 프록시가 안 끊긴다
+
+| 단계 | 무엇 | 효과 |
+|------|------|------|
+| 1. 구조 패치 | 번들 JSON + `STRUCTURAL_PATCH_IDS`에 `deprecated_at`(·설명) | 카탈로그 브라우징·추천에서 제외 (`findMany`: `is_active AND deprecated_at IS NULL`) |
+| 2. 런타임 비활성 | 배포 후 `POST /api/v1/admin/catalog/deactivate` | `is_active=false` — **프록시가 여기서만 차단** |
+
+근거: `src/app/api/v1/proxy/route.ts`는 `api.isActive`만 검사한다. `deprecated_at`이
+찍혀 있어도 `is_active=true`면 게시 사이트·미리보기가 계속 업스트림을 호출한다.
+구조 패치가 `is_active`를 쓰지 않는 불변조건과 맞물려 **완전한 폐기는 항상 수동
+deactivate가 한 번 더 필요하다.** (자동 폐기 스케줄러 없음 — 일시 업스트림 장애로
+건강한 API가 꺼지는 것을 막기 위함. 절차는 [operations.md](../guides/operations.md).)
 
 > **`seedAdminUser`는 제거됨**: 공개 다중 사용자 전환(2026-06-24)으로 env 단일 관리자 시드가 불필요해졌다. 신규 환경은 `/signup`으로 첫 사용자를 생성한다.
 

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -70,8 +70,39 @@ curl -sS -H "Authorization: Bearer $ADMIN_API_KEY" \
 
 - **“활성 N개” 고정 문구를 문서/대시보드에 박지 않는다.** 진실원은 DB(`api_catalog.is_active`)이며 랜딩 카피도 `getActiveApiCount()`로 읽는다.
 - 운영 확인: `GET /api/v1/admin/catalog-dump` → `data.summary`.
-- 번들 시드 [`src/data/apiCatalog.json`](../../src/data/apiCatalog.json) 기준(이 문서 작성 시 로컬 검증): **총 61 · 활성 36 · 비활성 25**. 프로덕션은 배포·ensureCatalog·수동 변경으로 달라질 수 있다.
+- 번들 시드 [`src/data/apiCatalog.json`](../../src/data/apiCatalog.json) 기준(2026-08-05 로컬 검증): **총 61**. 활성/비활성 수는 배포·ensureCatalog·수동 변경으로 달라지므로 **dump의 `summary`를 본다** (disease.sh 폐기 후 번들 기준 활성 약 35·비활성 약 26).
 - `supabase/seed.sql` **삭제됨**. 시드는 부팅 시 빈 테이블일 때만 JSON 삽입 + `ensureCatalogEntries` 멱등 반영. 절차 세부는 컷오버 ADR·[역사 런북](../archive/guides/sqlite-cutover-runbook.md).
+
+### 1.5 API 폐기 런북 (수동 전용 — 자동 폐기 없음)
+
+> **원칙:** 불안정한 서비스는 없느니만 못하다. 다만 **자동으로 `deprecated_at`/`is_active`를 바꾸는 스케줄러는 두지 않는다.**  
+> 짧은 샘플·일시 업스트림 장애로 “건강한 API를 죽인” 오판이 이미 있었다(2026-08-05: 5회 샘플이 12회 샘플과 어긋남 — ZenQuotes는 429 버스트, Jikan/OFF는 엔드포인트 1개만 문제). 임계값 데이터 없이 자동화하면 같은 오판이 기계 속도로 반복된다.
+
+**완전한 폐기 = 2단계** (구조 패치만으로는 프록시가 안 끊김):
+
+| 단계 | 작업 | 효과 |
+|------|------|------|
+| 1. 코드 | `src/data/apiCatalog.json`에 `deprecated_at`·설명·`is_active:false`(미러)·필요 시 엔드포인트 정리 + `ensureCatalog.ts`의 `STRUCTURAL_PATCH_IDS`에 id 등록 | 배포 부팅 시 `deprecated_at`·endpoints·`cache_ttl_seconds` 등 **구조 필드만** 동기화. **`is_active`는 구조 패치가 쓰지 않음** |
+| 2. 배포 후 런타임 | `POST /api/v1/admin/catalog/deactivate` `{ "apiIds": ["…"] }` | `is_active=false` — **프록시 차단** (`proxy/route.ts`는 `api.isActive`만 검사) |
+
+```bash
+# 배포 SUCCESS 확인 후 — disease.sh 예시
+curl -X POST "$APP_URL/api/v1/admin/catalog/deactivate" \
+  -H "Authorization: Bearer $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"apiIds":["bb29c4e4-e908-40f8-946a-6c9b9265fa6c"]}'
+```
+
+**엔드포인트만 죽은 경우 (API 전체 유지):** 번들에서 해당 path만 제거하고 id를 `STRUCTURAL_PATCH_IDS`에 넣는다. 예: Jikan `/v4/top/anime`, Open Food Facts `/cgi/search.pl`. 전체를 폐기하지 않는다.
+
+**플래키·레이트리밋인 경우 (폐기 금지):** `cache_ttl_seconds`를 번들에 넣고 구조 패치로 동기화한다. 예: ZenQuotes 120s(짧은 TTL — 장시간 캐시는 “랜덤” 제품 의미를 깨뜨림), 에어코리아 3600(시간 단위 데이터·Open-Meteo AQ와 동일). TTL만 JSON에 넣고 구조 목록에 id·필드가 없으면 **프로덕션에 영원히 안 먹는다**.
+
+**하지 말 것:**
+- `verify-catalog` broken → 자동 deactivate/deprecate 연결
+- 한두 번의 5xx만으로 전체 API 폐기 (엔드포인트 단위·샘플 폭을 먼저 볼 것)
+- 구조 패치 없이 번들만 고치고 “배포됐으니 프로덕션도 반영됐겠지” 가정
+
+상세 필드 표·불변조건: [database.md §ensureCatalogEntries](../architecture/database.md).
 
 ---
 

--- a/src/data/apiCatalog.json
+++ b/src/data/apiCatalog.json
@@ -883,7 +883,7 @@
   {
     "id": "4c6f5228-e6ec-45bb-b0bb-e947dcdeb1c1",
     "name": "ZenQuotes",
-    "description": "명언·격언 랜덤 표시. 오늘의 한마디, 동기부여 화면을 만들 때 좋아요. HTTPS 지원, 무료, 인증 불필요.",
+    "description": "명언·격언 랜덤 표시. 오늘의 한마디, 동기부여 화면을 만들 때 좋아요. HTTPS 지원, 무료, 인증 불필요. ⚠️ 2026-08-05: cache_ttl_seconds=120. 무작위 인용구인데 캐시하면 TTL 동안 모든 방문자가 같은 문구를 본다. 그럼에도 캐시가 없으면 429가 나서 아무것도 안 보인다 — 실측 200×5 → 429×6 → 200(버스트; 직접 호출은 정상). 장시간 TTL(예: 3600)은 제품 의미가 깨지므로 짧은 값만 사용.",
     "category": "fun",
     "base_url": "https://zenquotes.io/api",
     "auth_type": "none",
@@ -923,7 +923,7 @@
     "cors_supported": false,
     "requires_proxy": true,
     "credit_required": null,
-    "cache_ttl_seconds": null,
+    "cache_ttl_seconds": 120,
     "verification_status": "verified",
     "verified_at": "2026-06-22T21:41:04.914+00:00",
     "last_verification_note": "2026-06-22 자동 헬스체크: degraded",
@@ -2470,7 +2470,7 @@
   {
     "id": "c84860a1-336c-45f1-b1df-00f25bd810bd",
     "name": "에어코리아 대기오염정보",
-    "description": "대기오염 측정 정보. 측정소별 미세먼지·초미세먼지·오존 등 실시간 조회. ⚠️ 개발계정 일일 한도 500건 (타 공공API 10,000건의 1/20). (공공데이터포털 키 필요)",
+    "description": "대기오염 측정 정보. 측정소별 미세먼지·초미세먼지·오존 등 실시간 조회. ⚠️ 개발계정 일일 한도 500건 (타 공공API 10,000건의 1/20). (공공데이터포털 키 필요) ⚠️ 2026-08-05: cache_ttl_seconds=3600(Open-Meteo Air Quality와 동일·시간 단위 데이터). 실측 83%(10/12, HTTP 504 2회) · rate_limit 500/일인데 캐시가 없어 방문자마다 업스트림을 쳤다. 간헐 504는 있으나 호스트 자체는 살아 있어 폐기하지 않음. 활성화는 admin activate로만.",
     "category": "weather",
     "base_url": "https://apis.data.go.kr/B552584/ArpltnInforInqireSvc",
     "auth_type": "api_key",
@@ -2514,7 +2514,7 @@
     "cors_supported": false,
     "requires_proxy": true,
     "credit_required": null,
-    "cache_ttl_seconds": null,
+    "cache_ttl_seconds": 3600,
     "verification_status": "unverified",
     "verified_at": "2026-05-01T04:29:30.77912+00:00",
     "last_verification_note": "2026-05-01: HTTPS 전환. 개발계정 500건/일은 타 API 대비 매우 낮음. 운영계정 신청 권장.\n2026-05-01: API 키 등록 필요 — 즉시 사용 불가 기준으로 비활성화.",
@@ -2728,7 +2728,7 @@
   {
     "id": "6c31e6c8-0c29-44d0-98cd-0fd579ab6cb6",
     "name": "Jikan (MyAnimeList)",
-    "description": "애니메이션·만화 정보(평점, 줄거리, 캐릭터)를 MyAnimeList 기반으로 제공해요. 애니 추천·검색 앱에 좋아요. 오픈소스·키 불필요.",
+    "description": "애니메이션·만화 정보(평점, 줄거리, 캐릭터)를 MyAnimeList 기반으로 제공해요. 애니 추천·검색 앱에 좋아요. 오픈소스·키 불필요. ⚠️ 2026-08-05: `/v4/top/anime` 제거 — 실측 12/12 HTTP 504(\"Jikan failed to connect to MyAnimeList\"). 단건 조회(`/v4/anime/1`)는 100% 정상(p50 1.0s)이라 API 전체는 유지. 최악-엔드포인트 집계만으로 전체를 폐기하지 않음.",
     "category": "entertainment",
     "base_url": "https://api.jikan.moe",
     "auth_type": "none",
@@ -2755,14 +2755,6 @@
           "page": "number"
         },
         "description": "키워드로 애니 검색"
-      },
-      {
-        "path": "/v4/top/anime",
-        "method": "GET",
-        "parameters": {
-          "page": "number"
-        },
-        "description": "인기 애니 랭킹"
       }
     ],
     "tags": [
@@ -2788,7 +2780,7 @@
   {
     "id": "e0043eeb-749a-4890-94de-840d1a0c6164",
     "name": "Open Food Facts",
-    "description": "전 세계 식품 바코드로 제품명·성분·영양정보·등급을 알려줘요. 식품·건강·다이어트 앱에 좋아요. 오픈데이터·키 불필요.",
+    "description": "전 세계 식품 바코드로 제품명·성분·영양정보·등급을 알려줘요. 식품·건강·다이어트 앱에 좋아요. 오픈데이터·키 불필요. ⚠️ 2026-08-05: `/cgi/search.pl` 제거 — 카탈로그 선언 파라미터가 프로브에 주입되지 않아 HTML 200이 나오거나, search_terms+json=1로 호출해도 503. 제품 조회(`/api/v2/product/...`)는 100% 정상. 검색 경로는 업스트림이 안정된 뒤에만 재등록.",
     "category": "data",
     "base_url": "https://world.openfoodfacts.org",
     "auth_type": "none",
@@ -2807,15 +2799,6 @@
           "fields": "string"
         },
         "description": "바코드로 제품 조회 (경로의 숫자를 바코드로 변경)"
-      },
-      {
-        "path": "/cgi/search.pl",
-        "method": "GET",
-        "parameters": {
-          "search_terms": "string",
-          "json": "number"
-        },
-        "description": "제품명 검색 (json=1 필요)"
       }
     ],
     "tags": [
@@ -2895,14 +2878,14 @@
   {
     "id": "bb29c4e4-e908-40f8-946a-6c9b9265fa6c",
     "name": "disease.sh (세계 통계)",
-    "description": "나라별·세계 코로나19 및 보건 통계를 제공해요. 통계 위젯·지도 시각화에 좋아요. 오픈소스·키 불필요.",
+    "description": "나라별·세계 코로나19 및 보건 통계를 제공해요. 통계 위젯·지도 시각화에 좋아요. 오픈소스·키 불필요. ⚠️ 2026-08-05 실측: 두 엔드포인트 모두 12/12 HTTP 502(Cloudflare). 업스트림 사망으로 폐기. 후속 API 없음. 행은 이력 보존을 위해 삭제하지 않음.",
     "category": "data",
     "base_url": "https://disease.sh",
     "auth_type": "none",
     "auth_config": {},
     "rate_limit": null,
     "changelog": [],
-    "is_active": true,
+    "is_active": false,
     "icon_url": null,
     "docs_url": "https://disease.sh/docs/",
     "endpoints": [
@@ -2930,7 +2913,7 @@
       "no-auth"
     ],
     "api_version": null,
-    "deprecated_at": null,
+    "deprecated_at": "2026-08-05T00:00:00.000Z",
     "successor_id": null,
     "cors_supported": true,
     "requires_proxy": false,

--- a/src/lib/db/sqlite/ensureCatalog.test.ts
+++ b/src/lib/db/sqlite/ensureCatalog.test.ts
@@ -11,6 +11,11 @@ const rows = catalogData as unknown as InsertRow[];
 
 const TOUR_API_ID = 'c76876b5-a4d8-49cf-a0c9-0240daf3eb5e';
 const FOOD_NTR_ID = 'f45de6c5-95e6-4c4a-989e-c60b060a9c7c';
+const DISEASE_SH_ID = 'bb29c4e4-e908-40f8-946a-6c9b9265fa6c';
+const JIKAN_ID = '6c31e6c8-0c29-44d0-98cd-0fd579ab6cb6';
+const OFF_ID = 'e0043eeb-749a-4890-94de-840d1a0c6164';
+const ZENQUOTES_ID = '4c6f5228-e6ec-45bb-b0bb-e947dcdeb1c1';
+const AIRKOREA_ID = 'c84860a1-336c-45f1-b1df-00f25bd810bd';
 
 describe('ensureCatalogEntries', () => {
   let db: SqliteDb;
@@ -140,15 +145,141 @@ describe('ensureCatalogEntries', () => {
     expect(after?.is_active).toBe(true);
     expect(after?.verification_status).toBe('broken');
   });
+
+  it('구조 패치가 cache_ttl_seconds 를 번들과 동기화한다', () => {
+    const zen = rows.find((x) => x.id === ZENQUOTES_ID)!;
+    expect(zen.cache_ttl_seconds).toBe(120);
+
+    db.insert(schema.apiCatalog)
+      .values({
+        ...zen,
+        cache_ttl_seconds: null, // 프로덕션에 TTL 없던 상태
+        description: '구 설명',
+      })
+      .run();
+
+    const r1 = ensureCatalogEntries(db);
+    expect(r1.corrected).toBeGreaterThanOrEqual(1);
+
+    const after = db
+      .select()
+      .from(schema.apiCatalog)
+      .where(eq(schema.apiCatalog.id, ZENQUOTES_ID))
+      .get();
+    expect(after?.cache_ttl_seconds).toBe(120);
+    expect(after?.description).toBe(zen.description);
+
+    const r2 = ensureCatalogEntries(db);
+    expect(r2.corrected).toBe(0);
+  });
+
+  it('disease.sh: deprecated_at 반영 · is_active·verification_status 보존 (프록시 차단은 deactivate 2단계)', () => {
+    const disease = rows.find((x) => x.id === DISEASE_SH_ID)!;
+    expect(disease.deprecated_at).toBe('2026-08-05T00:00:00.000Z');
+    expect(disease.is_active).toBe(false);
+
+    db.insert(schema.apiCatalog)
+      .values({
+        ...disease,
+        deprecated_at: null,
+        description: '구 설명',
+        is_active: true, // 아직 활성 — 구조 패치가 끄면 안 됨
+        verification_status: 'verified',
+      })
+      .run();
+
+    ensureCatalogEntries(db);
+
+    const after = db
+      .select()
+      .from(schema.apiCatalog)
+      .where(eq(schema.apiCatalog.id, DISEASE_SH_ID))
+      .get();
+    expect(after?.deprecated_at).toBe('2026-08-05T00:00:00.000Z');
+    expect(after?.description).toBe(disease.description);
+    // proxy/route.ts 는 isActive 만 본다 — 구조 패치가 true를 유지해야 2단계 폐기가 성립
+    expect(after?.is_active).toBe(true);
+    expect(after?.verification_status).toBe('verified');
+  });
+
+  it('Jikan 엔드포인트에서 /v4/top/anime 가 제거되고 구조 패치로 반영된다', () => {
+    const jikan = rows.find((x) => x.id === JIKAN_ID)!;
+    const paths = (jikan.endpoints as { path: string }[]).map((e) => e.path);
+    expect(paths).not.toContain('/v4/top/anime');
+    expect(paths).toEqual(['/v4/anime/1', '/v4/anime']);
+
+    db.insert(schema.apiCatalog)
+      .values({
+        ...jikan,
+        endpoints: [
+          { path: '/v4/anime/1', method: 'GET' },
+          { path: '/v4/anime', method: 'GET' },
+          { path: '/v4/top/anime', method: 'GET' }, // 구 프로덕션 행
+        ],
+        description: '구 설명',
+      })
+      .run();
+
+    ensureCatalogEntries(db);
+
+    const after = db
+      .select()
+      .from(schema.apiCatalog)
+      .where(eq(schema.apiCatalog.id, JIKAN_ID))
+      .get();
+    const afterPaths = (after?.endpoints as { path: string }[]).map((e) => e.path);
+    expect(afterPaths).not.toContain('/v4/top/anime');
+    expect(afterPaths).toEqual(['/v4/anime/1', '/v4/anime']);
+  });
+
+  it('Open Food Facts 엔드포인트에서 /cgi/search.pl 이 제거되고 구조 패치로 반영된다', () => {
+    const off = rows.find((x) => x.id === OFF_ID)!;
+    const paths = (off.endpoints as { path: string }[]).map((e) => e.path);
+    expect(paths).not.toContain('/cgi/search.pl');
+    expect(paths).toEqual(['/api/v2/product/737628064502.json']);
+
+    db.insert(schema.apiCatalog)
+      .values({
+        ...off,
+        endpoints: [
+          { path: '/api/v2/product/737628064502.json', method: 'GET' },
+          { path: '/cgi/search.pl', method: 'GET' },
+        ],
+        description: '구 설명',
+      })
+      .run();
+
+    ensureCatalogEntries(db);
+
+    const after = db
+      .select()
+      .from(schema.apiCatalog)
+      .where(eq(schema.apiCatalog.id, OFF_ID))
+      .get();
+    const afterPaths = (after?.endpoints as { path: string }[]).map((e) => e.path);
+    expect(afterPaths).not.toContain('/cgi/search.pl');
+    expect(afterPaths).toEqual(['/api/v2/product/737628064502.json']);
+  });
 });
 
-describe('apiCatalog data.go.kr 구조 정정 (시드 데이터 회귀 방지)', () => {
-  it('6개 대상 항목이 기대 base_url·example_call·deprecated_at 을 갖는다', () => {
+describe('apiCatalog 구조 정정 (시드 데이터 회귀 방지)', () => {
+  it('구조 패치 대상 항목이 기대 base_url·endpoints·deprecated_at·cache_ttl 을 갖는다', () => {
     const byId = new Map(
       (catalogData as { id: string }[]).map((r) => [r.id, r as Record<string, unknown>]),
     );
 
-    expect(listStructuralPatchIds()).toHaveLength(6);
+    expect(listStructuralPatchIds()).toHaveLength(10);
+    expect(listStructuralPatchIds()).toEqual(
+      expect.arrayContaining([
+        TOUR_API_ID,
+        FOOD_NTR_ID,
+        DISEASE_SH_ID,
+        JIKAN_ID,
+        OFF_ID,
+        ZENQUOTES_ID,
+        AIRKOREA_ID,
+      ]),
+    );
 
     const tour = byId.get(TOUR_API_ID)!;
     expect(tour.base_url).toBe('https://apis.data.go.kr/B551011/KorService2');
@@ -172,12 +303,13 @@ describe('apiCatalog data.go.kr 구조 정정 (시드 데이터 회귀 방지)',
     );
     expect(midEp?.responseDataPath).toBe('response.body.items.item');
 
-    const air = byId.get('c84860a1-336c-45f1-b1df-00f25bd810bd')!;
+    const air = byId.get(AIRKOREA_ID)!;
     const airEp = (air.endpoints as { example_call?: string; responseDataPath?: string }[])[0];
     expect(airEp?.example_call).toBe(
       '/getMsrstnAcctoRltmMesureDnsty?stationName=종로구&dataTerm=DAILY&returnType=json&ver=1.0&pageNo=1&numOfRows=10',
     );
     expect(airEp?.responseDataPath).toBe('response.body.items');
+    expect(air.cache_ttl_seconds).toBe(3600);
 
     const molit = byId.get('17665554-5a7c-4df0-91a7-826dab855f05')!;
     expect(String(molit.description)).toMatch(/XML/);
@@ -191,5 +323,32 @@ describe('apiCatalog data.go.kr 구조 정정 (시드 데이터 회귀 방지)',
     expect(food.successor_id).toBeNull();
     expect(food.is_active).toBe(false);
     expect(String(food.description)).toMatch(/폐기|code 12|대체/);
+
+    const disease = byId.get(DISEASE_SH_ID)!;
+    expect(disease.deprecated_at).toBe('2026-08-05T00:00:00.000Z');
+    expect(disease.successor_id).toBeNull();
+    expect(disease.is_active).toBe(false);
+    expect(String(disease.description)).toMatch(/502|Cloudflare|폐기/);
+
+    const jikan = byId.get(JIKAN_ID)!;
+    expect((jikan.endpoints as { path: string }[]).map((e) => e.path)).toEqual([
+      '/v4/anime/1',
+      '/v4/anime',
+    ]);
+    expect(String(jikan.description)).toMatch(/top\/anime|504/);
+
+    const off = byId.get(OFF_ID)!;
+    expect((off.endpoints as { path: string }[]).map((e) => e.path)).toEqual([
+      '/api/v2/product/737628064502.json',
+    ]);
+    expect(String(off.description)).toMatch(/search\.pl|503/);
+
+    const zen = byId.get(ZENQUOTES_ID)!;
+    expect(zen.cache_ttl_seconds).toBe(120);
+    expect(String(zen.description)).toMatch(/429|캐시|TTL/);
+  });
+
+  it('apiCatalog 총 항목 수는 61 (행 삭제 없이 구조만 변경)', () => {
+    expect((catalogData as unknown[]).length).toBe(61);
   });
 });

--- a/src/lib/db/sqlite/ensureCatalog.ts
+++ b/src/lib/db/sqlite/ensureCatalog.ts
@@ -14,27 +14,38 @@ import catalogData from '@/data/apiCatalog.json';
  *     (Dog API, Lorem Picsum → is_active=true, verification_status=verified).
  *     이미 올바른 상태면 갱신하지 않는다(향후 헬스체크 갱신과 충돌 최소화).
  *  3) id 화이트리스트의 **구조 필드만** 번들 JSON과 맞춘다
- *     (`base_url` · `endpoints` · `deprecated_at` · `description`).
+ *     (`base_url` · `endpoints` · `deprecated_at` · `description` · `cache_ttl_seconds`).
  *
  * 멱등: 두 번째 호출부턴 inserted=0, corrected=0.
  */
 const CORRECTIONS = ['Dog API', 'Lorem Picsum'];
 
 /**
- * data.go.kr 등 구조 정정이 필요한 카탈로그 id 목록(명시·최소).
+ * 구조 정정이 필요한 카탈로그 id 목록(명시·최소).
  * 값은 번들 JSON에서 읽어 오며, 전체 테이블 덮어쓰기는 하지 않는다.
  *
  * ⚠️ is_active·verification_status 는 절대 건드리지 않는다.
  * 재배포가 is_active를 덮어쓰면 오퍼레이터의 활성/비활성 판단이 조용히 롤백된다.
  * ensureFeatureFlags가 기존 행의 enabled를 덮어쓰지 않는 것과 같은 전례.
+ *
+ * ⚠️ 폐기(deprecation)는 2단계다.
+ * 구조 패치는 `deprecated_at`만 동기화한다. 브라우징·추천은 `deprecated_at IS NULL`로
+ * 가려지지만, 프록시는 `proxy/route.ts`에서 `api.isActive`만 본다 — `deprecated_at`만
+ * 찍혀 있고 `is_active=true`면 게시 사이트가 계속 업스트림을 친다.
+ * 완전한 폐기는 (1) 번들 JSON + STRUCTURAL_PATCH_IDS 로 `deprecated_at`/설명 반영
+ * → 배포 후 (2) `POST /api/v1/admin/catalog/deactivate` 로 `is_active=false` 를 따로 건다.
  */
 const STRUCTURAL_PATCH_IDS: readonly string[] = [
   'c76876b5-a4d8-49cf-a0c9-0240daf3eb5e', // 한국관광공사 TourAPI → KorService2
   '7cb8f428-e284-4eee-944a-af47274662d2', // 기상청 단기예보 (example_call·파라미터 제약)
   '00412c2b-6c17-4b23-9a3d-46b7004285e4', // 기상청 중기예보 (tmFc 과거 슬롯)
-  'c84860a1-336c-45f1-b1df-00f25bd810bd', // 에어코리아 (returnType·pageNo 필수)
+  'c84860a1-336c-45f1-b1df-00f25bd810bd', // 에어코리아 (returnType·pageNo 필수 · cache_ttl)
   '17665554-5a7c-4df0-91a7-826dab855f05', // 국토부 아파트 전월세 (XML 전용)
   'f45de6c5-95e6-4c4a-989e-c60b060a9c7c', // 식약처 식품영양성분 (폐기)
+  'bb29c4e4-e908-40f8-946a-6c9b9265fa6c', // disease.sh (폐기 — 12/12 502)
+  '6c31e6c8-0c29-44d0-98cd-0fd579ab6cb6', // Jikan (/v4/top/anime 제거)
+  'e0043eeb-749a-4890-94de-840d1a0c6164', // Open Food Facts (/cgi/search.pl 제거)
+  '4c6f5228-e6ec-45bb-b0bb-e947dcdeb1c1', // ZenQuotes (cache_ttl 120)
 ];
 
 type CatalogSeedRow = typeof schema.apiCatalog.$inferInsert;
@@ -44,6 +55,7 @@ type StructuralFields = {
   endpoints: unknown[] | null;
   deprecated_at: string | null;
   description: string | null;
+  cache_ttl_seconds: number | null;
 };
 
 function pickStructural(row: CatalogSeedRow): StructuralFields {
@@ -52,6 +64,10 @@ function pickStructural(row: CatalogSeedRow): StructuralFields {
     endpoints: (row.endpoints as unknown[] | null | undefined) ?? null,
     deprecated_at: row.deprecated_at ?? null,
     description: row.description ?? null,
+    cache_ttl_seconds:
+      row.cache_ttl_seconds === undefined || row.cache_ttl_seconds === null
+        ? null
+        : Number(row.cache_ttl_seconds),
   };
 }
 
@@ -62,12 +78,18 @@ function sameStructural(
     endpoints: unknown;
     deprecated_at: string | null;
     description: string | null;
+    cache_ttl_seconds: number | null;
   },
 ): boolean {
+  const currentTtl =
+    current.cache_ttl_seconds === undefined || current.cache_ttl_seconds === null
+      ? null
+      : Number(current.cache_ttl_seconds);
   return (
     (desired.base_url ?? null) === (current.base_url ?? null) &&
     (desired.deprecated_at ?? null) === (current.deprecated_at ?? null) &&
     (desired.description ?? null) === (current.description ?? null) &&
+    (desired.cache_ttl_seconds ?? null) === currentTtl &&
     JSON.stringify(desired.endpoints ?? null) === JSON.stringify(current.endpoints ?? null)
   );
 }
@@ -90,6 +112,7 @@ function applyStructuralPatches(db: SqliteDb, rows: CatalogSeedRow[]): number {
         endpoints: schema.apiCatalog.endpoints,
         deprecated_at: schema.apiCatalog.deprecated_at,
         description: schema.apiCatalog.description,
+        cache_ttl_seconds: schema.apiCatalog.cache_ttl_seconds,
       })
       .from(schema.apiCatalog)
       .where(eq(schema.apiCatalog.id, id))
@@ -100,12 +123,14 @@ function applyStructuralPatches(db: SqliteDb, rows: CatalogSeedRow[]): number {
     if (sameStructural(desired, current)) continue;
 
     // is_active·verification_status 를 set에 넣지 않는다 — 오퍼레이터 판단을 보존.
+    // 폐기 시 is_active=false 는 admin/catalog/deactivate 로 별도 적용.
     db.update(schema.apiCatalog)
       .set({
         base_url: desired.base_url,
         endpoints: desired.endpoints,
         deprecated_at: desired.deprecated_at,
         description: desired.description,
+        cache_ttl_seconds: desired.cache_ttl_seconds,
       })
       .where(eq(schema.apiCatalog.id, id))
       .run();


### PR DESCRIPTION
> **"불안정한 서비스는 없느니만 못합니다. API도 일관된 품질을 유지못하면 폐기해주세요."** — 오너 방침

방침을 실측으로 집행하되, **표본 하나로 죽이지 않는다.**

## 5회 표본의 결론 중 둘이 12회 표본에서 뒤집혔다

성급히 폐기했으면 **멀쩡한 API를 죽일 뻔했다.** 활성 43개를 5회 돌려 의심 4건을 추린 뒤, 레이트리밋을 유발하지 않도록 15초 간격으로 12회 재측정했다.

| 대상 | 12회 결과 | 진짜 원인 |
|---|---|---|
| disease.sh (두 엔드포인트) | **0%** — 12/12 `502` Cloudflare | 업스트림 사망 |
| Jikan `/v4/top/anime` | **0%** — 12/12 `504` *"failed to connect to MyAnimeList"* | **이 엔드포인트만** |
| Jikan `/v4/anime/1` | **100%**, p50 1.0초 | 정상 |
| ZenQuotes `/random` | 50% — 실패가 **전부 `429`** (`200×5 → 429×6 → 200`) | **고장 아님, 레이트리밋** |
| OpenFoodFacts 상품조회 | **100%** | 정상 |
| 에어코리아 (키 사용, 8초 간격) | **83%** — `504` 2회 연속, p50 **94ms** | 간헐적 |

## 왜 판정이 갈렸나

**`summarizeApi`가 최악값을 취한다.** 엔드포인트 하나가 죽으면 API 전체가 `broken`이 된다. Jikan과 Open Food Facts가 정확히 그 경우였다 — API는 멀쩡한데 죽은 엔드포인트 하나 때문에 통째로 고장으로 보였다. **그래서 API 단위가 아니라 엔드포인트 단위로 조치한다.**

**ZenQuotes는 제 측정이 만든 가짜 신호였다.** 직접 호출은 정상이고 실패는 전부 `429`다. 반복 측정 자체가 원인이었을 수 있다. 이걸 폐기 근거로 쓸 뻔했다.

## 조치

| API | 조치 | 근거 |
|---|---|---|
| **disease.sh** | **폐기** (`deprecated_at` + `is_active=false`) | 살아 있는 엔드포인트가 없다 |
| **Jikan** | `/v4/top/anime`만 제거 | 나머지 100% — API는 유지 |
| **Open Food Facts** | `/cgi/search.pl` 제거 | 선언한 파라미터가 프로브에 도달하지도 않고, 올바르게 불러도 `503` |
| **ZenQuotes** | `cache_ttl_seconds: 120` | 무작위 인용구라 길게 캐시하면 제품이 깨지지만, 캐시가 없으면 `429`로 아무것도 안 보인다 |
| **에어코리아** | `cache_ttl_seconds: 3600` | 시간 단위 데이터인데 캐시가 없어 방문자마다 업스트림을 쳤다. `500/일` 한도에서 그 자체가 증폭 요인 |

## 놓칠 뻔한 것 — 폐기는 두 단계다

**`deprecated_at`만으로는 프록시가 막히지 않는다.**

```ts
// proxy/route.ts:332
if (!api || !api.isActive) { /* reject */ }
```

`deprecatedAt`을 보지 않으므로, 카탈로그 목록에서만 숨고 **이미 게시된 사이트는 계속 호출한다.** 완전한 폐기는 구조 패치(`deprecated_at`) + `admin/catalog/deactivate`(`is_active=false`) **두 단계**가 모두 필요하다. 주석과 런북에 못박았다.

## `cache_ttl_seconds`가 구조 동기화 대상이 아니었다

`StructuralFields`에 4개 필드뿐이라 **TTL 수정이 프로덕션에 도달하지 못한다.** 필드를 추가했다. `is_active`·`verification_status`를 건드리지 않는 규칙은 그대로이고 회귀 테스트도 유지된다.

## 자동 폐기는 만들지 않는다

일시적 업스트림 장애로 멀쩡한 API를 죽이게 된다. **이번 5회 vs 12회 사례가 그 위험을 그대로 보여준다** — 자동화했다면 ZenQuotes와 Jikan을 기계 속도로 죽였을 것이다. 판단은 사람이 하고, 운영 런북으로 절차만 남긴다.

## 검증

| 항목 | 결과 |
|---|---|
| JSON 변경 범위 | **61 → 61개, 정확히 5개 엔트리만** |
| 구조 패치 불변조건 | `is_active`·`verification_status` 여전히 불가침 (회귀 테스트) |
| `pnpm lint` / `type-check` | 0 errors / 통과 |
| `pnpm test` | **194 파일 2472 테스트 전건 통과** |

## 배포 후 조치

```bash
POST /api/v1/admin/catalog/deactivate
{ "apiIds": ["bb29c4e4-e908-40f8-946a-6c9b9265fa6c"] }   # disease.sh
```

구조 패치는 `deprecated_at`만 설정하므로, **deactivate를 돌려야 프록시가 실제로 막힌다.**

## 다음 (별도 PR)

**활성화 게이트가 1회만 샘플링한다** — 에어코리아가 그렇게 통과했다. 1회 프로브는 구조적으로 "일관된 품질"을 판정할 수 없다. N회 연속 성공을 요구하도록 바꾸는 작업을 후속 PR로 분리했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)