### PR TITLE
docs: 개발 명령어 절 파생분 삭제 — 파생 불가 사실 전부 보존 (문서 재편 PR4/7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,29 +94,17 @@ AI 기반 노코드 플랫폼. 무료 API를 선택하고 서비스를 설명하
 
 ## 개발 명령어
 
-```bash
-pnpm dev              # 개발 서버 (Turbopack)
-pnpm build            # 프로덕션 빌드
-pnpm lint             # ESLint 검사 (CI 게이트)
-pnpm lint:fix         # ESLint 자동 수정
-pnpm type-check       # TypeScript 타입 검사 (CI 게이트)
-pnpm test             # 전체 테스트 (CI는 test:coverage로 전체 실행)
-pnpm test:unit        # 단위 테스트 (lib, providers, services, repositories)
-pnpm test:integration # 통합 테스트 (API routes — src/__tests__/api + src/app/api)
-pnpm test:coverage    # 커버리지 리포트
-pnpm test:e2e         # E2E (Playwright — 실 백엔드 env 필요, CI에서 실행)
-```
+**명령 목록의 정본은 `package.json`의 `scripts`다** — 여기에 복제하지 않는다(복제하는 순간
+한쪽이 썩는다). 아래는 그 파일에서 **파생되지 않는 것**만이다.
 
-```bash
-# 운영 스크립트
-pnpm countries:generate  # 국가 데이터(src/data/countries.json) 재생성 (준-정적)
-pnpm countries:check     # 쓰기 없이 업스트림 드리프트 검사 — 0 동일 / 1 드리프트 / 2 업스트림 도달 실패
-pnpm ai:contract-check   # AI 규약 드리프트 검사 — 0 유지 / 1 드리프트 / 2 도달 실패
-pnpm docs:check          # 문서 정합성 4종(명령·경로·링크 대소문자·ADR 트리거) — 0 통과 / 1 위반 / 2 검사기 고장
-```
-
-> `docs:check`는 CI에서 **독립 잡 + `continue-on-error`** 로 돈다. 문서 결함이 워크플로를
-> red로 만들면 Wait for CI가 다음 코드 배포를 `SKIPPED`로 만들고, `SKIPPED`는 되살아나지 않는다.
+- **CI 게이트 순서**: `lint` → `type-check` → `test:coverage` → `build` → E2E.
+  CI가 도는 것은 `test`가 아니라 **`test:coverage`** 다
+- `test:e2e`는 **실제 백엔드 env가 있어야** 돈다 — 로컬에서 맨몸으로 돌리면 실패한다
+- 검사 스크립트(`countries:check`·`ai:contract-check`·`docs:check`)의 **종료 코드 1과 2를
+  절대 합치지 말 것** — 1은 드리프트·위반이고 **2는 도달 실패·검사기 고장**이다. 일시적
+  외부 장애를 "규약이 바뀌었다"로 오인하면 경보 신뢰가 통째로 무너진다(각 코드의 의미는 스크립트 헤더에)
+- `docs:check`는 CI에서 **독립 잡 + `continue-on-error`** 로 돈다. 문서 결함이 워크플로를
+  red로 만들면 Wait for CI가 다음 코드 배포를 `SKIPPED`로 만들고, `SKIPPED`는 되살아나지 않는다
 
 > `pnpm admin:hash`(단일 관리자 해시 생성)는 다중 사용자 전환(2026-06-24)으로 **제거됨**. 계정 생성은 `/signup` 공개 페이지를 통해 수행한다.
 


### PR DESCRIPTION
문서 재편 **4단계**. Anthropic `/doctor` 휴리스틱이 지목한 **"코드베이스에서 파생 가능한 것"** 만 지운다.

> *"cuts content Claude can derive from the codebase, such as directory layouts,
> dependency lists, and architecture overviews, and **keeps pitfalls, rationale,
> and conventions that differ from tool defaults**."*

## 삭제 — 기계 증명 완료

`pnpm` 스크립트 **14/14가 package.json에 실재**한다. 설명 문구조차 정의 문자열에서 그대로 나온다:

| 문서가 적던 설명 | package.json 정의 |
|---|---|
| `test:unit` "(lib, providers, services, repositories)" | `vitest run src/lib src/providers src/services src/repositories` |
| `dev` "(Turbopack)" | `next dev --turbopack` |
| `test:integration` "(src/__tests__/api + src/app/api)" | `vitest run src/__tests__/api src/app/api` |

명령 목록 복제는 **이 파일이 스스로 금지하는 패턴**이다 — 환경변수 절이
*"두 곳에 적히는 순간 한쪽이 썩는다"* 고 적고 있다.

## 보존 — 파생 불가한 것은 한 건도 안 지웠다

| 사실 | 왜 파생 불가인가 |
|---|---|
| CI 게이트 **순서**, "CI는 `test`가 아니라 `test:coverage`" | package.json에 없다 |
| `test:e2e`는 **실 백엔드 env 필요** | 로컬 맨몸 실행은 실패한다 |
| 검사 스크립트 **종료 코드 1과 2를 합치지 말라** | 규율이지 사실이 아니다 |
| `docs:check` CI 배선(독립 잡·`continue-on-error`)과 그 이유 | SKIPPED 비가역성은 실측 경험 |

종료 코드의 **개별 의미**는 각 스크립트 헤더에 이미 있어(= 파생 가능) 표를 빼고
**규율 문장만** 남겼다.

## 측정 — 지표를 줄 수에서 토큰으로 바꾼다

**PR4 단독: 22,681 → 22,533 tok (−148, −0.7%) · 474 → 462줄**
(`count_tokens` API · `claude-opus-5` 실측)

작다. 그리고 정직하게 작은 게 맞다. 이번 재편에서 확인된 것:

- **줄 수는 틀린 통화다.** 섹션별 밀도가 20~106 tok/line로 5배 차이 난다
- 실제로 **줄은 줄었는데 토큰은 늘어난** 구간이 있었다 — PR1이 거짓 문장을
  정확한 문장으로 바꾸며 길어졌기 때문이고, **그건 옳은 교환**이다
- 그래서 **200줄 목표는 폐기**했다. 남은 큰 덩어리(배포 품질 111줄, 타입 주의 45줄)는
  전부 결합·반직관 절차 본문이라 절단으로만 도달 가능한데, 그 절단이 역사적으로 사고를 냈다

## 검증

- `pnpm docs:check` 통과 (① pnpm 명령 검사가 이 삭제를 자동 검증한다)
- 삭제된 줄 중 **파생 불가한 사실 0건** — 각 항목의 대체 위치를 1:1로 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)