### PR TITLE
feat: 활성화 게이트를 연속 N회 검증으로 강화 (1회 샘플 → 3회)

### DIFF
--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -49,8 +49,8 @@ curl -sS -H "Authorization: Bearer $ADMIN_API_KEY" \
 | **GET** `/api/v1/admin/debug` | Node/플랫폼, **실제 적용 AI 모델**(`models.<task>.env` / `resolved` / **`fellBack`**), **이메일 설정 여부**(`email.configured` · `fromSet` · `fromDomain` — 값 자체는 비노출), standalone 필수 모듈 로드(`playwright-core`, `@anthropic-ai/sdk`, `better-sqlite3`, `drizzle-orm`) | **첫 진단.** 모델 env 변경 직후, 생성 500, 신규 가입자가 생성·배포 403일 때(`RESEND_API_KEY` 없으면 인증 메일이 no-op → `assertEmailVerified`가 막음) |
 | **GET** `/api/v1/admin/qc-stats?days=7` | 기간 내 생성 수·실패 수·실성공률, 구조/모바일/렌더링 QC 평균, Stage 스킵·Quality Loop 지표, 흔한 QC 실패 항목 | 생성 품질·실패율 추이. Slack 생성 실패 경보 후 원인 파악 |
 | **GET** `/api/v1/admin/site-proxy-stats?limit=50` | 게시 사이트(익명) 프록시 프로젝트별 허용/차단. **`blockedByIp` vs `blockedByProject` 구분** | 429 민원, 한도 조정 근거 수집. 인메모리 → **재시작 시 0**. `trackedProjects: 0`이면 아직 집계 트래픽 없음([#216](https://github.com/xzawed/CustomWebService/issues/216) 트리거 미충족 — **임의로 한도 바꾸지 말 것**) |
-| **GET** `/api/v1/admin/keys-verify` | 활성·플랫폼 키 의존 API의 env 키를 **배포 런타임에서** 실호출 검증(키 값 비노출) | 키 의존 API 재활성화 직후, 401 의심. **로컬/`railway run`은 sealed env 미주입** — 배포 환경에서만 유효 |
-| **POST** `/api/v1/admin/catalog/activate` | 비활성 키 의존 API를 **라이브 키 검증 VALID 시에만** 활성화 | 키 발급·env 등록 후 카탈로그에 다시 노출. `dryRun`으로 후보 확인 가능 |
+| **GET** `/api/v1/admin/keys-verify` | 활성·플랫폼 키 의존 API의 env 키를 **배포 런타임에서** 실호출 검증(키 값 비노출). **단발 프로브**(진단 전용) | 키 의존 API 재활성화 **전** 점검, 401 의심. **로컬/`railway run`은 sealed env 미주입** — 배포 환경에서만 유효. 쓰기 게이트가 아님 |
+| **POST** `/api/v1/admin/catalog/activate` | 비활성 키 의존 API를 **연속 N회 VALID**(기본 3·간격 2s) 일 때만 활성화 | 키 발급·env 등록 후 카탈로그에 다시 노출. `dryRun`으로 연속 검증만 확인 가능. 아래 §1.5.1 |
 | **POST** `/api/v1/admin/catalog/deactivate` | 지정 ID의 활성 API를 **키 검증 없이** 비활성화(`apiIds` 필수) | 장애·오시드·키 만료 API를 즉시 차단. `verificationStatus`는 보존. **생략=전부 끔 없음** |
 | **POST** `/api/v1/admin/verify-catalog` | 활성 API GET을 라이브 호출해 `verification_status` 갱신(`working/degraded→verified`, `broken→broken`, 변경 시에만 쓰기; `key_gated`/`unknown` 보존) | 카탈로그 이상 의심·시드 반영 후. **스케줄 없음 — 관리자 수동 트리거**(플래핑·무인 outbound 방지) |
 | **GET** `/api/v1/admin/catalog-dump` | 프로덕션 `api_catalog` 전체(활성·비활성) 안전 투영 + `summary.active`/`inactive` | “카탈로그가 몇 개?” **하드코딩 숫자를 믿지 말고 이 응답으로 확인**. 시드 JSON diff용 |
@@ -72,6 +72,33 @@ curl -sS -H "Authorization: Bearer $ADMIN_API_KEY" \
 - 운영 확인: `GET /api/v1/admin/catalog-dump` → `data.summary`.
 - 번들 시드 [`src/data/apiCatalog.json`](../../src/data/apiCatalog.json) 기준(2026-08-05 로컬 검증): **총 61**. 활성/비활성 수는 배포·ensureCatalog·수동 변경으로 달라지므로 **dump의 `summary`를 본다** (disease.sh 폐기 후 번들 기준 활성 약 35·비활성 약 26).
 - `supabase/seed.sql` **삭제됨**. 시드는 부팅 시 빈 테이블일 때만 JSON 삽입 + `ensureCatalogEntries` 멱등 반영. 절차 세부는 컷오버 ADR·[역사 런북](../archive/guides/sqlite-cutover-runbook.md).
+
+### 1.5.1 카탈로그 활성화 연속 검증 게이트
+
+`POST /admin/catalog/activate` 는 단발 200 으로 켜지 않는다. 한 번 프로브하면
+간헐 5xx(예: 에어코리아 실측 83%·연속 504)를 놓쳐 불안정한 API가 사용자에게 노출된다.
+
+| 항목 | 값 |
+|------|-----|
+| 구현 | `verifyApiKeyForActivation` (`keyCheck.ts`) — `verifyApiKey` 재사용 |
+| 기본 | **3회 연속 VALID**, 시도 간격 **2s** |
+| 조기 종료 | **첫 non-VALID 에서 중단** (남은 샘플 미실행) — 관리자 요청 시간 상한 |
+| `keys-verify` | **단발 유지** (진단 전용). 연속 검증은 activate(쓰기)만 |
+
+**`outcomes[].reason` 읽기:**
+
+| reason 예 | 의미 | 조치 |
+|-----------|------|------|
+| `키 검증 통과 (3/3)` | 연속 성공 → 활성화됨 | 없음 |
+| `dryRun — 키 검증 통과 (3/3)` | 연속 성공, DB 미기록 | `dryRun` 빼고 재호출 |
+| `키 검증 실패(INVALID) — 3회 중 0회 성공 (401)` | 키 거부 | env 키·prefix 점검 |
+| `키 검증 실패(ERROR) — 3회 중 2회 성공 (504)` | 간헐 업스트림 장애 | **지금은 켜지 않음**. 안정화 후 재시도 또는 폐기 검토 |
+| `키 검증 실패(RATE_LIMITED) — … (429)` | 키는 통과, 한도 초과 | **키가 틀린 게 아님** — 나중에 재시도. INVALID 로 해석 금지 |
+| `키 검증 실패(MISSING) — 환경변수 미설정` | env 비어 있음 | Railway 변수 값 확인 |
+
+`apiIds` 로 대상을 좁히면 벽시계 시간이 줄어든다. 전체 후보를 한 번에 돌릴 때는
+MISSING(fetch 없음)은 즉시 스킵되고, 실패 API는 1회에서 끝나므로 현실 상한은
+「프로브 대상 수 × (최대 3회 fetch + 2×2s 간격)」이다.
 
 ### 1.5 API 폐기 런북 (수동 전용 — 자동 폐기 없음)
 

--- a/src/__tests__/api/admin-catalog-activate.test.ts
+++ b/src/__tests__/api/admin-catalog-activate.test.ts
@@ -1,16 +1,16 @@
 /**
- * POST /api/v1/admin/catalog/activate — 키 검증 통과 시에만 비활성 API 활성화.
+ * POST /api/v1/admin/catalog/activate — 연속 키 검증 통과 시에만 비활성 API 활성화.
  *
- * 핵심 안전 속성: 키가 유효하지 않으면 repo.update를 절대 호출하지 않는다.
- * dryRun이면 검증만 하고 쓰지 않는다.
+ * 핵심 안전 속성: 키가 유효하지 않거나 N회 연속 VALID 가 아니면 repo.update를 절대 호출하지 않는다.
+ * dryRun이면 연속 검증은 수행하고 쓰지 않는다.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ApiCatalogItem } from '@/types/api';
-import type { KeyCheckResult } from '@/lib/catalog/keyCheck';
+import type { ConsistencyResult } from '@/lib/catalog/keyCheck';
 
 const findMany = vi.fn();
 const update = vi.fn();
-const verifyApiKey = vi.fn();
+const verifyApiKeyForActivation = vi.fn();
 const eventBusEmit = vi.fn();
 
 vi.mock('@/repositories/factory', () => ({
@@ -18,7 +18,8 @@ vi.mock('@/repositories/factory', () => ({
 }));
 
 vi.mock('@/lib/catalog/keyCheck', () => ({
-  verifyApiKey: (...args: unknown[]) => verifyApiKey(...args) as ReturnType<typeof verifyApiKey>,
+  verifyApiKeyForActivation: (...args: unknown[]) =>
+    verifyApiKeyForActivation(...args) as ReturnType<typeof verifyApiKeyForActivation>,
 }));
 
 vi.mock('@/lib/events/eventBus', () => ({
@@ -64,23 +65,54 @@ function makeInactiveKeyedApi(overrides: Partial<ApiCatalogItem> = {}): ApiCatal
   };
 }
 
-function makeValidKeyResult(name: string): KeyCheckResult {
+function makeValidConsistency(name: string, samples = 3): ConsistencyResult {
   return {
     name,
     envVar: 'NASA_API_KEY',
     verdict: 'VALID',
     httpStatus: 200,
-    detail: '인증 성공',
+    detail: `연속 ${samples}회 인증 성공`,
+    samples,
+    successes: samples,
+    attempts: samples,
+    attemptResults: Array.from({ length: samples }, () => ({
+      verdict: 'VALID' as const,
+      httpStatus: 200,
+      detail: '인증 성공',
+    })),
   };
 }
 
-function makeInvalidKeyResult(name: string): KeyCheckResult {
+function makeInvalidConsistency(name: string): ConsistencyResult {
   return {
     name,
     envVar: 'NASA_API_KEY',
     verdict: 'INVALID',
     httpStatus: 401,
     detail: '키 거부(401)',
+    samples: 3,
+    successes: 0,
+    attempts: 1,
+    attemptResults: [{ verdict: 'INVALID', httpStatus: 401, detail: '키 거부(401)' }],
+  };
+}
+
+/** VALID×2 후 ERROR — 3회 중 2회 성공 (에어코리아형 간헐 실패) */
+function makePartialErrorConsistency(name: string): ConsistencyResult {
+  return {
+    name,
+    envVar: 'NASA_API_KEY',
+    verdict: 'ERROR',
+    httpStatus: 504,
+    detail: '예상치 못한 504',
+    samples: 3,
+    successes: 2,
+    attempts: 3,
+    attemptResults: [
+      { verdict: 'VALID', httpStatus: 200, detail: '인증 성공' },
+      { verdict: 'VALID', httpStatus: 200, detail: '인증 성공' },
+      { verdict: 'ERROR', httpStatus: 504, detail: '예상치 못한 504' },
+    ],
   };
 }
 
@@ -117,7 +149,7 @@ describe('POST /api/v1/admin/catalog/activate', () => {
     process.env.NASA_API_KEY = 'test-nasa-key';
     findMany.mockResolvedValue({ items: [], total: 0 });
     update.mockResolvedValue(undefined);
-    verifyApiKey.mockResolvedValue(makeValidKeyResult('NASA APOD'));
+    verifyApiKeyForActivation.mockResolvedValue(makeValidConsistency('NASA APOD'));
   });
 
   it('Authorization 헤더 없음 → 403', async () => {
@@ -132,10 +164,10 @@ describe('POST /api/v1/admin/catalog/activate', () => {
     expect(res.status).toBe(403);
   });
 
-  it('키 검증 VALID인 비활성 키 의존 API → 활성화하고 activated:true', async () => {
+  it('연속 검증 3/3 VALID → 활성화하고 reason 에 3/3 포함', async () => {
     const candidate = makeInactiveKeyedApi();
     findMany.mockResolvedValue({ items: [candidate], total: 1 });
-    verifyApiKey.mockResolvedValue(makeValidKeyResult(candidate.name));
+    verifyApiKeyForActivation.mockResolvedValue(makeValidConsistency(candidate.name));
 
     const { POST } = await import('@/app/api/v1/admin/catalog/activate/route');
     const res = await POST(makeReq(VALID_ADMIN_KEY, {}));
@@ -156,17 +188,18 @@ describe('POST /api/v1/admin/catalog/activate', () => {
       apiId: candidate.id,
       activated: true,
     });
+    expect(body.data.outcomes[0]?.reason).toMatch(/3\/3/);
     expect(update).toHaveBeenCalledWith(candidate.id, {
       isActive: true,
       verificationStatus: 'verified',
     });
-    expect(verifyApiKey).toHaveBeenCalledOnce();
+    expect(verifyApiKeyForActivation).toHaveBeenCalledOnce();
   });
 
-  it('키 검증이 VALID가 아니면 repo.update를 호출하지 않는다', async () => {
+  it('3회 중 2회 성공(ERROR) → activated:false, reason 에 부분 성공 카운트', async () => {
     const candidate = makeInactiveKeyedApi();
     findMany.mockResolvedValue({ items: [candidate], total: 1 });
-    verifyApiKey.mockResolvedValue(makeInvalidKeyResult(candidate.name));
+    verifyApiKeyForActivation.mockResolvedValue(makePartialErrorConsistency(candidate.name));
 
     const { POST } = await import('@/app/api/v1/admin/catalog/activate/route');
     const res = await POST(makeReq(VALID_ADMIN_KEY, {}));
@@ -180,14 +213,37 @@ describe('POST /api/v1/admin/catalog/activate', () => {
     };
     expect(body.data.activated).toBe(0);
     expect(body.data.outcomes[0]?.activated).toBe(false);
-    expect(body.data.outcomes[0]?.reason).toMatch(/키 검증 실패/);
+    expect(body.data.outcomes[0]?.reason).toMatch(/키 검증 실패\(ERROR\)/);
+    expect(body.data.outcomes[0]?.reason).toMatch(/3회 중 2회 성공/);
+    expect(body.data.outcomes[0]?.reason).toMatch(/504/);
     expect(update).not.toHaveBeenCalled();
   });
 
-  it('dryRun:true이면 검증은 하되 repo.update는 호출하지 않는다', async () => {
+  it('키 검증이 INVALID면 repo.update를 호출하지 않는다 (기존 동작 유지)', async () => {
     const candidate = makeInactiveKeyedApi();
     findMany.mockResolvedValue({ items: [candidate], total: 1 });
-    verifyApiKey.mockResolvedValue(makeValidKeyResult(candidate.name));
+    verifyApiKeyForActivation.mockResolvedValue(makeInvalidConsistency(candidate.name));
+
+    const { POST } = await import('@/app/api/v1/admin/catalog/activate/route');
+    const res = await POST(makeReq(VALID_ADMIN_KEY, {}));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        activated: number;
+        outcomes: Array<{ activated: boolean; reason: string }>;
+      };
+    };
+    expect(body.data.activated).toBe(0);
+    expect(body.data.outcomes[0]?.activated).toBe(false);
+    expect(body.data.outcomes[0]?.reason).toMatch(/키 검증 실패\(INVALID\)/);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('dryRun:true + 3/3 → 연속 검증은 수행하되 repo.update 는 호출하지 않는다', async () => {
+    const candidate = makeInactiveKeyedApi();
+    findMany.mockResolvedValue({ items: [candidate], total: 1 });
+    verifyApiKeyForActivation.mockResolvedValue(makeValidConsistency(candidate.name));
 
     const { POST } = await import('@/app/api/v1/admin/catalog/activate/route');
     const res = await POST(makeReq(VALID_ADMIN_KEY, { dryRun: true }));
@@ -204,7 +260,8 @@ describe('POST /api/v1/admin/catalog/activate', () => {
     expect(body.data.activated).toBe(0);
     expect(body.data.outcomes[0]?.activated).toBe(false);
     expect(body.data.outcomes[0]?.reason).toMatch(/dryRun/);
-    expect(verifyApiKey).toHaveBeenCalledOnce();
+    expect(body.data.outcomes[0]?.reason).toMatch(/3\/3/);
+    expect(verifyApiKeyForActivation).toHaveBeenCalledOnce();
     expect(update).not.toHaveBeenCalled();
   });
 
@@ -216,7 +273,7 @@ describe('POST /api/v1/admin/catalog/activate', () => {
       authConfig: { env_var: 'OTHER_KEY', param_in: 'query', param_name: 'key' },
     });
     findMany.mockResolvedValue({ items: [a, b], total: 2 });
-    verifyApiKey.mockResolvedValue(makeValidKeyResult('A'));
+    verifyApiKeyForActivation.mockResolvedValue(makeValidConsistency('A'));
 
     const { POST } = await import('@/app/api/v1/admin/catalog/activate/route');
     const res = await POST(makeReq(VALID_ADMIN_KEY, { apiIds: ['api-a'] }));
@@ -228,7 +285,7 @@ describe('POST /api/v1/admin/catalog/activate', () => {
     expect(body.data.candidates).toBe(1);
     expect(body.data.outcomes).toHaveLength(1);
     expect(body.data.outcomes[0]?.apiId).toBe('api-a');
-    expect(verifyApiKey).toHaveBeenCalledOnce();
+    expect(verifyApiKeyForActivation).toHaveBeenCalledOnce();
     expect(update).toHaveBeenCalledWith('api-a', {
       isActive: true,
       verificationStatus: 'verified',
@@ -265,7 +322,7 @@ describe('POST /api/v1/admin/catalog/activate', () => {
       items: [alreadyActive, keyless, withDefaultKey, candidate],
       total: 4,
     });
-    verifyApiKey.mockResolvedValue(makeValidKeyResult(candidate.name));
+    verifyApiKeyForActivation.mockResolvedValue(makeValidConsistency(candidate.name));
 
     const { POST } = await import('@/app/api/v1/admin/catalog/activate/route');
     const res = await POST(makeReq(VALID_ADMIN_KEY, {}));
@@ -276,7 +333,7 @@ describe('POST /api/v1/admin/catalog/activate', () => {
     };
     expect(body.data.candidates).toBe(1);
     expect(body.data.outcomes.map((o) => o.apiId)).toEqual(['api-real']);
-    expect(verifyApiKey).toHaveBeenCalledOnce();
+    expect(verifyApiKeyForActivation).toHaveBeenCalledOnce();
     expect(update).toHaveBeenCalledTimes(1);
     expect(update).toHaveBeenCalledWith('api-real', {
       isActive: true,
@@ -287,7 +344,7 @@ describe('POST /api/v1/admin/catalog/activate', () => {
   it('빈 요청 본문은 허용된다(전체 후보 의미)', async () => {
     const candidate = makeInactiveKeyedApi();
     findMany.mockResolvedValue({ items: [candidate], total: 1 });
-    verifyApiKey.mockResolvedValue(makeValidKeyResult(candidate.name));
+    verifyApiKeyForActivation.mockResolvedValue(makeValidConsistency(candidate.name));
 
     const { POST } = await import('@/app/api/v1/admin/catalog/activate/route');
     // body 없음 (undefined) → 라우트가 {}로 처리
@@ -325,16 +382,18 @@ describe('POST /api/v1/admin/catalog/activate', () => {
     expect(body.success).toBe(false);
     expect(body.error.code).toBe('INVALID_INPUT');
     expect(findMany).not.toHaveBeenCalled();
-    expect(verifyApiKey).not.toHaveBeenCalled();
+    expect(verifyApiKeyForActivation).not.toHaveBeenCalled();
   });
 });
 
 /**
  * realFetch(라우트 내부 KeyFetch) 커버리지.
  *
- * 위 describe는 keyCheck 모듈을 모킹해 verifyApiKey 분기만 본다.
+ * 위 describe는 keyCheck 모듈을 모킹해 연속 검증 분기만 본다.
  * 여기선 keyCheck를 실제 모듈로 두고 global fetch만 스텁해 realFetch 성공/네트워크 실패 경로를 탄다.
  * MSW를 우회하므로 setup.ts의 unhandled-request 단언에 걸리지 않는다.
+ *
+ * 연속 검증(3회)이므로 성공 경로에서 fetch 는 3회 호출된다.
  */
 describe('POST /api/v1/admin/catalog/activate — realFetch 경로', () => {
   const REAL_FETCH_ENV = 'TEST_ACTIVATE_REAL_FETCH_KEY';
@@ -354,7 +413,8 @@ describe('POST /api/v1/admin/catalog/activate — realFetch 경로', () => {
     vi.unstubAllEnvs();
     // 이후 파일/스위트가 다시 모킹된 keyCheck를 쓰도록 복구
     vi.doMock('@/lib/catalog/keyCheck', () => ({
-      verifyApiKey: (...args: unknown[]) => verifyApiKey(...args) as ReturnType<typeof verifyApiKey>,
+      verifyApiKeyForActivation: (...args: unknown[]) =>
+        verifyApiKeyForActivation(...args) as ReturnType<typeof verifyApiKeyForActivation>,
     }));
   });
 
@@ -380,7 +440,7 @@ describe('POST /api/v1/admin/catalog/activate — realFetch 경로', () => {
     });
   }
 
-  it('fetch 성공 시 realFetch 성공 경로로 키가 VALID 판정되고 활성화된다', async () => {
+  it('fetch 성공 시 연속 검증 통과로 활성화된다 (fetch 3회)', async () => {
     const candidate = makeRealFetchCandidate();
     findMany.mockResolvedValue({ items: [candidate], total: 1 });
 
@@ -406,14 +466,15 @@ describe('POST /api/v1/admin/catalog/activate — realFetch 경로', () => {
       apiId: candidate.id,
       activated: true,
     });
-    expect(fetchStub).toHaveBeenCalled();
+    expect(body.data.outcomes[0]?.reason).toMatch(/3\/3/);
+    expect(fetchStub).toHaveBeenCalledTimes(3);
     expect(update).toHaveBeenCalledWith(candidate.id, {
       isActive: true,
       verificationStatus: 'verified',
     });
-  });
+  }, 15_000);
 
-  it('fetch 거부 시 realFetch networkError 경로로 활성화하지 않는다', async () => {
+  it('fetch 거부 시 첫 시도 ERROR 로 조기 종료·활성화하지 않는다', async () => {
     const candidate = makeRealFetchCandidate();
     findMany.mockResolvedValue({ items: [candidate], total: 1 });
 
@@ -433,7 +494,8 @@ describe('POST /api/v1/admin/catalog/activate — realFetch 경로', () => {
     expect(body.data.activated).toBe(0);
     expect(body.data.outcomes[0]?.activated).toBe(false);
     expect(body.data.outcomes[0]?.reason).toMatch(/키 검증 실패/);
-    expect(fetchStub).toHaveBeenCalled();
+    // 조기 종료: 첫 non-VALID 에서 멈춤 → fetch 1회
+    expect(fetchStub).toHaveBeenCalledTimes(1);
     expect(update).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/api/admin-catalog-activate.test.ts
+++ b/src/__tests__/api/admin-catalog-activate.test.ts
@@ -219,6 +219,36 @@ describe('POST /api/v1/admin/catalog/activate', () => {
     expect(update).not.toHaveBeenCalled();
   });
 
+  // attempts===0 (env 미설정 등 프로브 이전 탈락)은 "3회 중 N회" 카운트를 붙이면 거짓말이 된다.
+  // 한 번도 시도하지 않았기 때문이다 — 사유만 그대로 전달해야 한다.
+  it('env 미설정(MISSING, attempts:0)이면 reason 에 성공 카운트를 붙이지 않는다', async () => {
+    const candidate = makeInactiveKeyedApi();
+    findMany.mockResolvedValue({ items: [candidate], total: 1 });
+    verifyApiKeyForActivation.mockResolvedValue({
+      name: candidate.name,
+      envVar: 'API_KEY_TEST',
+      verdict: 'MISSING',
+      detail: '환경변수 미설정',
+      samples: 3,
+      successes: 0,
+      attempts: 0,
+      attemptResults: [],
+    });
+
+    const { POST } = await import('@/app/api/v1/admin/catalog/activate/route');
+    const res = await POST(makeReq(VALID_ADMIN_KEY, {}));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { activated: number; outcomes: Array<{ activated: boolean; reason: string }> };
+    };
+    expect(body.data.activated).toBe(0);
+    expect(body.data.outcomes[0]?.reason).toMatch(/키 검증 실패\(MISSING\)/);
+    expect(body.data.outcomes[0]?.reason).toMatch(/환경변수 미설정/);
+    expect(body.data.outcomes[0]?.reason).not.toMatch(/회 중/);
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it('키 검증이 INVALID면 repo.update를 호출하지 않는다 (기존 동작 유지)', async () => {
     const candidate = makeInactiveKeyedApi();
     findMany.mockResolvedValue({ items: [candidate], total: 1 });

--- a/src/app/api/v1/admin/catalog/activate/route.ts
+++ b/src/app/api/v1/admin/catalog/activate/route.ts
@@ -1,7 +1,12 @@
 import { createCatalogRepository } from '@/repositories/factory';
 import { adminCorsHeaders, verifyAdminKey, withAdminCors } from '@/lib/utils/adminAuth';
 import { handleApiError, jsonResponse, ValidationError } from '@/lib/utils/errors';
-import { verifyApiKey, type KeyCheckApi, type KeyFetch } from '@/lib/catalog/keyCheck';
+import {
+  verifyApiKeyForActivation,
+  type ConsistencyResult,
+  type KeyCheckApi,
+  type KeyFetch,
+} from '@/lib/catalog/keyCheck';
 import { activateCatalogSchema } from '@/types/schemas';
 import { eventBus } from '@/lib/events/eventBus';
 import { logger } from '@/lib/utils/logger';
@@ -28,6 +33,16 @@ interface ActivateOutcome {
   reason: string;
 }
 
+/** 오퍼레이터가 "3회 중 2회 성공" vs "키가 거부됨"을 구분할 수 있게 reason 을 만든다. */
+function formatActivationFailureReason(check: ConsistencyResult): string {
+  if (check.attempts === 0) {
+    return `키 검증 실패(${check.verdict})${check.detail ? ` — ${check.detail}` : ''}`;
+  }
+  const statusPart =
+    check.httpStatus !== undefined && check.httpStatus > 0 ? ` (${check.httpStatus})` : '';
+  return `키 검증 실패(${check.verdict}) — ${check.samples}회 중 ${check.successes}회 성공${statusPart}`;
+}
+
 export async function OPTIONS(): Promise<Response> {
   return new Response(null, { status: 204, headers: adminCorsHeaders });
 }
@@ -35,19 +50,22 @@ export async function OPTIONS(): Promise<Response> {
 /**
  * POST /api/v1/admin/catalog/activate
  *
- * 비활성 상태인 "플랫폼 키 의존" API를, **라이브 키 검증을 통과한 것만** 활성화한다.
+ * 비활성 상태인 "플랫폼 키 의존" API를, **라이브 키 연속 검증(N회 VALID)을 통과한 것만** 활성화한다.
  *
  * 왜 이 엔드포인트가 필요한가: `is_active`를 true로 되돌리는 코드 경로가 이 프로젝트에
  * 아예 없었다(부팅 시 키리스 2종 하드코딩 정정이 전부). 그래서 오너가 무료 키를 발급해
  * env에 등록해도 카탈로그·추천·프록시에서 계속 빠졌고, 심지어 `keys-verify`가 활성만
  * 조회해 **검증 대상에도 못 들어갔다**.
  *
- * **검증 통과를 활성화의 전제로 못박는다.** 관리자가 손으로 켜게 두면 키가 틀린 API가
- * 사용자에게 노출돼 401만 반환한다 — 이전에 7개가 정확히 그 상태로 방치됐던 이력이 있다.
+ * **1회 프로브로 켜지 않는다.** 단발 VALID 는 간헐 5xx(에어코리아 83%·연속 504)를 놓친다.
+ * `verifyApiKeyForActivation` 이 기본 3회·간격 2s 로 연속 성공을 요구한다.
+ * 첫 non-VALID 에서 조기 종료해 관리자 요청 시간을 묶는다.
  *
  * body: `{ apiIds?: string[], dryRun?: boolean }`
  * - `apiIds` 생략 → 비활성 키 의존 API 전부가 대상
- * - `dryRun: true` → 검증만 하고 쓰지 않는다 (무엇이 켜질지 먼저 확인)
+ * - `dryRun: true` → 연속 검증은 전부 수행하고 쓰지 않는다
+ *
+ * 참고: `keys-verify` 는 진단용 단발 프로브로 남긴다(쓰기 게이트가 아님).
  */
 export async function POST(request: Request): Promise<Response> {
   const res = await (async () => {
@@ -89,7 +107,7 @@ export async function POST(request: Request): Promise<Response> {
           authConfig: a.authConfig as KeyCheckApi['authConfig'],
           endpoints: a.endpoints as unknown as KeyCheckApi['endpoints'],
         };
-        const check = await verifyApiKey(api, key, realFetch);
+        const check = await verifyApiKeyForActivation(api, key, realFetch);
 
         if (check.verdict !== 'VALID') {
           outcomes.push({
@@ -97,23 +115,40 @@ export async function POST(request: Request): Promise<Response> {
             name: a.name,
             envVar,
             activated: false,
-            reason: `키 검증 실패(${check.verdict})${check.detail ? ` — ${check.detail}` : ''}`,
+            reason: formatActivationFailureReason(check),
           });
           continue;
         }
 
         if (dryRun) {
-          outcomes.push({ apiId: a.id, name: a.name, envVar, activated: false, reason: 'dryRun — 검증만 수행' });
+          outcomes.push({
+            apiId: a.id,
+            name: a.name,
+            envVar,
+            activated: false,
+            reason: `dryRun — 키 검증 통과 (${check.successes}/${check.samples})`,
+          });
           continue;
         }
 
         await repo.update(a.id, { isActive: true, verificationStatus: 'verified' });
-        logger.warn('Catalog API activated by admin', { apiId: a.id, name: a.name, envVar });
+        logger.warn('Catalog API activated by admin', {
+          apiId: a.id,
+          name: a.name,
+          envVar,
+          samples: check.samples,
+        });
         eventBus.emit({
           type: 'CATALOG_API_ACTIVATED',
           payload: { apiId: a.id, apiName: a.name, envVar },
         });
-        outcomes.push({ apiId: a.id, name: a.name, envVar, activated: true, reason: '키 검증 통과' });
+        outcomes.push({
+          apiId: a.id,
+          name: a.name,
+          envVar,
+          activated: true,
+          reason: `키 검증 통과 (${check.successes}/${check.samples})`,
+        });
       }
 
       return jsonResponse({

--- a/src/lib/catalog/keyCheck.test.ts
+++ b/src/lib/catalog/keyCheck.test.ts
@@ -251,4 +251,40 @@ describe('verifyApiKeyForActivation (연속 검증 게이트)', () => {
     await verifyApiKeyForActivation(apiQuery, 'k', okFetch, { gapMs: -500, sleep });
     expect(sleep).toHaveBeenCalledWith(0);
   });
+
+  // 아래 두 케이스는 프로브 이전에 빠지는 경로다 — fetch·sleep 이 한 번도 일어나면 안 된다.
+  it('env_var 미정의면 ERROR 로 즉시 빠진다 (fetch 0회)', async () => {
+    const doFetch: KeyFetch = vi.fn(async () => ({ status: 200, bodyText: '{}', networkError: false }));
+    const sleep = vi.fn(async () => undefined);
+
+    const r = await verifyApiKeyForActivation(
+      { ...apiQuery, authConfig: { param_in: 'query', param_name: 'k' } },
+      'k',
+      doFetch,
+      { sleep },
+    );
+
+    expect(r.verdict).toBe('ERROR');
+    expect(r.detail).toContain('env_var');
+    expect(r.attempts).toBe(0);
+    expect(doFetch).not.toHaveBeenCalled();
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('GET 엔드포인트가 없으면 NO_ENDPOINT 로 즉시 빠진다 (fetch 0회)', async () => {
+    const doFetch: KeyFetch = vi.fn(async () => ({ status: 200, bodyText: '{}', networkError: false }));
+    const sleep = vi.fn(async () => undefined);
+
+    const r = await verifyApiKeyForActivation(
+      { ...apiQuery, endpoints: [{ path: '/x', method: 'POST' }] },
+      'k',
+      doFetch,
+      { sleep },
+    );
+
+    expect(r.verdict).toBe('NO_ENDPOINT');
+    expect(r.attempts).toBe(0);
+    expect(doFetch).not.toHaveBeenCalled();
+    expect(sleep).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/catalog/keyCheck.test.ts
+++ b/src/lib/catalog/keyCheck.test.ts
@@ -3,6 +3,7 @@ import {
   classifyKeyResponse,
   resolvePrefix,
   verifyApiKey,
+  verifyApiKeyForActivation,
   type KeyCheckApi,
   type KeyFetch,
 } from './keyCheck';
@@ -43,6 +44,13 @@ const apiHeader: KeyCheckApi = {
   baseUrl: 'https://dapi.kakao.com',
   authConfig: { env_var: 'API_KEY_F1EC6F97', param_in: 'header', param_name: 'Authorization', header_prefix: 'KakaoAK ' },
   endpoints: [{ path: '/v2/local/search/keyword.json', method: 'GET', parameters: { query: 'string' } }],
+};
+
+const apiQuery: KeyCheckApi = {
+  name: '에어코리아',
+  baseUrl: 'https://apis.data.go.kr/x',
+  authConfig: { env_var: 'API_KEY_AIR', param_in: 'query', param_name: 'serviceKey' },
+  endpoints: [{ path: '/getMsrstn', method: 'GET' }],
 };
 
 describe('verifyApiKey', () => {
@@ -94,5 +102,153 @@ describe('verifyApiKey', () => {
     const r = await verifyApiKey(queryApi, 'mykey', doFetch);
     expect(r.verdict).toBe('VALID');
     expect(seenUrl).toContain('serviceKey=mykey');
+  });
+});
+
+describe('verifyApiKeyForActivation (연속 검증 게이트)', () => {
+  const okFetch: KeyFetch = vi.fn(async () => ({
+    status: 200,
+    bodyText: '{"ok":true}',
+    networkError: false,
+  }));
+
+  it('3× VALID → 활성화 가능, successes:3, attempts:3, sleep 2회', async () => {
+    const doFetch: KeyFetch = vi.fn(async () => ({
+      status: 200,
+      bodyText: '{"ok":true}',
+      networkError: false,
+    }));
+    const sleep = vi.fn(async () => undefined);
+
+    const r = await verifyApiKeyForActivation(apiQuery, 'k', doFetch, { sleep });
+
+    expect(r.verdict).toBe('VALID');
+    expect(r.successes).toBe(3);
+    expect(r.attempts).toBe(3);
+    expect(r.samples).toBe(3);
+    expect(r.attemptResults.map((a) => a.verdict)).toEqual(['VALID', 'VALID', 'VALID']);
+    expect(doFetch).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenNthCalledWith(1, 2000);
+    expect(sleep).toHaveBeenNthCalledWith(2, 2000);
+  });
+
+  it('VALID 후 ERROR → 활성화 불가, attempts:2, 세 번째 fetch 없음', async () => {
+    let n = 0;
+    const doFetch: KeyFetch = vi.fn(async () => {
+      n += 1;
+      if (n === 1) return { status: 200, bodyText: '{"ok":true}', networkError: false };
+      return { status: 504, bodyText: 'gateway', networkError: false };
+    });
+    const sleep = vi.fn(async () => undefined);
+
+    const r = await verifyApiKeyForActivation(apiQuery, 'k', doFetch, { sleep });
+
+    expect(r.verdict).toBe('ERROR');
+    expect(r.successes).toBe(1);
+    expect(r.attempts).toBe(2);
+    expect(r.httpStatus).toBe(504);
+    expect(doFetch).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it('첫 시도 INVALID → attempts:1, sleep 전혀 없음', async () => {
+    const doFetch: KeyFetch = vi.fn(async () => ({
+      status: 401,
+      bodyText: 'Unauthorized',
+      networkError: false,
+    }));
+    const sleep = vi.fn(async () => undefined);
+
+    const r = await verifyApiKeyForActivation(apiQuery, 'bad', doFetch, { sleep });
+
+    expect(r.verdict).toBe('INVALID');
+    expect(r.successes).toBe(0);
+    expect(r.attempts).toBe(1);
+    expect(doFetch).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('2번째 시도 RATE_LIMITED → verdict 는 RATE_LIMITED (INVALID 로 덮지 않음)', async () => {
+    let n = 0;
+    const doFetch: KeyFetch = vi.fn(async () => {
+      n += 1;
+      if (n === 1) return { status: 200, bodyText: '{"ok":true}', networkError: false };
+      return { status: 429, bodyText: 'rate', networkError: false };
+    });
+    const sleep = vi.fn(async () => undefined);
+
+    const r = await verifyApiKeyForActivation(apiQuery, 'k', doFetch, { sleep });
+
+    expect(r.verdict).toBe('RATE_LIMITED');
+    expect(r.verdict).not.toBe('INVALID');
+    expect(r.successes).toBe(1);
+    expect(r.attempts).toBe(2);
+    expect(doFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('MISSING → attempts:0, fetch·sleep 없음', async () => {
+    const doFetch = vi.fn();
+    const sleep = vi.fn(async () => undefined);
+
+    const r = await verifyApiKeyForActivation(apiQuery, undefined, doFetch, { sleep });
+
+    expect(r.verdict).toBe('MISSING');
+    expect(r.attempts).toBe(0);
+    expect(r.successes).toBe(0);
+    expect(r.attemptResults).toEqual([]);
+    expect(doFetch).not.toHaveBeenCalled();
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('samples:5 커스텀이 적용된다', async () => {
+    const doFetch: KeyFetch = vi.fn(async () => ({
+      status: 200,
+      bodyText: '{"ok":true}',
+      networkError: false,
+    }));
+    const sleep = vi.fn(async () => undefined);
+
+    const r = await verifyApiKeyForActivation(apiQuery, 'k', doFetch, { samples: 5, sleep });
+
+    expect(r.verdict).toBe('VALID');
+    expect(r.samples).toBe(5);
+    expect(r.successes).toBe(5);
+    expect(r.attempts).toBe(5);
+    expect(doFetch).toHaveBeenCalledTimes(5);
+    expect(sleep).toHaveBeenCalledTimes(4);
+  });
+
+  it('gapMs 가 주입 sleep 에 전달된다', async () => {
+    const sleep = vi.fn(async () => undefined);
+    await verifyApiKeyForActivation(apiQuery, 'k', okFetch, { gapMs: 750, sleep });
+    expect(sleep).toHaveBeenCalledWith(750);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  // samples 0·음수를 그대로 두면 루프가 한 번도 돌지 않는다. 그러면 프로브를 단 한 번도
+  // 하지 않은 API가 "전부 VALID"로 떨어져 활성화된다 — 게이트를 통째로 무력화하는 값이다.
+  // (구현 초기에 실제로 null 역참조로 죽었다.)
+  it.each([0, -1, -99])('samples=%i 여도 최소 1회는 프로브한다 (게이트 무력화 방지)', async (bad) => {
+    const doFetch: KeyFetch = vi.fn(async () => ({
+      status: 200,
+      bodyText: '{"ok":true}',
+      networkError: false,
+    }));
+    const sleep = vi.fn(async () => undefined);
+
+    const r = await verifyApiKeyForActivation(apiQuery, 'k', doFetch, { samples: bad, sleep });
+
+    expect(r.verdict).toBe('VALID');
+    expect(r.samples).toBe(1);
+    expect(r.attempts).toBe(1);
+    expect(doFetch).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('음수 gapMs 는 0으로 죈다', async () => {
+    const sleep = vi.fn(async () => undefined);
+    await verifyApiKeyForActivation(apiQuery, 'k', okFetch, { gapMs: -500, sleep });
+    expect(sleep).toHaveBeenCalledWith(0);
   });
 });

--- a/src/lib/catalog/keyCheck.ts
+++ b/src/lib/catalog/keyCheck.ts
@@ -119,3 +119,161 @@ export async function verifyApiKey(
 
   return { name: api.name, envVar, verdict: 'INVALID', httpStatus: raw.status, detail: raw.detail };
 }
+
+/** 활성화 게이트 한 번의 시도 결과 (오퍼레이터가 부분 실패 원인을 볼 수 있게). */
+export interface ConsistencyAttempt {
+  verdict: KeyVerdict;
+  httpStatus?: number;
+  detail: string;
+}
+
+/**
+ * 활성화 전용 연속 검증 결과.
+ * `KeyCheckResult`와 호환 필드를 유지하고, samples/successes/attempts·시도별 판정을 붙인다.
+ */
+export interface ConsistencyResult extends KeyCheckResult {
+  /** 요청한 연속 성공 횟수 (기본 3) */
+  samples: number;
+  /** VALID 로 끝난 시도 수 */
+  successes: number;
+  /** 실제로 돌린 시도 수 (조기 종료 시 samples 미만). MISSING/NO_ENDPOINT 는 0 */
+  attempts: number;
+  /** 시도별 판정 (네트워크 프로브가 나간 것만) */
+  attemptResults: ConsistencyAttempt[];
+}
+
+export interface ConsistencyOptions {
+  samples?: number;
+  gapMs?: number;
+  /** 테스트 결정성용. 기본은 setTimeout 기반 sleep */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * 활성화 게이트 — N회 연속 VALID 일 때만 통과.
+ *
+ * `verifyApiKey` 를 시도마다 재사용한다(로직 복제 금지).
+ *
+ * **첫 non-VALID 에서 즉시 중단**한다. 이유: 정상 API는 빠르게 응답하고,
+ * 실패·타임아웃 API는 1회에서 끝난다. 조기 종료 없이 전부 돌리면
+ * 최악 `후보 수 × samples × 15s` 로 관리자 요청이 수분 단위가 된다.
+ *
+ * 판정:
+ * - 전부 VALID → activatable
+ * - INVALID → 키 거부 (그대로 INVALID)
+ * - RATE_LIMITED → 보류(키가 틀린 게 아님). INVALID 로 덮어쓰지 않음
+ * - ERROR(5xx/타임아웃 등) → 활성화 거부 — 에어코리아 간헐 504 가 이 경로
+ * - MISSING / NO_ENDPOINT → 재시도·sleep 없이 즉시 반환 (attempts=0)
+ */
+export async function verifyApiKeyForActivation(
+  api: KeyCheckApi,
+  key: string | undefined,
+  doFetch: KeyFetch,
+  options: ConsistencyOptions = {},
+): Promise<ConsistencyResult> {
+  // samples는 최소 1로 죈다. 0·음수를 그대로 두면 루프가 한 번도 돌지 않아
+  // "전부 VALID" 분기로 떨어지고, 프로브를 한 번도 안 한 API가 활성화된다.
+  // (게이트를 통째로 무력화하는 값이므로 조용히 통과시키지 않고 1로 올린다.)
+  const samples = Math.max(1, Math.trunc(options.samples ?? 3));
+  const gapMs = Math.max(0, options.gapMs ?? 2000);
+  const sleep = options.sleep ?? defaultSleep;
+
+  const cfg = api.authConfig ?? {};
+  const envVar = cfg.env_var ?? '(none)';
+  const emptyAttempts: ConsistencyAttempt[] = [];
+
+  if (!cfg.env_var) {
+    return {
+      name: api.name,
+      envVar,
+      verdict: 'ERROR',
+      detail: 'env_var 미정의',
+      samples,
+      successes: 0,
+      attempts: 0,
+      attemptResults: emptyAttempts,
+    };
+  }
+  if (!key) {
+    return {
+      name: api.name,
+      envVar,
+      verdict: 'MISSING',
+      detail: '환경변수 미설정',
+      samples,
+      successes: 0,
+      attempts: 0,
+      attemptResults: emptyAttempts,
+    };
+  }
+
+  const getEp = (api.endpoints ?? []).find((e) => (e.method ?? 'GET') === 'GET');
+  if (!getEp) {
+    return {
+      name: api.name,
+      envVar,
+      verdict: 'NO_ENDPOINT',
+      detail: 'GET 엔드포인트 없음',
+      samples,
+      successes: 0,
+      attempts: 0,
+      attemptResults: emptyAttempts,
+    };
+  }
+
+  const attemptResults: ConsistencyAttempt[] = [];
+  let successes = 0;
+  let last: KeyCheckResult | null = null;
+
+  for (let i = 0; i < samples; i += 1) {
+    if (i > 0) {
+      await sleep(gapMs);
+    }
+
+    const r = await verifyApiKey(api, key, doFetch);
+    last = r;
+    attemptResults.push({
+      verdict: r.verdict,
+      httpStatus: r.httpStatus,
+      detail: r.detail,
+    });
+
+    if (r.verdict === 'VALID') {
+      successes += 1;
+      continue;
+    }
+
+    // 첫 non-VALID — 남은 샘플은 돌리지 않는다 (INVALID / RATE_LIMITED / ERROR 모두)
+    return {
+      name: r.name,
+      envVar: r.envVar,
+      verdict: r.verdict,
+      httpStatus: r.httpStatus,
+      detail: r.detail,
+      needsPrefixFix: r.needsPrefixFix,
+      samples,
+      successes,
+      attempts: attemptResults.length,
+      attemptResults,
+    };
+  }
+
+  // 전부 VALID
+  return {
+    name: last!.name,
+    envVar: last!.envVar,
+    verdict: 'VALID',
+    httpStatus: last!.httpStatus,
+    detail: `연속 ${samples}회 인증 성공`,
+    needsPrefixFix: last!.needsPrefixFix,
+    samples,
+    successes,
+    attempts: attemptResults.length,
+    attemptResults,
+  };
+}


### PR DESCRIPTION
## 왜

**에어코리아가 83%(10/12, `504` 2회 연속)인데도 활성화됐다.** `verifyApiKey`가 엔드포인트를 **1회만** 프로브하기 때문이다.

1회 프로브는 구조적으로 "일관된 품질"을 판정할 수 없다 — 불안정한 API도 **운 좋은 한 번**이면 통과한다. 오너 방침("불안정한 서비스는 없느니만 못하다")을 게이트가 집행하려면 여기가 바뀌어야 한다.

## 무엇을

`verifyApiKeyForActivation` — 기본 **3회 연속 성공**을 요구한다.

**읽기 전용인 `keys-verify`는 그대로 1회다.** 진단은 빠르게 보는 게 목적이고, **쓰기 경로인 `activate`만** 엄격하면 된다.

## 첫 non-VALID에서 즉시 중단 — 이것이 실행 시간을 묶는다

잘 되는 API는 빠르게 답하고(실측 p50 ~1초), 죽어가는 API는 **1회 만에 빠진다.**

| 상황 | 소요 |
|---|---|
| `MISSING`/`NO_ENDPOINT` | fetch·sleep **0회** |
| 1회차 실패 | **≤15초** (gap 없음) |
| 3회 전부 성공 (실측 1초) | **~7초** |

현재 후보 24개 중 **실제 프로브 대상은 10개**(14개는 env 미설정)라, 현실적인 전체 소요는 1분 미만이다. 조기 종료가 없으면 실패 케이스에서 후보당 3×15초를 그대로 쓴다.

## 판정 규칙 — 두 가지가 중요하다

**`RATE_LIMITED`를 `INVALID`로 덮어쓰지 않는다.** "나중에 다시"와 "키가 틀렸다"는 운영자가 취할 조치가 완전히 다르다. ZenQuotes에서 실제로 겪었다 — 반복 측정이 `429`를 유발했고, 그걸 키 문제로 기록했다면 **멀쩡한 API를 폐기**했을 것이다.

**`ERROR`(타임아웃·5xx·본문 에러)는 활성화를 막는다.** 에어코리아의 간헐적 `504`가 정확히 이 경로로 걸린다.

실패 사유에 연속 결과를 실어 보낸다:
```
키 검증 실패(ERROR) — 3회 중 2회 성공 (504)     ← 불안정
키 검증 실패(INVALID) — 키 거부(403)            ← 키 문제
키 검증 통과 (3/3)                              ← 활성화
```

## 리뷰에서 잡은 것 — `samples: 0` 크래시

옵션을 노출한 이상 방어해야 한다. `samples: 0`을 넘기면 루프가 한 번도 돌지 않아 **"전부 VALID" 분기로 떨어지고, 프로브를 단 한 번도 안 한 API가 활성화된다** — 게이트를 통째로 무력화하는 값이다.

초기 구현은 실제로 null 역참조로 죽었다(로컬 실행으로 확인):
```
samples=0  → ❌ CRASH: Cannot read properties of null (reading 'name')
samples=-1 → ❌ CRASH: Cannot read properties of null (reading 'name')
```

`Math.max(1, trunc)`로 죄고 회귀 테스트를 붙였다. 음수 `gapMs`도 0으로 죈다.

## 검증

| 항목 | 결과 |
|---|---|
| `keys-verify` 미변경 | diff 없음 확인 |
| `pnpm lint` / `type-check` | 0 errors / 통과 |
| `pnpm test` | **194 파일 2484 테스트 전건 통과** |

## 배포 후 — 에어코리아 재평가

이 게이트는 **비활성 API에만** 작동하므로, 현재 활성인 에어코리아는 자동으로 재평가되지 않는다. 배포 후 의도적으로 확인한다:

```bash
POST /admin/catalog/deactivate  { "apiIds": ["c84860a1-..."] }
POST /admin/catalog/activate    { "apiIds": ["c84860a1-..."], "dryRun": true }
```

83%면 **3/3을 통과하지 못할 가능성이 높다.** 그러면 그대로 꺼진 채 두는 것이 방침에 맞다 — 다만 PR-A에서 `cache_ttl_seconds: 3600`을 넣었으므로 사용자 체감은 이전과 다르다. 결과를 보고 판단한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)