### PR TITLE
docs: 네비 표에 database.md 추가 + 저빈도 6행 일원화 (문서 재편 PR7/7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,17 +180,14 @@ AI 기반 노코드 플랫폼. 무료 API를 선택하고 서비스를 설명하
 | **배포했는데 반영이 안 될 때** (조용한 미배포 2종) | [docs/guides/railway-deploy-troubleshooting.md](docs/guides/railway-deploy-troubleshooting.md) |
 | SQLite 복구 런북 | [docs/guides/sqlite-restore-runbook.md](docs/guides/sqlite-restore-runbook.md) |
 | 시크릿 노출·회전 | [docs/security/incident-response.md](docs/security/incident-response.md) |
-| 에러 코드 | [docs/reference/error-codes.md](docs/reference/error-codes.md) |
+| **DB 스키마·시드·`ensureCatalog` 계약** | [docs/architecture/database.md](docs/architecture/database.md) |
 | 개발 환경·팩토리 규칙 | [docs/guides/development.md](docs/guides/development.md) |
 | 설계 결정(ADR) 전체 | [docs/decisions/](docs/decisions/) · 목록은 [docs/README.md](docs/README.md) |
-| 컷오버 등 **비실행** 역사 | [docs/archive/](docs/archive/) |
-| 문서 인덱스·anti-recurrence | [docs/README.md](docs/README.md) |
-| 슬래시 커맨드 체크리스트 only | [.claude/commands/](.claude/commands/) |
+| 문서 인덱스·anti-recurrence·**나머지 전부** | [docs/README.md](docs/README.md) |
 
-- [README.md](README.md) — 제품 정문·설치 퀵스타트
-- [AGENTS.md](AGENTS.md) — **포인터 only** (규칙 본문 복제 금지)
-- [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) — PR 템플릿
-- [.scamanager/](.scamanager/) — pre-push 자동 코드리뷰 훅 (`install-hook.sh`로 설치)
+여기 없는 문서(에러 코드·archive 역사·`.claude/commands`·`.claude/rules`·PR 템플릿·`.scamanager`)는
+**전부 [docs/README.md](docs/README.md)에 등재돼 있다.** 현재 시제 문서는 모두 첫 줄에
+`> **언제 읽나**` 트리거를 갖고 있으므로, 인덱스에서 제목만 보고 열지 말지 판단할 수 있다.
 
 ## 배포 품질 원칙 (필수)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,9 @@
 | [`README.md`](../README.md) | 제품 정문·설치 퀵스타트 |
 | [`.env.example`](../.env.example) | 로컬 스타터 env (코드가 읽는 변수만) |
 | [`.claude/commands/`](../.claude/commands/) | 슬래시 커맨드 체크리스트 5종 |
+| [`.claude/rules/`](../.claude/rules/) | **경로 스코프 규칙** — `paths` 프론트매터가 매칭하는 파일을 **읽을 때만** 로드된다(신규 파일 Write 시엔 안 뜬다) |
+| [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) | PR 템플릿 |
+| [`.scamanager/`](../.scamanager/) | pre-push 자동 코드리뷰 훅 (`install-hook.sh`로 설치) |
 
 ---
 


### PR DESCRIPTION
문서 재편 **마지막 7단계**. **PR6 선행 필수** — 목적지에 트리거가 붙은 뒤에만 실행한다.

순서를 뒤집으면 1홉이던 문서가 *"무엇이 들었는지 몰라 안 여는"* 2홉이 되어 **순손실**이고,
그게 정확히 역사적 오류 #7("진실원이 있었는데 안 열었다")의 형태다.

## 추가 — `docs/architecture/database.md`

526줄짜리 **스키마·시드·`ensureCatalog` 계약의 진실원**인데 네비 표에 없었다(산문 링크 하나뿐).
PR1에서 `ensureCatalog`의 `CORRECTIONS` 함정이 드러난 만큼 1홉에 있어야 한다.

## 내림 — 6행 (전부 목적지 확인 후)

에러 코드 · archive 역사 · `.claude/commands` · PR 템플릿 · `.scamanager` · docs/README 자기 참조

### ⚠️ 하드 게이트가 실제로 걸렸다

```
  ✔ reference/error-codes.md
  ✔ archive/
  ✔ .claude/commands/
  ✘ BLOCKED PULL_REQUEST_TEMPLATE
  ✘ BLOCKED scamanager
```

`PULL_REQUEST_TEMPLATE`·`.scamanager`가 `docs/README.md`에 **미등재**였다.
→ **먼저 등재한 뒤** 내렸다. PR5와 같은 규율: **목적지에 없는 것을 지우면 이동이 아니라 유실이다.**

`.claude/rules/`도 이 기회에 루트 보조 표에 넣고 **발동 조건**(Read 시점에만, 신규 파일 Write 시엔 안 뜸)을 명시했다.

**최종 재검사 BLOCKED 0건.**

## 왜 안전한가

내린 문서는 전부 (a) `docs/README.md` 인덱스에 있고 (b) 첫 줄에 `> **언제 읽나**` 트리거가 있다(PR6).
즉 **인덱스에서 제목만 보고도 열지 말지 판단할 수 있다.**
그 사실을 표 아래 한 문단으로 명시해, 표에 없다고 "없는 문서"로 오인하지 않게 했다.

## 측정

- 444 → **441줄** · 22,081 → **22,016 tok (−65)**
- `pnpm docs:check` **5/5 통과** · 삭제 9줄 전부 목적지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)