### PR TITLE
fix: 인기 서비스 데드엔드와 세션 간 추천 오염 수정 (F20 ③④)

### DIFF
--- a/src/app/(main)/builder/page.test.tsx
+++ b/src/app/(main)/builder/page.test.tsx
@@ -247,7 +247,7 @@ describe('KNOWN-DEFECT: 인기 서비스 선택이 카탈로그 미로드 시 �
     });
   });
 
-  it('KNOWN-DEFECT — 카탈로그가 비어 있으면 컨텍스트만 채우고 API를 조용히 버린다', async () => {
+  it('카탈로그가 비어 있으면 컨텍스트만 채우고 **기존 선택은 건드리지 않는다**', async () => {
     // 카탈로그 응답이 비어 있는 상황(로드 실패·지연·limit 캡으로 잘림)을 재현한다.
     installHandlers({ catalog: [] });
     server.use(
@@ -257,16 +257,20 @@ describe('KNOWN-DEFECT: 인기 서비스 선택이 카탈로그 미로드 시 �
     );
 
     await enterContextFirst();
+    // 사용자가 이미 고른 API가 있는 상태로 만든다 — 수정 전에는 이게 지워졌다.
+    useApiSelectionStore.getState().addApi(makeApi('user-picked') as never);
     await waitFor(() => expect(screen.getByText('날씨 대시보드')).toBeTruthy());
     fireEvent.click(screen.getByText('날씨 대시보드').closest('button')!);
 
     await waitFor(() => expect(useContextStore.getState().context).toBe(LONG_CONTEXT));
-    // ⛔ 여기가 결함이다 — 컨텍스트는 들어갔는데 API는 하나도 안 들어갔다.
-    // `apis.find()`가 전부 undefined를 반환하는데 `clearApis()`는 이미 실행된 뒤다.
-    expect(useApiSelectionStore.getState().selectedApis).toHaveLength(0);
+    // 해석된 API가 0개이므로 `handleSelectPopularService`는 조기 반환한다 —
+    // `clearApis()`가 실행되지 않아 사용자의 기존 선택이 살아남는다.
+    const selected = useApiSelectionStore.getState().selectedApis;
+    expect(selected).toHaveLength(1);
+    expect(selected[0].id).toBe('user-picked');
   });
 
-  it('KNOWN-DEFECT — 그 상태에서 「다음」을 눌러도 추천을 재조회하지 않는다 (데드엔드)', async () => {
+  it('회귀 — 그 상태에서 「다음」을 누르면 추천을 정상적으로 재조회한다 (데드엔드 아님)', async () => {
     let suggestApiHits = 0;
     installHandlers({ catalog: [] });
     server.use(
@@ -286,13 +290,12 @@ describe('KNOWN-DEFECT: 인기 서비스 선택이 카탈로그 미로드 시 �
 
     fireEvent.click(screen.getByText('다음').closest('button')!);
 
-    // ⛔ 결함의 핵심 — `handleSelectPopularService`가 `lastRecommendedContext`를
-    // `context`와 **같은 값**으로 설정해 두었기 때문에, `handleNextStep`의
-    // `context !== lastRecommendedContext` 가드가 거짓이 되어 재조회가 막힌다.
-    // 사용자는 API 0개인 채로 2단계에 도착하고 빠져나갈 방법이 없다.
+    // 수정 전에는 `lastRecommendedContext`가 `context`와 같은 값으로 설정돼 있어
+    // `handleNextStep`의 `context !== lastRecommendedContext` 가드가 거짓이 되고
+    // 재조회가 막혀 **API 0개로 2단계에 갇혔다**. 지금은 해석 실패 시 그 값을 건드리지
+    // 않으므로 정상적으로 추천을 조회한다.
     await waitFor(() => expect(screen.getByText('추천된 API를 확인하세요')).toBeTruthy());
-    expect(suggestApiHits).toBe(0);
-    expect(useApiSelectionStore.getState().selectedApis).toHaveLength(0);
+    await waitFor(() => expect(suggestApiHits).toBe(1));
   });
 });
 
@@ -310,7 +313,7 @@ describe('KNOWN-DEFECT: 늦게 도착한 추천 응답이 사용자 선택을 �
   // "비행 중 수동 선택이 지워진다"는 **의도된 동작일 수 있다**(추천이 도착하면 자동 선택이
   // 대체하는 게 설계일 수 있음). 반면 **방식을 바꿔 새 세션을 시작했는데 이전 세션의 추천이
   // 흘러드는 것**은 어떤 해석으로도 옳지 않다. 모호하지 않은 쪽을 고정한다.
-  it('KNOWN-DEFECT — 방식 변경 후에도 이전 세션의 늦은 추천이 새 세션을 오염시킨다', async () => {
+  it('회귀 — 방식 변경 후 도착한 이전 세션의 추천은 새 세션에 주입되지 않는다', async () => {
     const gate = deferred<void>();
     const leaked = makeApi('leaked', '이전 세션 추천 API');
     installHandlers({ catalog: [makeApi('a1'), leaked] });
@@ -344,14 +347,10 @@ describe('KNOWN-DEFECT: 늦게 도착한 추천 응답이 사용자 선택을 �
     // 이제 **이전 세션의** 늦은 응답이 도착한다.
     gate.resolve();
 
-    // ⛔ 결함 — `fetchApiRecommendations`(295-323)에 AbortController가 없다.
-    // (이 페이지에서 AbortController는 113행 카탈로그·217행 preferences 둘뿐이다.)
-    // 그래서 방식 변경으로 취소돼야 할 요청이 살아남아, 312행 `clearApis()` 후
-    // **이전 컨텍스트의 추천이 새 세션에 주입된다.**
-    await waitFor(() => {
-      const selected = useApiSelectionStore.getState().selectedApis;
-      expect(selected).toHaveLength(1);
-      expect(selected[0].id).toBe('leaked');
-    });
+    // `handleResetMode`·`handleModeSelect`가 `aiRequestAbortRef`를 abort했으므로
+    // 이 응답은 아무 상태도 쓰지 않는다. 수정 전에는 `clearApis()` 후 이전 컨텍스트의
+    // 추천이 새 세션에 주입됐다.
+    await new Promise((r) => setTimeout(r, 50)); // 주입이 일어난다면 이 사이에 일어난다
+    expect(useApiSelectionStore.getState().selectedApis).toHaveLength(0);
   });
 });

--- a/src/app/(main)/builder/page.tsx
+++ b/src/app/(main)/builder/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { CatalogView } from '@/components/catalog/CatalogView';
@@ -50,6 +50,16 @@ export default function BuilderPage() {
   const [categories, setCategories] = useState<Category[]>([]);
   const [isLoadingCatalog, setIsLoadingCatalog] = useState(true);
   const [regenVersion, setRegenVersion] = useState<number | undefined>(undefined);
+
+  /**
+   * 비행 중인 AI 제안 요청(suggest-context · suggest-apis)의 취소 핸들.
+   *
+   * 둘은 모드별로 배타적이라(api-first는 suggest-context, context-first는 suggest-apis)
+   * ref 하나를 공유한다. 방식 변경·모드 선택은 이걸 abort해서 **이전 세션의 늦은 응답이
+   * 새 세션에 주입되는 것**을 막는다. 없으면 `fetchApiRecommendations`의 `clearApis()`가
+   * 새 세션 선택을 지우고 이전 컨텍스트의 추천을 채워 넣는다.
+   */
+  const aiRequestAbortRef = useRef<AbortController | null>(null);
 
   // Context suggestion state (for api-first mode)
   const [suggestions, setSuggestions] = useState<string[]>([]);
@@ -137,12 +147,18 @@ export default function BuilderPage() {
       }
     }
     loadCatalog();
-    return () => abortCtrl.abort();
+    return () => {
+      abortCtrl.abort();
+      // 언마운트 시 비행 중인 AI 제안 요청도 끊는다 — 사라진 화면에 상태를 쓰지 않는다.
+      aiRequestAbortRef.current?.abort();
+    };
   }, []);
 
   // === Mode selection from big cards ===
   const handleModeSelect = useCallback(
     (selectedMode: BuilderMode) => {
+      // 이전 세션의 AI 요청이 살아 있으면 새 세션을 오염시킨다 — 먼저 끊는다.
+      aiRequestAbortRef.current?.abort();
       setMode(selectedMode);
       setModeConfirmed(true);
       setStep(1);
@@ -163,6 +179,9 @@ export default function BuilderPage() {
     setStep(1);
     clearApis();
     resetContext();
+    // 비행 중인 AI 제안 요청을 끊는다. 안 끊으면 늦은 응답의 clearApis()가
+    // 새 세션 선택을 지우고 이전 컨텍스트의 추천을 주입한다.
+    aiRequestAbortRef.current?.abort();
     // 고아 폴러 네트워크를 즉시 끊는다. 스토어 오염 1차 방어는 runId(E8).
     abortGenerationSession();
     resetGeneration();
@@ -261,6 +280,13 @@ export default function BuilderPage() {
   // === API-first mode: fetch context suggestions ===
   const fetchSuggestions = useCallback(async () => {
     if (selectedApis.length === 0) return;
+
+    // 추천과 같은 이유로 취소 가능해야 한다 — 방식을 바꾸면 이전 세션의 제안이
+    // 새 세션 화면에 뜨면 안 된다. 두 요청은 서로 배타적이라 ref 하나를 공유한다.
+    aiRequestAbortRef.current?.abort();
+    const abortCtrl = new AbortController();
+    aiRequestAbortRef.current = abortCtrl;
+
     setIsSuggestionsLoading(true);
     setSuggestions([]);
     setActiveSuggestionIndex(null);
@@ -275,6 +301,7 @@ export default function BuilderPage() {
             category: a.category,
           })),
         }),
+        signal: abortCtrl.signal,
       });
       if (!res.ok) {
         const errBody = await res.json().catch(() => ({}));
@@ -282,18 +309,30 @@ export default function BuilderPage() {
         throw new Error(errBody?.error?.message ?? `HTTP ${res.status}`);
       }
       const data = await res.json();
+      if (abortCtrl.signal.aborted) return;
       setSuggestions(data.data?.suggestions ?? []);
     } catch (err) {
+      if ((err as { name?: string }).name === 'AbortError') return;
       console.error('[suggest-context] failed:', err instanceof Error ? err.message : err);
       setSuggestions([]);
     } finally {
-      setIsSuggestionsLoading(false);
+      if (!abortCtrl.signal.aborted) {
+        setIsSuggestionsLoading(false);
+      }
     }
   }, [selectedApis]);
 
   // === Context-first mode: fetch API recommendations ===
   const fetchApiRecommendations = useCallback(async () => {
     if (!context || context.length < LIMITS.contextMinLength) return;
+
+    // 이전 요청을 취소하고 이번 요청을 현재 것으로 등록한다.
+    // 없으면 방식 변경으로 세션을 새로 시작해도 **이전 컨텍스트의 추천이 살아남아**
+    // 아래 clearApis() 이후 새 세션에 주입된다(세션 간 오염).
+    aiRequestAbortRef.current?.abort();
+    const abortCtrl = new AbortController();
+    aiRequestAbortRef.current = abortCtrl;
+
     setIsRecommendationsLoading(true);
     setApiRecommendations([]);
     setRecommendationsError(false);
@@ -302,9 +341,12 @@ export default function BuilderPage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ context }),
+        signal: abortCtrl.signal,
       });
       if (!res.ok) throw new Error('Failed to fetch API recommendations');
       const data = await res.json();
+      // 응답 파싱 사이에 취소됐을 수 있다 — 쓰기 직전에 한 번 더 본다.
+      if (abortCtrl.signal.aborted) return;
       const recs: ApiRecommendation[] = data.data?.recommendations ?? [];
       setApiRecommendations(recs);
       setLastRecommendedContext(context);
@@ -313,12 +355,16 @@ export default function BuilderPage() {
       for (const rec of recs) {
         addApi(rec.api);
       }
-    } catch {
+    } catch (err) {
+      // 취소는 실패가 아니다 — 에러 UI를 띄우거나 상태를 되돌리지 않는다.
+      if ((err as { name?: string }).name === 'AbortError') return;
       setApiRecommendations([]);
       setRecommendationsError(true);
       setLastRecommendedContext(null);
     } finally {
-      setIsRecommendationsLoading(false);
+      if (!abortCtrl.signal.aborted) {
+        setIsRecommendationsLoading(false);
+      }
     }
   }, [context, clearApis, addApi]);
 
