### PR TITLE
chore: .claude/rules 파일럿 + 실발동 관측 — CLAUDE.md 이동 0줄 (문서 재편 PR3/7)

### DIFF
--- a/.claude/rules/ai-generation-qc.md
+++ b/.claude/rules/ai-generation-qc.md
@@ -1,0 +1,48 @@
+---
+paths:
+  - "src/lib/ai/**"
+  - "src/lib/qc/**"
+  - "src/providers/**"
+---
+
+# AI 생성·QC 파이프라인을 손댈 때
+
+> 이 파일은 **경로 스코프 규칙**이다. 위 `paths`에 해당하는 파일을 Claude가 **읽을 때만**
+> 컨텍스트에 들어온다. 루트 `CLAUDE.md`에서 옮겨온 내용은 **한 줄도 없다** —
+> 원래 `docs/`에만 있어서 사실상 열리지 않던 것을 여기로 끌어올린 것이다.
+>
+> ⚠️ **발동 조건을 오해하지 말 것.** 이 규칙은 **Read 시점**에 뜬다.
+> 매칭 경로에 **새 파일을 Write로 만들 때는 뜨지 않는다**(읽을 파일이 없으므로).
+> 따라서 "새 파일을 만들 때 지켜야 할 규칙"을 여기에 두면 안 된다 — 그건 `CLAUDE.md`에 남는다.
+
+## 먼저 열어야 하는 문서
+
+| 무엇을 손대나 | 열 문서 |
+|---|---|
+| QC 단계·임계값·재생성 판단 | [docs/guides/qc-process.md](../../docs/guides/qc-process.md) — 8단계 표준 프로세스 |
+| Stage 구성·프롬프트·복잡도 배점 | [docs/architecture/ai-pipeline.md](../../docs/architecture/ai-pipeline.md) |
+
+## 그 문서에만 있고, 모르면 조용히 깨지는 것
+
+- **파이프라인 총 예산은 290초**(`PIPELINE_MAX_DURATION_MS`)다. Railway 300초 한도에서
+  10초만 남긴 값이라 여유가 거의 없다. **Quality Loop는 반복을 시작하기 전에 잔여 예산을
+  확인해야 한다** — 확인 없이 반복을 늘리면 마지막 반복이 잘려 나가고, 사용자에겐
+  "생성 실패"로만 보인다.
+
+- **QC 타임아웃은 차단이 아니다.** Fast 3초 / Deep 10초를 넘기면 `null`을 반환하고
+  **파이프라인은 그대로 진행**한다(`QC_FAST_TIMEOUT_MS` · `QC_DEEP_TIMEOUT_MS`).
+  이걸 실패로 바꾸면 업스트림이 느린 날 전부 생성 실패가 된다. 반대로 `null`을
+  "통과"로 취급해도 안 된다 — 점수가 없는 것이지 좋은 것이 아니다.
+
+- **Deep QC는 Fast QC가 실패했을 때만 돈다.** 항상 돌린다고 가정하고 코드를 짜면
+  비용·지연이 조용히 늘어난다.
+
+- **복잡도 배점의 진실원은 코드다** (`evaluateComplexityScore`, `generationPipeline.ts`).
+  ET 활성 조건은 `>= ET_COMPLEXITY_THRESHOLD`(기본 35)이며, "API 3개" 또는 "컨텍스트 500자"
+  **단독으로는 도달하지 않는다**(각 5pt·15pt). 문서 수치를 고칠 때 코드와 대조할 것 —
+  2026-08-06에 `ai-pipeline.md`가 3pt를 10pt로 적고 있었고, 그 값은 단조성까지 깨고 있었다.
+
+## 파일 소유권 (qc-process.md §4의 부분 사본이 아니라 진입점만)
+
+`codeValidator`(보안·품질) · `qualityLoop`(재시도) · `renderingQc`(Fast/Deep 오케스트레이터) ·
+`deepQcRunner`(비동기 저장 후 업데이트) · `browserPool`. 전체 표는 위 qc-process.md §4.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,16 @@
     "deny": []
   },
   "hooks": {
+    "InstructionsLoaded": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{require('fs').appendFileSync('.claude/instructions-loaded.jsonl',d.trim()+'\\n')}catch(e){}})\""
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash(git push*)",

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ verify.log
 # 접근성 스냅샷은 페이지에 보이는 값을 그대로 담는다 — 2026-07-31에 Slack Incoming Webhook URL이
 # 평문으로 기록된 것을 실제로 확인했다. 커밋되면 라이브 시크릿이 유출되므로 반드시 무시한다.
 .playwright-mcp/
