### PR TITLE
fix: 네트워크 실패 시 로그인·가입 버튼이 영구 비활성화되던 문제 (TDD)

### DIFF
--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -71,4 +71,25 @@ describe('LoginPage local(Credentials) mode', () => {
     expect(signupLink.getAttribute('href')).toBe('/signup');
     expect(forgotLink.getAttribute('href')).toBe('/forgot-password');
   });
+
+  // KNOWN-DEFECT: handleCredentialsLogin에서 setCredLoading(true) 후 signIn(line 26)이
+  // reject되면 try/catch/finally가 없어 credLoading이 true로 남고 에러도 안 보인다.
+  // 수정 전까지 이 테스트는 FAIL이 정상이다.
+  it('signIn이 거부되면(네트워크 실패) 버튼이 영구 비활성화되고 에러도 표시되지 않는다 (KNOWN-DEFECT)', async () => {
+    mocks.signIn.mockRejectedValue(new Error('network down'));
+    renderComponent(<LoginPage />);
+
+    const emailInput = screen.getByLabelText('이메일');
+    fireEvent.change(emailInput, { target: { value: 'admin@example.com' } });
+    fireEvent.change(screen.getByLabelText('비밀번호'), { target: { value: 'hunter2' } });
+    fireEvent.submit(emailInput.closest('form')!);
+
+    // 기대: 네트워크 실패 후에도 버튼이 다시 활성화되고 에러가 보여야 한다.
+    await waitFor(() => {
+      const button = screen.getByRole('button', { name: /로그인/ });
+      expect(button.hasAttribute('disabled')).toBe(false);
+    });
+    // credError는 role=alert 없는 plain div. 의도 문구는 아직 미정 → 관용 매처.
+    expect(screen.getByText(/오류|실패|잠시 후|다시 시도/)).toBeTruthy();
+  });
 });

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -23,14 +23,31 @@ export default function LoginPage() {
     setCredError(null);
     setCredLoading(true);
 
-    const res = await signIn('credentials', { email, password, redirect: false });
+    let res: Awaited<ReturnType<typeof signIn>>;
+    try {
+      res = await signIn('credentials', { email, password, redirect: false });
+    } catch {
+      // signIn은 자격증명 오류를 `res.error`로 돌려주지만 **네트워크·서버 도달 실패는 throw**한다.
+      // 이 catch가 없으면 아래가 통째로 실행되지 않아 credLoading이 true로 굳고, 버튼이
+      // '로그인 중...'으로 영구 비활성화되며 **에러 문구조차 뜨지 않는다**(새로고침 외 탈출 불가).
+      // 자격증명 오류와 문구를 반드시 구분한다 — 같은 문구를 쓰면 사용자가 비밀번호를 의심하며
+      // 재시도해 계정 스로틀만 소모한다. 이 문구는 계정 존재 여부와 무관하므로 오라클이 아니다.
+      setCredError('로그인 요청에 실패했습니다. 네트워크 상태를 확인하고 잠시 후 다시 시도해 주세요.');
+      setCredLoading(false);
+      return;
+    }
 
     if (res?.error) {
+      // 스로틀 초과도 여기로 온다(authorize가 null 반환). 계정 존재 여부가 새지 않도록
+      // **항상 같은 문구**여야 한다 — docs/decisions/2026-07-30-login-rate-limit.md
       setCredError('이메일 또는 비밀번호가 올바르지 않습니다.');
       setCredLoading(false);
       return;
     }
 
+    // 성공 경로는 credLoading을 **의도적으로 true로 둔다.** 페이지를 떠나는 중이며,
+    // 여기서 false로 되돌리면 내비게이션이 끝나기 전에 버튼이 다시 눌려 이중 제출이 된다.
+    // (finally로 일괄 해제하지 않는 이유가 이것이다 — 실패 경로에서만 해제한다.)
     window.location.assign(getSafeRedirectParam() ?? '/dashboard');
   };
 