@@ -411,23 +457,28 @@ export default function BuilderPage() {
   const handleSelectPopularService = useCallback(
     (service: PopularService) => {
       setContext(service.context);
-      if (service.apiIds.length > 0) {
-        clearApis();
-        for (const apiId of service.apiIds) {
-          const api = apis.find((a) => a.id === apiId);
-          if (api) addApi(api);
-        }
-        setApiRecommendations(
-          service.apiIds
-            .map((apiId) => {
-              const api = apis.find((a) => a.id === apiId);
-              return api ? { api, reason: '인기 서비스 추천 API' } : null;
-            })
-            .filter((r): r is ApiRecommendation => r !== null)
-        );
-        setLastRecommendedContext(service.context);
-        setRecommendationsError(false);
-      }
+
+      // 카탈로그에서 **실제로 해석된** API만 센다. 카탈로그가 아직 안 왔거나
+      // 로드에 실패했으면 여기가 빈 배열이 된다.
+      const resolved = service.apiIds
+        .map((apiId) => apis.find((a) => a.id === apiId))
+        .filter((api): api is ApiCatalogItem => api !== undefined);
+
+      // ⚠️ 해석된 게 하나도 없으면 **아무것도 건드리지 않는다.**
+      // 예전에는 `service.apiIds.length > 0`만 보고 진행해서, 카탈로그가 비어 있으면
+      // clearApis()로 선택만 지우고 API는 하나도 못 넣은 채 `lastRecommendedContext`를
+      // 설정했다. 그러면 handleNextStep의 `context !== lastRecommendedContext` 가드가
+      // 거짓이 되어 추천 재조회까지 막혀 **2단계에서 빠져나갈 수 없었다**(데드엔드).
+      // 지금은 컨텍스트만 채우고 빠지므로, 「다음」에서 정상적으로 추천을 조회한다.
+      if (resolved.length === 0) return;
+
+      clearApis();
+      for (const api of resolved) addApi(api);
+      setApiRecommendations(
+        resolved.map((api) => ({ api, reason: '인기 서비스 추천 API' }))
+      );
+      setLastRecommendedContext(service.context);
+      setRecommendationsError(false);
     },
     [setContext, clearApis, addApi, apis]
   );


### PR DESCRIPTION
KNOWN-DEFECT로 고정해 둔 두 결함을 고친다.
**고정 단언이 뒤집히는 것이 수정의 증거**이므로, 이 PR은 그 단언을 회귀 단언으로 전환한다
(사전에 명문화한 **허용된 유일한 테스트 수정**).

## ③ 인기 서비스 데드엔드

```
기존:  if (service.apiIds.length > 0) { clearApis(); … setLastRecommendedContext(...) }
문제:  카탈로그가 비면 apis.find()가 전부 undefined → 선택만 지우고 API는 0개
       그런데 lastRecommendedContext 는 설정됨
결과:  handleNextStep 의 `context !== lastRecommendedContext` 가드가 거짓
    →  재조회 차단 →  API 0개로 2단계에 갇힘
```

**수정**: 카탈로그에서 **실제로 해석된** API만 세고, 0개면 컨텍스트만 채우고 조기 반환.
`clearApis()`도 `lastRecommendedContext`도 건드리지 않아 「다음」에서 정상 조회된다.
부수 효과로 `apis.find()` 중복 순회(2회 → 1회)도 정리됐다.

## ④ 세션 간 추천 오염

`fetchApiRecommendations`·`fetchSuggestions`에 **AbortController가 없었다**
(이 페이지에서 AbortController는 카탈로그·preferences 둘뿐이었다).

방식을 바꿔 새 세션을 시작해도 이전 요청이 살아남아, 응답 도착 시 `clearApis()` 후
**이전 컨텍스트의 추천이 새 세션에 주입**됐다.

**수정**: `aiRequestAbortRef` 하나를 두 요청이 공유한다(모드별로 배타적이라 안전).
- 신규 요청 시 이전 것 abort
- `handleResetMode` · `handleModeSelect` · 언마운트에서 abort
- 응답 파싱 후 **상태 쓰기 직전**에 `signal.aborted` 재확인
- `AbortError`는 실패로 처리하지 않음(에러 UI 안 띄움, `lastRecommendedContext` 안 지움)

## 검증 — 양방향으로 확인했다

```
① 수정 적용        → KNOWN-DEFECT 단언 2건 실패   ← 수정이 동작한다는 증거
② 회귀 단언 전환   → 11 passed (11)
③ 수정 되돌림      → 회귀 단언 3건 실패           ← 단언이 수정을 지킨다는 증거
④ 수정 복원        → 11 passed (11)
```

단언이 **수정 그 자체**에 걸려 있다 — 부수 효과로 통과하는 게 아니다.

## 측정

| | 이전 | 이후 |
|---|---:|---:|
| `builder/page.tsx` Stmts | 55.55% | **60.42%** |
| Lines | 57.86% | **63.38%** |
| 전역 Statements | 93.16% | **93.23%** |

195 파일 **2,498 테스트 통과** · lint 0 error · type-check clean

## 잔여 (G3)

결함 **①**(regenVersion → 미리보기 404) · **②**(isPreferenceLoading 영구 true)는
**아직 고정도 수정도 안 했다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)