### PR TITLE
docs: 세션시작 SonarCloud 절차·디렉터리 표 중복 제거 — 바이트 동일 이동 (문서 재편 PR5/7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,20 +399,9 @@ Sentry SaaS 도입.
 작업 세션을 시작할 때 아래 두 가지를 반드시 먼저 확인한다.
 
 1. **Railway 배포 상태** — `railway deployment list --json` (최신 배포 status·커밋 확인)
-2. **SonarCloud 품질 상태** — 아래 우선순위로 확인:
-   - **(기본)** SonarQube MCP 도구로 `xzawed_CustomWebService` 프로젝트 이슈·품질 게이트 조회
-   - **(차선 — MCP 미로드 시)** SonarCloud REST API로 대체 (`SONARCLOUD_TOKEN` 환경변수 또는 `~/.sonar-token` 파일에서 읽기):
-     ```bash
-     # 토큰 설정: echo "토큰값" > ~/.sonar-token && chmod 600 ~/.sonar-token
-     # 또는: export SONARCLOUD_TOKEN=토큰값
-     SONAR_TOKEN="${SONARCLOUD_TOKEN:-$(cat ~/.sonar-token 2>/dev/null)}"
-     # 품질 게이트
-     curl -s -u "$SONAR_TOKEN:" \
-       "https://sonarcloud.io/api/qualitygates/project_status?projectKey=xzawed_CustomWebService"
-     # 신규 이슈
-     curl -s -u "$SONAR_TOKEN:" \
-       "https://sonarcloud.io/api/issues/search?projectKeys=xzawed_CustomWebService&resolved=false&ps=5"
-     ```
+2. **SonarCloud 품질 상태** — SonarQube MCP 도구로 `xzawed_CustomWebService` 조회.
+   MCP 미로드 시 REST 폴백 절차(토큰 셋업·curl 2건)는 [operations.md §1.6](docs/guides/operations.md).
+   **게이트는 신규 코드만 본다** — PASS여도 기존 BLOCKER·CRITICAL은 따로 조회해야 한다
 
 이상 징후(배포 실패, 품질 게이트 FAILED, 신규 버그/취약점)가 있을 때만 사용자에게 보고한다. 정상이면 별도 보고 없이 작업을 진행한다.
 
@@ -447,13 +436,7 @@ Claude는 이 프로젝트에서 컨텍스트 업무를 정확하고 효율적�
 
 Claude는 프로젝트 문서의 파일명·위치·내용을 정확하고 이해하기 쉽게 관리합니다.
 
-**디렉터리 용도:**
-- `docs/architecture/` — 시스템 구조 설명
-- `docs/guides/` — 작업 절차 가이드
-- `docs/reference/` — API·환경변수 등 참조 자료
-- `docs/decisions/` — 설계 결정 배경 (ADR)
-- `docs/superpowers/specs/` — 기능 설계 문서 (`YYYY-MM-DD-<topic>-design.md`)
-- `docs/superpowers/plans/` — 구현 계획 (`YYYY-MM-DD-<topic>.md`)
+**디렉터리 용도·파일명 규약**: [docs/README.md](docs/README.md)의 폴더 표가 진실원이다.
 
 **규칙:**
 - 새 문서 추가·수정·삭제 시 [docs/README.md](docs/README.md) 인덱스를 갱신하고, 에이전트 필수 문서면 이 파일의 "문서 참조"에도 반영

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,12 @@
 | [superpowers/](superpowers/) | 설계 초안·장기 계획. **현재 상태는 architecture/guides/reference/`CLAUDE.md` 우선** |
 | [archive/](archive/) | **역사 문서 (비실행).** 완료된 컷오버·마이그레이션 절차 |
 
+**파일명 규약** — 날짜가 붙는 두 곳만 고정이다(나머지는 주제 기반 kebab-case):
+
+- `superpowers/specs/` — 기능 설계 문서 `YYYY-MM-DD-<topic>-design.md`
+- `superpowers/plans/` — 구현 계획 `YYYY-MM-DD-<topic>.md`
+- `decisions/` — ADR `YYYY-MM-DD-<topic>.md`
+
 루트 보조:
 
 | 경로 | 내용 |

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -131,6 +131,28 @@ curl -X POST "$APP_URL/api/v1/admin/catalog/deactivate" \
 
 상세 필드 표·불변조건: [database.md §ensureCatalogEntries](../architecture/database.md).
 
+### 1.6 SonarCloud 품질 상태 조회
+
+세션 시작 시 품질 게이트를 본다. **우선순위 1은 SonarQube MCP 도구**(`xzawed_CustomWebService`
+프로젝트 이슈·품질 게이트 조회)이고, 아래는 **MCP가 로드되지 않았을 때의 REST 폴백**이다.
+토큰 셋업은 1회성이라 매 세션 읽을 필요가 없어 여기에 둔다.
+
+```bash
+# 토큰 설정: echo "토큰값" > ~/.sonar-token && chmod 600 ~/.sonar-token
+# 또는: export SONARCLOUD_TOKEN=토큰값
+SONAR_TOKEN="${SONARCLOUD_TOKEN:-$(cat ~/.sonar-token 2>/dev/null)}"
+# 품질 게이트
+curl -s -u "$SONAR_TOKEN:" \
+  "https://sonarcloud.io/api/qualitygates/project_status?projectKey=xzawed_CustomWebService"
+# 신규 이슈
+curl -s -u "$SONAR_TOKEN:" \
+  "https://sonarcloud.io/api/issues/search?projectKeys=xzawed_CustomWebService&resolved=false&ps=5"
+```
+
+> **품질 게이트는 신규 코드만 본다.** 게이트가 PASS여도 기존 코드의 BLOCKER·CRITICAL은
+> 그대로 남아 있을 수 있으므로, 필요하면 `issues/search`에 `severities=BLOCKER,CRITICAL`을
+> 붙여 **따로 조회**한다.
+
 ---
 
 ## 2. 모니터링·경보


### PR DESCRIPTION
문서 재편 **5단계**. **이동만 한다** — 요약·압축은 하지 않는다.

## ① SonarCloud REST 폴백 → `operations.md §1.6` (신설)

토큰 셋업(`~/.sonar-token` 생성·`chmod 600`)과 curl 2건은 **1회성 셋업**이다.
매 세션 항상 로드할 이유가 없다.

**명령 9줄은 바이트 동일하게 옮겼다** — 리스트 밖으로 나오면서 5칸 들여쓰기만 제거했고,
`diff`로 **차이 0**을 증명했다.

CLAUDE.md 잔류:
- MCP 우선 조회 (기본 경로)
- 폴백 절차 위치 링크
- **"게이트는 신규 코드만 본다 — PASS여도 기존 BLOCKER·CRITICAL은 따로 조회해야 한다"**
  ← 원래 어디에도 없던 운영 함정. 이번에 명시(순증)

## ② 디렉터리 용도 목록 → `docs/README.md` 폴더 표로 일원화

`docs/README.md:39-47`에 **이미 같은 표가 있었다**. 그쪽이 `security/`·`archive/`까지
포함한 **상위집합**이고, CLAUDE.md 쪽이 열등한 부분 사본이었다.

⚠️ 단, **파일명 규약**(`YYYY-MM-DD-<topic>-design.md` 등)은 **CLAUDE.md에만** 있었다.
→ **먼저 `docs/README.md`로 옮긴 뒤** 삭제했다. 목적지에 없는 것을 지우면 그건 이동이 아니라 유실이다.

## 검증

| 항목 | 결과 |
|---|---|
| 삭제 21줄의 목적지 | **21/21 확인** (12줄 → operations.md §1.6 · 6줄 → docs/README 폴더 표 + 신규 규약 절 · 3줄은 같은 hunk에서 재작성) |
| SonarCloud 명령 본문 | 9/9줄 `diff` **차이 0** |
| 줄 수 | 461 → **444** |
| 토큰 | 22,533 → **22,081 (−452)** (`count_tokens` · claude-opus-5 실측) |
| `pnpm docs:check` | **5/5 통과** (③ 링크 검사가 새 링크를 자동 검증) |

## 덤 — 검증 명령의 버그를 하나 잡았다

삭제줄 열거에 `^-[^-]` 패턴을 쓰면 **`- `로 시작하는 리스트 삭제줄이 통째로 누락**된다
(diff에서 `-- item`이 되므로). 처음 실행에서 21줄 중 15줄만 보였다.

G4("너무 깨끗한 결과는 도메인 결론 전에 방법을 의심하라")대로 재확인해서 잡았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)