+
+# .claude/rules 실발동 관측 로그(InstructionsLoaded 훅) — 머신·세션마다 다르다
+.claude/instructions-loaded.jsonl

--- a/scripts/checkDocIntegrity.ts
+++ b/scripts/checkDocIntegrity.ts
@@ -204,6 +204,80 @@ for (const name of adrs) {
   }
 }
 
+// ── ⑤ .claude/rules 의 paths 글롭이 **실제로 파일에 매치되는가** ────────────
+// 경로가 실재하는지만 보면 부족하다. gitignore 시맨틱 매처에서 대괄호 리터럴은
+// 문자 클래스로 해석되어 `src/app/site/[slug]/route.ts` 같은 Next.js 동적 경로에
+// **영구 미발동**한다 — 파일은 실재하는데 규칙은 절대 안 뜬다.
+// 0매치는 "규칙이 존재하지만 아무 일도 하지 않는다"는 뜻이므로 위반으로 센다.
+const RULES_DIR = path.join(ROOT, '.claude/rules');
+
+/** 글롭 → 정규식. `**` = 임의 깊이, `*` = 세그먼트 내부, `?` = 한 글자 */
+function globToRegExp(glob: string): RegExp {
+  let re = '';
+  for (let i = 0; i < glob.length; i += 1) {
+    const c = glob[i];
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        re += glob[i + 2] === '/' ? '(?:.*/)?' : '.*';
+        i += glob[i + 2] === '/' ? 2 : 1;
+      } else re += '[^/]*';
+    } else if (c === '?') re += '[^/]';
+    else re += c.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  }
+  return new RegExp(`^${re}$`);
+}
+
+if (fs.existsSync(RULES_DIR)) {
+  const allRepoFiles: string[] = (function collect(dir: string, acc: string[] = []): string[] {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (/node_modules|[\\/]\.git$|\.next|coverage/.test(p)) continue;
+        collect(p, acc);
+      } else acc.push(rel(p));
+    }
+    return acc;
+  })(ROOT);
+
+  const ruleFiles = (function collect(dir: string, acc: string[] = []): string[] {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) collect(p, acc);
+      else if (e.name.endsWith('.md')) acc.push(p);
+    }
+    return acc;
+  })(RULES_DIR);
+
+  for (const f of ruleFiles) {
+    const src = fs.readFileSync(f, 'utf8');
+    const fm = /^---\r?\n([\s\S]*?)\r?\n---/.exec(src);
+    if (!fm) continue; // paths 없는 규칙 = 무조건 로드. 검사 대상 아님
+    const pathsBlock = /paths:\s*\n((?:\s*-\s*.*\n?)+)/.exec(fm[1]);
+    if (!pathsBlock) continue;
+
+    for (const line of pathsBlock[1].split(/\r?\n/)) {
+      const m = /^\s*-\s*["']?(.+?)["']?\s*$/.exec(line);
+      if (!m) continue;
+      const glob = m[1];
+
+      if (glob.includes('[')) {
+        add(
+          '⑤ rules paths',
+          rel(f),
+          `\`${glob}\` — 대괄호는 글롭 매처에서 문자 클래스로 해석된다. ` +
+            `Next.js 동적 경로(\`[slug]\`)를 이렇게 쓰면 **영구 미발동**한다. 디렉터리 재귀형(\`dir/**\`)을 쓸 것`,
+        );
+        continue;
+      }
+      const reg = globToRegExp(glob);
+      const hits = allRepoFiles.filter((p) => reg.test(p)).length;
+      if (hits === 0) {
+        add('⑤ rules paths', rel(f), `\`${glob}\` 가 **0개 파일**에 매치된다 — 이 규칙은 절대 뜨지 않는다`);
+      }
+    }
+  }
+}
+
 // ── 보고 ──────────────────────────────────────────────────────────────────
 const byCheck = new Map<string, Violation[]>();
 for (const v of violations) {
@@ -215,7 +289,7 @@ for (const v of violations) {
 console.log(`문서 정합성 검사 — md ${allMd.length}개 · ADR ${adrs.length}개\n`);
 
 if (violations.length === 0) {
-  console.log('위반 없음 (4/4 통과)');
+  console.log('위반 없음 (5/5 통과)');
   process.exit(0);
 }
 


### PR DESCRIPTION
문서 재편 **3단계**. **CLAUDE.md에서 한 줄도 옮기지 않는다.**

## 왜 대량 이관을 하지 않는가 — 3회차 검토가 제 가설을 기각했다

당초 계획은 "배포 품질 원칙 111줄을 `.claude/rules/`로 옮겨 항상로드 예산을 줄인다"였다.
완결성 비평에서 무너졌고, 근거를 직접 확인했다:

> **공식 문서**: *"Path-scoped rules trigger when Claude **reads** files matching the
> pattern, **not on every tool use**."*

→ **Write로 만드는 신규 파일에는 뜨지 않는다.** 그런데 CLAUDE.md 규칙 상당수는
트리거가 *"새 리밋을 추가할 때"*, *"새 테스트 파일 작성"*, *"새 스케줄러에 경보를 붙일 때"* 다
— **가장 필요한 순간에 침묵한다.**

한 가지는 바로잡는다: 검토 과정에서 *"Anthropic이 경로 스코프를 항상로드 대체로 쓰지 말라고
금지한다"* 는 주장이 나왔는데, **공식 문서를 확인한 결과 거짓**이다. 문서는 오히려
*"If your instructions are growing large, **use path-scoped rules**"* 라고 **두 번** 권장한다.
보류 사유는 벤더 규칙이 아니라 **위 발동 시점 제약**이다.

## 그래서 방향을 뒤집었다 — L2 → L1 승격

이관(L0→L1) 대신, 지금 열람 확률이 사실상 0인 온디맨드 문서(L2)를 경로 스코프(L1)로 올린다.
**L0 예산을 1바이트도 쓰지 않으므로 구조적으로 잃을 것이 없고**, 역사적 오류 #7
("진실원이 있었는데 안 열었다")에 직접 작용하는 유일한 조치다.

`.claude/rules/ai-generation-qc.md` — `paths: src/lib/ai/** · src/lib/qc/** · src/providers/**`
(대괄호 리터럴은 영구 미발동이므로 **디렉터리 재귀형만**)

원래 `docs/`에만 있어 사실상 안 열리던 것 중 **모르면 조용히 깨지는 4가지**:

| 사실 | 모르면 |
|---|---|
| 파이프라인 총 예산 **290초**(Railway 300초 − 10초) | Quality Loop 반복이 잘려 "생성 실패"로만 보인다 |
| QC 타임아웃은 **차단이 아니라 null 반환 후 진행** | 실패로 바꾸면 업스트림 느린 날 전부 생성 실패 |
| Deep QC는 **Fast QC 실패 시에만** | 항상 돈다고 가정하면 비용·지연이 조용히 증가 |
| ET 임계 35는 "API 3개"·"컨텍스트 500자" 단독으론 미달 | 문서 수치를 코드 대조 없이 고치게 된다 |

규칙 파일 자체에 **발동 조건 경고**를 박아 뒀다 — *"새 파일 Write 시엔 안 뜬다,
그런 규칙은 CLAUDE.md에 남긴다"*.

## 관측 장치 — 이게 이 PR의 진짜 목적

`InstructionsLoaded` 훅으로 실제 로드 이벤트를 `.claude/instructions-loaded.jsonl`에
**원문 그대로** 적재한다(payload 스키마를 지어내지 않기 위해 raw stdin 기록). gitignore.

이 데이터 없이는 "rules가 실제로 뜨는가"를 아무도 모른다 — 설계안 3종이 전부
이 **미측정 값**에 편익을 걸고 있었다. 관측 후에 L0 이관 여부를 판단한다.

## 검사기에 ⑤ 추가 — 이 결함을 CI가 잡게 한다

```
paths: "src/app/site/[slug]/route.ts"   ← 파일은 실재한다
→ 매처는 [slug]를 문자 클래스로 해석 → 영구 미발동
```

검토에서 `csp-headers` 규칙이 fatal 판정을 받은 이유가 정확히 이것이다.
⑤는 (a) 대괄호 글롭을 즉시 위반으로 잡고 (b) 그 외 글롭의 **매치 수가 0이면** 위반으로 센다.

## 검증

- **CLAUDE.md 무변경** — `git diff main --stat -- CLAUDE.md` 비어 있음 (이 PR의 하드 조건)
- paths 글롭 3개가 실제 파일에 매치: 38 · 9 · 6개
- ⑤ **변이 테스트 2/2** (대괄호 리터럴 · 0매치 글롭)
- `pnpm docs:check` 5/5 통과 · lint 0 error · type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)