--- a/src/app/(auth)/signup/page.test.tsx
+++ b/src/app/(auth)/signup/page.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment happy-dom
 import { describe, it, expect } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/mocks/server';
 import SignupPage from './page';
 
 describe('SignupPage', () => {
@@ -10,5 +12,28 @@ describe('SignupPage', () => {
     fireEvent.change(screen.getByLabelText('비밀번호'), { target: { value: 'pw12345678' } });
     fireEvent.click(screen.getByRole('button', { name: /가입/ }));
     await waitFor(() => expect(screen.getByText(/이메일.*인증/)).toBeTruthy());
+  });
+
+  // KNOWN-DEFECT: handleSubmit에서 setLoading(true) 후 fetch(line 20)가 reject되면
+  // try/catch/finally가 없어 setLoading(false)(line 25)가 실행되지 않고 에러도 안 보인다.
+  // 수정 전까지 이 테스트는 FAIL이 정상이다.
+  it('fetch가 거부되면(네트워크 실패) 버튼이 영구 비활성화되고 에러도 표시되지 않는다 (KNOWN-DEFECT)', async () => {
+    // 기존 테스트와 동일하게 MSW로 signup fetch를 제어한다 (네트워크 거부).
+    server.use(
+      http.post('*/api/v1/auth/signup', () => HttpResponse.error()),
+    );
+
+    render(<SignupPage />);
+    fireEvent.change(screen.getByLabelText('이메일'), { target: { value: 'new@example.com' } });
+    fireEvent.change(screen.getByLabelText('비밀번호'), { target: { value: 'pw12345678' } });
+    fireEvent.click(screen.getByRole('button', { name: /가입/ }));
+
+    // 기대: 네트워크 실패 후에도 버튼이 다시 활성화되고 에러가 보여야 한다.
+    await waitFor(() => {
+      const button = screen.getByRole('button', { name: /가입/ });
+      expect(button.hasAttribute('disabled')).toBe(false);
+    });
+    // AuthError는 role=alert 없는 plain div. 의도 문구는 아직 미정 → 관용 매처.
+    expect(screen.getByText(/오류|실패|잠시 후|다시 시도/)).toBeTruthy();
   });
 });

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -17,18 +17,28 @@ export default function SignupPage() {
     e.preventDefault();
     setError(null);
     setLoading(true);
-    const res = await fetch('/api/v1/auth/signup', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
-    });
-    setLoading(false);
-    if (!res.ok) {
-      const data = await res.json().catch(() => null);
-      setError(data?.error?.message ?? '가입 중 오류가 발생했습니다.');
-      return;
+    // `finally`는 **무조건** 실행되어야 한다. 조건부로 만들면(예: `if (!aborted)`) 취소·거부
+    // 경로에서 loading이 true로 굳어 버튼이 '가입 중...'으로 영구 비활성화된다.
+    // 여기는 성공해도 페이지를 떠나지 않으므로(`done` 화면으로 전환) 일괄 해제가 안전하다.
+    try {
+      const res = await fetch('/api/v1/auth/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        setError(data?.error?.message ?? '가입 중 오류가 발생했습니다.');
+        return;
+      }
+      setDone(true);
+    } catch {
+      // fetch는 네트워크 도달 실패 시 throw한다. 이 catch가 없으면 아래 setLoading(false)가
+      // 실행되지 않아 버튼이 영구 비활성화되고 에러 문구도 뜨지 않는다.
+      setError('가입 요청에 실패했습니다. 네트워크 상태를 확인하고 잠시 후 다시 시도해 주세요.');
+    } finally {
+      setLoading(false);
     }
-    setDone(true);
   };
 
   return (


### PR DESCRIPTION
## 증상

네트워크가 끊긴 상태에서 로그인/가입을 제출하면 버튼이 `로그인 중...`·`가입 중...`으로 **영구 비활성화**되고 **에러 문구조차 뜨지 않는다.** 탈출 수단은 새로고침뿐이고, 사용자는 무엇이 잘못됐는지 알 수 없다.

**로그인은 전 사용자의 진입점**이고, 모바일 네트워크에서 흔한 실패 모드다.

## 원인

두 핸들러 모두 `setLoading(true)` 직후의 `await`에 try/catch/finally가 없었다.

| 위치 | 문제 |
|---|---|
| `login/page.tsx:26` | `signIn`은 자격증명 오류를 `res.error`로 돌려주지만 **네트워크 실패는 throw**한다. throw되면 이후 `setCredLoading(false)`와 에러 표시가 통째로 미실행 |
| `signup/page.tsx:20` | `fetch`가 reject하면 다음 줄 `setLoading(false)`에 도달하지 못한다 |

## 수정

- **login** — `signIn`을 try/catch로 감싸고 **자격증명 오류와 다른 문구**를 쓴다. 같은 문구면 사용자가 비밀번호를 의심하며 재시도해 계정 스로틀만 소모한다. 네트워크 실패 문구는 계정 존재 여부와 무관해 오라클이 아니다.
  성공 경로는 `credLoading`을 **의도적으로 true로 유지**한다 — 페이지를 떠나는 중이고, 해제하면 내비게이션 완료 전 이중 제출이 가능하다. `finally`로 일괄 해제하지 **않는** 이유를 주석에 못박았다.
- **signup** — try/catch + **무조건 `finally`**. 성공해도 페이지를 떠나지 않으므로(`done` 화면 전환) 일괄 해제가 안전하다.

`res.error` 분기 문구는 **바꾸지 않았다** — 스로틀 초과도 이 분기로 오며, 계정 존재 여부가 새지 않으려면 항상 같은 문구여야 한다 ([ADR](docs/decisions/2026-07-30-login-rate-limit.md)).

## TDD

RED 테스트를 **먼저** 작성했다 (Grok 위임 — 라우팅 `LOW`/테스트 전용, diff는 제가 검토).

```
수정 전:  Tests  2 failed | 5 passed (7)
          expect(button.hasAttribute('disabled')).toBe(false)
          →  AssertionError: expected true to be false
             <button disabled="">로그인 중...</button>

수정 후:  Test Files  2 passed (2)  /  Tests  7 passed (7)
```

기존 5건은 전 구간 유지. 전체 스위트 **2510 passed**, `pnpm lint` **0 errors**.

## 발견 경로

빌더 로딩 결함(WBS 결함 ①②) 조사 중 **동일 안티패턴 전수 스캔**에서 부수적으로 드러났다. 원래 조사 대상보다 이쪽이 심각해 먼저 처리한다. 빌더 쪽 결함은 별도 PR로 이어진다.

## 검증 주의

`pnpm type-check`는 이 브랜치에서 아직 clean 확인을 못 했다 — 작업트리에 **조사용 임시 테스트 파일**(untracked, 커밋 대상 아님)이 남아 있어 tsc가 그 파일에서 실패한다. 임시 파일 정리 후 재확인 예정이며, **커밋된 4개 파일에는 타입 오류가 없다**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)