### PR TITLE
ci: builder 페이지를 커버리지 집계에 편입 — 괄호 경로 glob 함정 재확인

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -76,6 +76,11 @@ export default defineConfig({
         // 이 패턴이 login/signup/forgot-password/reset-password/verify-email 5개를 전부 잡으며,
         // `(main)` 하위 페이지는 잡지 않는다(의도된 범위).
         'src/app/[(]auth[)]/**/page.tsx',
+        // 2026-08-06: F14 조사 결과 이 페이지(757줄)가 **커버리지 집계에서 빠져 있었다**.
+        // 위 (auth) 건과 같은 함정을 다시 확인했다 — `'src/app/(main)/**/*.tsx'`는 매칭 0건이고
+        // 문자 클래스 형태만 잡힌다(picomatch 2.3.2 실측). 범위를 이 파일 하나로 좁힌 이유는
+        // `'src/app/[(]main[)]/**/*.tsx'`가 12건(테스트 없는 다른 페이지 포함)을 쓸어담기 때문.
+        'src/app/[(]main[)]/builder/page.tsx',
         'src/hooks/**',
         'src/lib/**',
         'src/services/**',


### PR DESCRIPTION
`src/app/(main)/builder/page.tsx`(757줄)가 **커버리지 집계에서 빠져 있었다.**
이 파일을 고쳐도 codecov/patch·SonarCloud new_coverage가 0%로 계산하므로,
리팩터가 회귀를 만들어도 **CI가 구조적으로 못 잡는** 상태였다.

## 괄호 경로 함정 — 라이브 재확인

이 레포가 `(auth)`에서 이미 겪고 §3.2에 기록한 함정을 **그대로 다시 밟았다.**
picomatch 2.3.2 실측:

| 패턴 | 결과 |
|---|---|
| `src/app/(main)/**/*.tsx` | **매칭 0건** — `(main)`을 extglob으로 해석 |
| `src/app/[(]main[)]/builder/page.tsx` | ✔ 1건 (채택) |
| `src/app/[(]main[)]/**/*.tsx` | ✔ 12건 — 테스트 없는 다른 페이지까지 쓸어담음 |
| `src/app/**/builder/page.tsx` | ✔ 1건 |

기존 `(auth)` 항목과 **같은 문자 클래스 형태**를 골라 관례를 유지했고,
범위를 이 파일 하나로 좁혔다.

## 검증

- **lcov 등재 확인**(§3.2 요구 절차): `SF:src/app/(main)/builder/page.tsx` ✔
- **전역 임계 여유**: 실측 Statements 90.84 / Branches 81.34 / Functions 88.5 / Lines 92.09
  vs 임계 43 / 40 / 30 / 45 — 757줄 0% 파일 편입에도 여유가 크다
- 194 파일 **2,487 테스트 통과** · lint 0 error · type-check clean

## 하지 않은 것 (의도)

`codecov.yml`·`sonar-project.properties`는 **건드리지 않았다.** 둘 다
`src/app/**/page.tsx`를 제외하는데, 테스트 없이 제외를 풀면 builder를 건드리는 모든 PR이
patch 0%로 실패한다. 세 곳을 함께 켜는 것은 **특성화 테스트가 생긴 뒤**다.

## 협업 기록

이 조사는 Grok에 위임했다(라우팅 판정 LOW·worktree). Grok이 picomatch를 pnpm 스토어에서
resolve해 6개 패턴을 실측하고 최소 매칭 패턴을 골랐으며, **저는 동일 실측을 독립 재현해
결과가 일치함을 확인한 뒤** 반영했다. codecov/sonar를 건드리지 않는다는 판단도 양쪽이 독립적으로 같았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)