### PR TITLE
fix: 로딩 플래그 소유권 토큰 + 재생성 버전 신원 (F20 결함 ①②⑤)

### DIFF
--- a/docs/superpowers/plans/2026-07-31-project-wbs.md
+++ b/docs/superpowers/plans/2026-07-31-project-wbs.md
@@ -615,20 +615,44 @@ SSE가 끊긴 **모바일 폴링 사용자는 진행률 5%에 정체**한다 —
 
 F14 조사 중 `builder/page.tsx`를 전수로 읽으며 나왔다. **이것이 F14의 실제 산출이다.**
 
-| # | 결함 | 확인된 경로 | 위험 |
-|---|---|---|---|
-| 1 | `regenVersion` 미리셋 → 미리보기 **404** | `setRegenVersion`이 `onRegenerationComplete` 2곳에서만 호출되고 어디서도 리셋 안 됨. 574·694행이 `regenVersion ?? version` | 재생성 후 방식 변경 시 |
-| 2 | `isPreferenceLoading` 영구 true | 비행 중 abort → `finally`의 `!aborted` 가드가 리셋 스킵 → 다음 실행이 212행 가드로 조기 반환. **`try` 안 조기 `return`은 원인이 아니다**(`finally`가 덮음) | 로딩 스피너 영구 표시 |
-| 3 | 인기 서비스 **데드엔드** | `apis`가 비면 `clearApis()`로 선택만 지우고 아무것도 못 추가하는데 `setLastRecommendedContext`·`setRecommendationsError(false)`는 설정돼 재조회까지 막힘 | 카탈로그 미로드·실패 시 |
-| 4 | 늦은 응답이 **사용자 선택을 덮어씀** | `AbortController`가 113·217행 둘뿐. `fetchSuggestions`·`fetchApiRecommendations`엔 없고 후자는 `clearApis()` 후 주입 | 모드 변경·빠른 조작 시 |
+| # | 결함 | 확인된 경로 | 위험 | 상태 |
+|---|---|---|---|---|
+| 1 | `regenVersion` 미리셋 → 미리보기 **404** | `setRegenVersion(undefined)` 호출이 저장소 전체에 **0건**. 625·745행이 `regenVersion ?? version` | 재생성 후 **새 프로젝트 생성** 시 | ✅ 해소 |
+| 2 | `isPreferenceLoading` 고착 | 비행 중 abort → `finally`의 `!aborted` 가드가 리셋 스킵 → 재실행이 231행 조기 반환. **`try` 안 조기 `return`은 원인이 아니다**(`finally`가 덮음) | 거짓 진행 표시 | ✅ 해소 |
+| 3 | 인기 서비스 **데드엔드** | `apis`가 비면 `clearApis()`로 선택만 지우고 아무것도 못 추가하는데 `setLastRecommendedContext`·`setRecommendationsError(false)`는 설정돼 재조회까지 막힘 | 카탈로그 미로드·실패 시 | ✅ 해소 ([#289](https://github.com/xzawed/CustomWebService/pull/289)) |
+| 4 | 늦은 응답이 **사용자 선택을 덮어씀** | `fetchSuggestions`·`fetchApiRecommendations`에 `AbortController` 부재 | 모드 변경·빠른 조작 시 | ✅ 해소 ([#289](https://github.com/xzawed/CustomWebService/pull/289)) |
+| 5 | `isRecommendationsLoading` **데드엔드** (신규 — #289가 만든 것) | #289의 `finally { if (!aborted) }`가 `handleResetMode:184`의 abort와 결합. `ApiRecommendations.tsx:30-39`가 로딩이면 **스피너만 리턴하고 조기 종료**해 「다시 추천」·「재시도」 버튼까지 사라진다 | **자력 탈출 불가** — 컨텍스트 텍스트를 직접 고쳐야만 풀림 | ✅ 해소 |
+| 6 | 로그인·가입 **영구 비활성화** (신규 — 전수 스캔 부산물) | `setLoading(true)` 뒤 `await`에 try/catch/finally 없음. 네트워크 실패 시 버튼 disabled 고착 + **에러 문구도 안 뜸** | **전 사용자 진입점** · 새로고침 외 탈출 없음 | ✅ 해소 ([#292](https://github.com/xzawed/CustomWebService/pull/292)) |
+
+**2026-08-07 조사에서 정정된 것** — 위 표의 원래 기술 3건이 실제와 달랐다:
+
+- 행 번호 574·694 → **625·745** (드리프트)
+- 결함 1의 트리거는 "재생성 후 **방식 변경**"이 아니라 **새 프로젝트 생성**(「새로 생성하기」→「생성하기」)이다. 증상도 404 그 자체가 아니라, 404 본문이 `application/json`이라 **iframe에 원본 JSON 에러 텍스트가 그대로 보이는 것**이다(실측)
+- 결함 2는 **"영구 true"가 아니다.** 정상 분기(`context ≥ 20자` + API 선택됨)로 재진입하면 회복된다 — 정확한 표현은 *"조기 반환 분기로 재실행된 경우 무기한 지속"*. 또 **"로딩 스피너"가 아니라** `TemplateSelector.tsx:80-84`의 `<p>` **한 줄**이다(스피너·disabled·차단 없음). 기능 차단이 아니라 **거짓 진행 표시**
+- 결함 1의 `RePromptPanel.tsx:106` `?? 1` 폴백 가설은 **거짓**이었다 — 서버가 version을 항상 채우므로 도달 불가한 방어 코드다(아래 잔여 참조)
+
+**해소 방식(2026-08-07)**: 결함 2·5는 **소유권 토큰**으로 닫았다 — 해제 조건을 *"내 요청이
+취소됐나"*(`!signal.aborted`)에서 *"내가 아직 최신 소유자인가"*(`reqIdRef.current === reqId`)로
+바꿨다. 전자는 (a) 후속 요청의 선점과 (b) 리셋에 의한 폐기를 구분하지 못하는데, (a)에서는
+끄면 안 되고 (b)에서는 반드시 꺼야 한다. **한 비트로 두 질문에 답하려던 것이 결함이었다.**
+결함 1은 `regen: { projectId, version } | null`로 **신원을 값 안에 담아** 리셋 호출 자체를
+불필요하게 만들었다 — 리셋 누락이 버그가 될 수 없는 형태다.
+
+> **왜 abort 지점마다 해제 코드를 넣지 않았나**: 그 방식은 의무가 `abort 지점 × 플래그`로
+> 곱해진다. **#289가 정확히 그 곱셈을 절반만 채우다 결함 5를 만들었다.** 같은 형태를 한 번 더
+> 사는 것은 "최소 수정이 재발을 못 막았다"는 전제와 모순된다.
+
+**남긴 것(부풀리지 않고 명시)**:
+- `RePromptPanel.tsx:106`의 `?? 1` — 오늘 도달 불가지만 **"버전 미상"을 최신본이 아니라 1번으로
+  바꾸는 잘못된 기본값**. 고치려면 `RePromptPanel.test.tsx:315`(현재 green)와
+  `RePromptSection.tsx:14`(타입 `number`)를 함께 바꿔야 한다 → **별건 PR**
+- `isLoadingCatalog`(144행)의 `!aborted` — abort 주체가 언마운트뿐이라 도달 불가. 일관성 결여만 남음
+- `isSuggestionsLoading` — 상태는 고쳐졌으나 **오늘 화면에 드러나는 경로를 찾지 못했다**(없다고
+  증명한 것은 아니다). 회귀 테스트 없음 — "증상이 고쳐졌다"고 보고하면 안 된다
 
 **선행 조건(완료)**: 이 페이지가 커버리지 집계에서 빠져 있었다 → `vitest.config.ts` 편입
 ([PR #284](https://github.com/xzawed/CustomWebService/pull/284)). `(auth)`와 같은 **괄호 경로
 glob 함정**을 다시 확인했다 — `'src/app/(main)/**/*.tsx'`는 매칭 0건.
-
-**착수 순서**: 특성화 테스트(결함 3건을 KNOWN-DEFECT 라벨로 고정) → 커버리지 게이트 3파일
-정합 → 중복 제거 → 결함 수정. `codecov.yml`·`sonar-project.properties`는 **테스트가 생긴 뒤에만**
-건드린다(지금 제외를 풀면 builder를 건드리는 모든 PR이 patch 0%로 실패한다).
 
 ---
 

--- a/src/app/(main)/builder/page.regen-version.test.tsx
+++ b/src/app/(main)/builder/page.regen-version.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment happy-dom
+//
+// regen 버전 정체 회귀 — page.test.tsx 와 분리한다.
+// 이 파일은 next/dynamic · runClientGeneration · runClientRegeneration 모킹이 필요해서
+// page.test.tsx 의 "한 줄도 고치지 말 것" 계약을 위반하지 않도록 별도 파일로 둔다.
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+import { server } from '@/test/mocks/server';
+import { renderComponent, screen, fireEvent, waitFor, act } from '@/test/helpers/component';
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  nextProject: { id: 'proj-A', version: 3 } as { id: string; version: number },
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mocks.push, replace: vi.fn(), back: vi.fn(), prefetch: vi.fn() }),
+}));
+
+// PreviewFrame 은 next/dynamic 으로 로드된다 — 테스트에서 실제 컴포넌트가 뜨도록 lazy+Suspense.
+vi.mock('next/dynamic', () => ({
+  default: (loader: () => Promise<{ default: React.ComponentType<Record<string, unknown>> }>) => {
+    const Lazy = React.lazy(loader);
+    return function DynamicComponent(props: Record<string, unknown>) {
+      return (
+        <React.Suspense fallback={null}>
+          <Lazy {...props} />
+        </React.Suspense>
+      );
+    };
+  },
+}));
+
+vi.mock('@/lib/generation/runClientRegeneration', () => ({
+  runClientRegeneration: async (
+    _input: unknown,
+    deps: { completeRegeneration: (version: number | undefined) => void },
+  ) => {
+    deps.completeRegeneration(4);
+  },
+}));
+
+vi.mock('@/lib/generation/runClientGeneration', () => ({
+  runClientGeneration: async (
+    _input: unknown,
+    deps: {
+      startGeneration: () => string;
+      setGeneratingProjectId: (id: string) => void;
+      completeGeneration: (
+        projectId: string,
+        version: number | undefined,
+        runId: string,
+      ) => void;
+      onCompleted?: () => void;
+    },
+  ) => {
+    const p = mocks.nextProject;
+    const runId = deps.startGeneration();
+    deps.setGeneratingProjectId(p.id);
+    deps.completeGeneration(p.id, p.version, runId);
+    deps.onCompleted?.();
+  },
+}));
+
+import BuilderPage from './page';
+import { useBuilderModeStore } from '@/stores/builderModeStore';
+import { useApiSelectionStore } from '@/stores/apiSelectionStore';
+import { useContextStore } from '@/stores/contextStore';
+import { useGenerationStore } from '@/stores/generationStore';
+
+const LONG_CONTEXT =
+  '실시간 날씨와 미세먼지를 한 화면에서 보여주는 대시보드를 만들고 싶습니다. 지역을 선택하면 해당 지역 정보가 표시되면 좋겠습니다.';
+
+function makeApi(id: string, name = `API ${id}`) {
+  return {
+    id,
+    name,
+    description: `${name} 설명`,
+    category: 'utility',
+    baseUrl: `https://example.test/${id}`,
+    authType: 'none',
+    isActive: true,
+    endpoints: [],
+  };
+}
+
+function installHandlers(
+  overrides: {
+    catalog?: ReturnType<typeof makeApi>[];
+    categories?: { id: string; name: string }[];
+    popular?: unknown[];
+  } = {},
+) {
+  server.use(
+    http.get('*/api/v1/catalog', () =>
+      HttpResponse.json({ data: { items: overrides.catalog ?? [makeApi('a1'), makeApi('a2')] } }),
+    ),
+    http.get('*/api/v1/catalog/categories', () =>
+      HttpResponse.json({ data: overrides.categories ?? [{ id: 'utility', name: '유틸리티' }] }),
+    ),
+    http.get('*/api/v1/popular-services', () =>
+      HttpResponse.json({ data: overrides.popular ?? [] }),
+    ),
+    http.post('*/api/v1/suggest-context', () => HttpResponse.json({ data: { suggestions: [] } })),
+    http.post('*/api/v1/suggest-apis', () => HttpResponse.json({ data: { recommendations: [] } })),
+    http.post('*/api/v1/suggest-preferences', () => HttpResponse.json({ data: null })),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.nextProject = { id: 'proj-A', version: 3 };
+  window.localStorage.removeItem('builder-mode');
+  window.localStorage.removeItem('builder-context');
+  useBuilderModeStore.setState({ mode: 'api-first' });
+  useApiSelectionStore.getState().clearApis();
+  useContextStore.getState().reset();
+  useGenerationStore.getState().reset();
+  installHandlers();
+});
+
+describe('BuilderPage — regen version 은 projectId 와 함께 묶인다', () => {
+  it('이전 프로젝트의 regen version 이 새 프로젝트 미리보기에 남지 않는다', async () => {
+    installHandlers({ catalog: [makeApi('a1')] });
+
+    renderComponent(<BuilderPage />);
+    fireEvent.click(screen.getByText('API를 직접 선택').closest('button')!);
+    await waitFor(() => expect(screen.getByText('사용할 API를 선택하세요')).toBeTruthy());
+
+    await act(async () => {
+      useApiSelectionStore.getState().addApi(makeApi('a1') as never);
+      useContextStore.getState().setContext(LONG_CONTEXT);
+    });
+
+    // step 1 → 2 → 3
+    fireEvent.click(screen.getByText('다음').closest('button')!);
+    await waitFor(() => expect(screen.getByText('어떤 서비스를 만들고 싶으세요?')).toBeTruthy());
+    fireEvent.click(screen.getByText('다음').closest('button')!);
+    await waitFor(() => expect(screen.getByText('서비스 생성')).toBeTruthy());
+
+    // step 3 에 「생성하기」가 두 개(GenerationProgress + 하단 네비) — 첫 번째 클릭
+    fireEvent.click(screen.getAllByText('생성하기')[0]!);
+
+    await waitFor(() => {
+      expect(useGenerationStore.getState().status).toBe('completed');
+      expect(useGenerationStore.getState().projectId).toBe('proj-A');
+    });
+
+    // PreviewFrame iframe 이 로드될 때까지
+    const iframe = await waitFor(() => {
+      const el = document.querySelector('iframe');
+      expect(el).toBeTruthy();
+      return el as HTMLIFrameElement;
+    });
+    expect(iframe.getAttribute('src')).toContain('/api/v1/preview/proj-A');
+
+    // 대조군 — 재생성 버전이 미리보기에 실제로 반영된다
+    fireEvent.click(screen.getByText('프롬프트로 수정하기').closest('button')!);
+    const textarea = await waitFor(() =>
+      screen.getByPlaceholderText(/차트를 막대 그래프/i),
+    );
+    fireEvent.change(textarea, {
+      target: { value: '차트를 막대 그래프로 변경해주세요' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('수정 생성').closest('button')!);
+    });
+
+    await waitFor(() => expect(iframe.getAttribute('src')).toContain('version=4'));
+
+    // 새 프로젝트 생성 — 이전 regen version=4 가 따라오면 안 된다
+    mocks.nextProject = { id: 'proj-B', version: 1 };
+    fireEvent.click(screen.getByText('새로 생성하기').closest('button')!);
+    await waitFor(() => expect(useGenerationStore.getState().status).toBe('idle'));
+
+    fireEvent.click(screen.getAllByText('생성하기')[0]!);
+    await waitFor(() => {
+      expect(useGenerationStore.getState().status).toBe('completed');
+      expect(useGenerationStore.getState().projectId).toBe('proj-B');
+    });
+
+    const iframeB = await waitFor(() => {
+      const el = document.querySelector('iframe');
+      expect(el).toBeTruthy();
+      expect(el!.getAttribute('src')).toContain('/api/v1/preview/proj-B');
+      return el as HTMLIFrameElement;
+    });
+    const src = iframeB.getAttribute('src') ?? '';
+    expect(src).toContain('/api/v1/preview/proj-B');
+    expect(src).not.toContain('version=4');
+  });
+});

--- a/src/app/(main)/builder/page.test.tsx
+++ b/src/app/(main)/builder/page.test.tsx
@@ -354,3 +354,158 @@ describe('KNOWN-DEFECT: 늦게 도착한 추천 응답이 사용자 선택을 �
     expect(useApiSelectionStore.getState().selectedApis).toHaveLength(0);
   });
 });
+
+describe('KNOWN-DEFECT 해소: 취소된 AI 요청이 로딩 표시를 고착시킨다', () => {
+  /** 응답을 테스트가 원하는 시점에 해소할 수 있게 만드는 지연 게이트. */
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((r) => {
+      resolve = r;
+    });
+    return { promise, resolve };
+  }
+
+  it('Gate label must not survive into a new session (suggest-preferences)', async () => {
+    const gate = deferred<void>();
+    installHandlers({ catalog: [makeApi('a1')] });
+    server.use(
+      http.post('*/api/v1/suggest-preferences', async () => {
+        await gate.promise;
+        return HttpResponse.json({ data: null });
+      }),
+    );
+
+    renderComponent(<BuilderPage />);
+    fireEvent.click(screen.getByText('API를 직접 선택').closest('button')!);
+    await waitFor(() => expect(screen.getByText('사용할 API를 선택하세요')).toBeTruthy());
+
+    const { act } = await import('@testing-library/react');
+    await act(async () => {
+      useApiSelectionStore.getState().addApi(makeApi('a1') as never);
+      useContextStore.getState().setContext(LONG_CONTEXT);
+    });
+
+    fireEvent.click(screen.getByText('다음').closest('button')!);
+    await waitFor(() => expect(screen.getByText('어떤 서비스를 만들고 싶으세요?')).toBeTruthy());
+
+    // 대조군 — 600ms debounce 후 로딩 라벨이 실제로 뜬다 (TemplateSelector.tsx:82)
+    await waitFor(
+      () => expect(screen.getByText('✦ AI 추천 준비 중...')).toBeTruthy(),
+      { timeout: 3000 },
+    );
+
+    // 비행 중 방식 변경 → 새 context-first 세션 (TemplateSelector가 step 1에도 렌더됨)
+    fireEvent.click(screen.getByText('방식 변경').closest('button')!);
+    await waitFor(() => expect(screen.getByText('어떤 방식으로 시작하시겠어요?')).toBeTruthy());
+    fireEvent.click(screen.getByText('아이디어로 시작').closest('button')!);
+    await waitFor(() => expect(screen.getByText('어떤 서비스를 만들고 싶으세요?')).toBeTruthy());
+
+    // 이전 세션 응답이 늦게 도착해도 로딩 라벨이 남지 않아야 한다
+    gate.resolve();
+    await waitFor(() => expect(screen.queryByText('✦ AI 추천 준비 중...')).toBeNull());
+  });
+
+  it('Recommendation spinner must not survive into a new session (suggest-apis)', async () => {
+    const gate = deferred<void>();
+    let recHits = 0;
+    installHandlers({ catalog: [makeApi('a1', 'Weather API')] });
+    server.use(
+      http.get('*/api/v1/popular-services', () =>
+        HttpResponse.json({ data: { services: [popularService(['a1'])] } }),
+      ),
+      http.post('*/api/v1/suggest-apis', async () => {
+        recHits += 1;
+        await gate.promise;
+        return HttpResponse.json({ data: { recommendations: [] } });
+      }),
+    );
+
+    await enterContextFirst();
+    useContextStore.getState().setContext(LONG_CONTEXT);
+    await waitFor(() => expect(useContextStore.getState().isValid()).toBe(true));
+
+    fireEvent.click(screen.getByText('다음').closest('button')!);
+    await waitFor(() => expect(screen.getByText('추천된 API를 확인하세요')).toBeTruthy());
+
+    // 대조군 — 추천 스피너가 실제로 보인다 (ApiRecommendations.tsx:34)
+    await waitFor(() =>
+      expect(screen.getByText('AI가 서비스에 적합한 API를 찾고 있습니다...')).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByText('방식 변경').closest('button')!);
+    await waitFor(() => expect(screen.getByText('어떤 방식으로 시작하시겠어요?')).toBeTruthy());
+    gate.resolve();
+    fireEvent.click(screen.getByText('아이디어로 시작').closest('button')!);
+    await waitFor(() => expect(screen.getByText('어떤 서비스를 만들고 싶으세요?')).toBeTruthy());
+
+    // 인기 서비스 카드: lastRecommendedContext를 fetch 없이 설정하는 유일한 경로
+    // → 다음 「다음」에서 재조회 가드가 막혀, 고착된 로딩 플래그가 드러난다
+    await waitFor(() => expect(screen.getByText('날씨 대시보드')).toBeTruthy());
+    fireEvent.click(screen.getByText('날씨 대시보드').closest('button')!);
+    await waitFor(() => {
+      expect(useApiSelectionStore.getState().selectedApis).toHaveLength(1);
+    });
+
+    fireEvent.click(screen.getByText('다음').closest('button')!);
+    await waitFor(() => expect(screen.getByText('추천된 API를 확인하세요')).toBeTruthy());
+
+    expect(screen.queryByText('AI가 서비스에 적합한 API를 찾고 있습니다...')).toBeNull();
+    expect(screen.getByText('AI 추천 API')).toBeTruthy();
+    // CRITICAL: 재조회가 일어나면 테스트가 공허해진다 — 정확히 1회만
+    expect(recHits).toBe(1);
+  });
+
+  it('NEGATIVE CONTROL — 이전 요청 finally가 최신 요청 로딩을 끄면 안 된다 (token guard)', async () => {
+    // 이 테스트는 토큰 가드(if (reqIdRef.current === reqId))를 삭제하고
+    // finally에서 무조건 setIsXLoading(false)로 "단순화"하면 CI가 실패하도록 존재한다.
+    const gates: Array<ReturnType<typeof deferred<void>>> = [];
+    let recHits = 0;
+    installHandlers({ catalog: [makeApi('a1')] });
+    server.use(
+      http.post('*/api/v1/suggest-apis', async () => {
+        recHits += 1;
+        const gate = deferred<void>();
+        gates.push(gate);
+        await gate.promise;
+        return HttpResponse.json({ data: { recommendations: [] } });
+      }),
+    );
+
+    await enterContextFirst();
+    useContextStore.getState().setContext(LONG_CONTEXT);
+    await waitFor(() => expect(useContextStore.getState().isValid()).toBe(true));
+
+    fireEvent.click(screen.getByText('다음').closest('button')!);
+    await waitFor(() => expect(screen.getByText('추천된 API를 확인하세요')).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByText('AI가 서비스에 적합한 API를 찾고 있습니다...')).toBeTruthy(),
+    );
+    await waitFor(() => expect(gates).toHaveLength(1));
+
+    // 이전 → step 1, 컨텍스트를 다른 유효 문자열로 바꾼 뒤 다시 다음 (request 2)
+    fireEvent.click(screen.getByText('이전').closest('button')!);
+    await waitFor(() => expect(screen.getByText('어떤 서비스를 만들고 싶으세요?')).toBeTruthy());
+
+    const OTHER_CONTEXT =
+      '다른 컨텍스트로 추천을 다시 요청합니다. 실시간 환율과 뉴스를 보여주는 앱을 만들고 싶습니다.';
+    useContextStore.getState().setContext(OTHER_CONTEXT);
+    await waitFor(() => expect(useContextStore.getState().context).toBe(OTHER_CONTEXT));
+
+    fireEvent.click(screen.getByText('다음').closest('button')!);
+    await waitFor(() => expect(screen.getByText('추천된 API를 확인하세요')).toBeTruthy());
+    await waitFor(() => expect(recHits).toBe(2));
+    await waitFor(() => expect(gates).toHaveLength(2));
+    expect(screen.getByText('AI가 서비스에 적합한 API를 찾고 있습니다...')).toBeTruthy();
+
+    // request 1만 해소 — 최신 요청(request 2)이 아직 비행 중이므로 스피너는 유지돼야 한다
+    gates[0].resolve();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.getByText('AI가 서비스에 적합한 API를 찾고 있습니다...')).toBeTruthy();
+
+    // request 2 해소 후에야 스피너가 사라진다
+    gates[1].resolve();
+    await waitFor(() =>
+      expect(screen.queryByText('AI가 서비스에 적합한 API를 찾고 있습니다...')).toBeNull(),
+    );
+  });
+});

--- a/src/app/(main)/builder/page.tsx
+++ b/src/app/(main)/builder/page.tsx
@@ -49,7 +49,18 @@ export default function BuilderPage() {
   const [apis, setApis] = useState<ApiCatalogItem[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [isLoadingCatalog, setIsLoadingCatalog] = useState(true);
-  const [regenVersion, setRegenVersion] = useState<number | undefined>(undefined);
+  /**
+   * 재생성 결과 버전은 **그 버전이 속한 프로젝트와 한 쌍으로만** 의미가 있다.
+   *
+   * `number` 하나로 들면 「새로 생성하기」→「생성하기」로 만든 **다음 프로젝트에도 살아남아**
+   * 미리보기가 존재하지 않는 버전을 요구한다. preview 라우트는 최신본 폴백을 하지 않고
+   * `NotFoundError`(404)를 던지며, 그 본문은 `application/json`이라 iframe에 **원본 JSON
+   * 에러 텍스트가 그대로 보인다**(실측).
+   *
+   * 신원을 값 안에 담으면 `setRegen(null)`을 **어디서도 부를 필요가 없다** — 즉 리셋 누락이
+   * 버그가 될 수 없다. 이전 구현은 `setRegenVersion(undefined)` 호출이 저장소 전체에 0건이었다.
+   */
+  const [regen, setRegen] = useState<{ projectId: string; version: number } | null>(null);
 
   /**
    * 비행 중인 AI 제안 요청(suggest-context · suggest-apis)의 취소 핸들.
@@ -60,6 +71,27 @@ export default function BuilderPage() {
    * 새 세션 선택을 지우고 이전 컨텍스트의 추천을 채워 넣는다.
    */
   const aiRequestAbortRef = useRef<AbortController | null>(null);
+
+  /**
+   * 로딩 플래그 **소유권 토큰**.
+   *
+   * 해제 조건은 "내 요청이 취소됐나"가 아니라 **"내가 아직 이 플래그의 최신 소유자인가"**다.
+   * `signal.aborted`는 (a) 후속 요청의 선점과 (b) 리셋·이펙트 정리에 의한 폐기를 구분하지
+   * 못하는데, (a)에서는 선점자가 이미 true를 다시 썼으니 내가 끄면 안 되고 (b)에서는
+   * 후속자가 없으니 **반드시 내가 꺼야 한다**. 한 비트로 두 질문에 답하려던 것이 결함이었다.
+   *
+   * 요점: 리셋 핸들러(`handleModeSelect`·`handleResetMode`)와 이펙트 조기반환 분기는
+   * **로딩 플래그의 존재를 알 필요가 없다.** 새 abort 지점이 생겨도 자동으로 옳다.
+   * (abort 지점마다 해제 코드를 추가하는 방식은 그 곱셈을 절반만 채우다 #289에서 재도입됐다.)
+   *
+   * ⚠️ 불변조건: `++xxxReqIdRef.current` 다음 줄이 `setIsXLoading(true)`여야 하고 그 직후가
+   * 대응하는 `finally`를 가진 `try`여야 한다. 사이에 `await`나 조기 return을 넣으면
+   * "true를 쓴 실행에는 반드시 대응하는 finally가 있다"가 깨져 고착이 그대로 돌아온다.
+   * 정적으로 강제되지 않는다 — `page.test.tsx`의 **선점 음성대조 테스트가 유일한 방어**다.
+   */
+  const suggestionsReqIdRef = useRef(0);
+  const recommendationsReqIdRef = useRef(0);
+  const preferenceReqIdRef = useRef(0);
 
   // Context suggestion state (for api-first mode)
   const [suggestions, setSuggestions] = useState<string[]>([]);
@@ -235,6 +267,7 @@ export default function BuilderPage() {
 
     const abortCtrl = new AbortController();
     const timer = setTimeout(async () => {
+      const reqId = ++preferenceReqIdRef.current;
       setIsPreferenceLoading(true);
       try {
         const res = await fetch('/api/v1/suggest-preferences', {
@@ -266,7 +299,7 @@ export default function BuilderPage() {
           // 폴백: 현재 UX 유지
         }
       } finally {
-        if (!abortCtrl.signal.aborted) setIsPreferenceLoading(false);
+        if (preferenceReqIdRef.current === reqId) setIsPreferenceLoading(false);
       }
     }, 600);
 
@@ -287,6 +320,7 @@ export default function BuilderPage() {
     const abortCtrl = new AbortController();
     aiRequestAbortRef.current = abortCtrl;
 
+    const reqId = ++suggestionsReqIdRef.current;
     setIsSuggestionsLoading(true);
     setSuggestions([]);
     setActiveSuggestionIndex(null);
@@ -316,7 +350,7 @@ export default function BuilderPage() {
       console.error('[suggest-context] failed:', err instanceof Error ? err.message : err);
       setSuggestions([]);
     } finally {
-      if (!abortCtrl.signal.aborted) {
+      if (suggestionsReqIdRef.current === reqId) {
         setIsSuggestionsLoading(false);
       }
     }
@@ -333,6 +367,7 @@ export default function BuilderPage() {
     const abortCtrl = new AbortController();
     aiRequestAbortRef.current = abortCtrl;
 
+    const reqId = ++recommendationsReqIdRef.current;
     setIsRecommendationsLoading(true);
     setApiRecommendations([]);
     setRecommendationsError(false);
@@ -362,7 +397,7 @@ export default function BuilderPage() {
       setRecommendationsError(true);
       setLastRecommendedContext(null);
     } finally {
-      if (!abortCtrl.signal.aborted) {
+      if (recommendationsReqIdRef.current === reqId) {
         setIsRecommendationsLoading(false);
       }
     }
@@ -622,12 +657,19 @@ export default function BuilderPage() {
               />
 
               {genStatus === 'completed' && projectId && (
-                <PreviewFrame projectId={projectId} version={regenVersion ?? version ?? undefined} />
+                <PreviewFrame
+                  projectId={projectId}
+                  version={
+                    regen !== null && regen.projectId === projectId
+                      ? regen.version
+                      : (version ?? undefined)
+                  }
+                />
               )}
               {genStatus === 'completed' && projectId && (
                 <RePromptPanel
                   projectId={projectId}
-                  onRegenerationComplete={(v) => setRegenVersion(v)}
+                  onRegenerationComplete={(v) => setRegen({ projectId, version: v })}
                 />
               )}
             </div>
@@ -742,12 +784,19 @@ export default function BuilderPage() {
               />
 
               {genStatus === 'completed' && projectId && (
-                <PreviewFrame projectId={projectId} version={regenVersion ?? version ?? undefined} />
+                <PreviewFrame
+                  projectId={projectId}
+                  version={
+                    regen !== null && regen.projectId === projectId
+                      ? regen.version
+                      : (version ?? undefined)
+                  }
+                />
               )}
               {genStatus === 'completed' && projectId && (
                 <RePromptPanel
                   projectId={projectId}
-                  onRegenerationComplete={(v) => setRegenVersion(v)}
+                  onRegenerationComplete={(v) => setRegen({ projectId, version: v })}
                 />
               )}
             </div>


### PR DESCRIPTION
builder 페이지에서 **취소된 요청이 로딩 표시를 고착**시키고, **이전 프로젝트의 재생성 버전이 새 프로젝트 미리보기로 새던** 것을 닫는다.

## 무엇이 틀렸었나 — 한 비트로 두 질문에 답하려 했다

해제 조건이 `if (!abortCtrl.signal.aborted)` 였다. 이 비트는 두 상황을 **구분하지 못한다**:

| 상황 | `aborted` | 로딩을 꺼야 하나 |
|---|---|---|
| (a) 후속 요청이 나를 **선점**했다 | `true` | ❌ 아니오 — 선점자가 이미 true를 다시 썼다 |
| (b) 리셋·이펙트 정리가 나를 **폐기**했다 | `true` | ✅ **예** — 후속자가 없다 |

둘 다 `true`라 (b)에서 아무도 안 끄고 고착된다. abort를 일으키는 **5개 지점 중 언마운트는 하나뿐**이고 나머지 넷은 화면이 살아 있는 채로 일어난다 — 이 가드는 "언마운트 방어"가 아니라 **"살아 있는 화면의 로딩을 영구히 켜 두는 장치"** 로 작동했다. (React 19에서 언마운트 후 setState는 no-op이라, 원래 막으려던 문제 자체가 무해하다.)

**수정**: 해제 조건을 **소유권**으로 바꾼다 — `reqIdRef.current === reqId`. (a)면 토큰이 다르니 건너뛰고, (b)면 같으니 끈다. 리셋 핸들러와 조기반환 분기는 **로딩 플래그의 존재를 알 필요가 없어진다.**

## 왜 abort 지점마다 해제 코드를 넣지 않았나

그 방식은 의무가 **`abort 지점 × 플래그`로 곱해진다.** [#289](https://github.com/xzawed/CustomWebService/pull/289)가 정확히 그 곱셈을 절반만 채우다 **결함 ⑤를 새로 만들었다.** 같은 형태의 최소 수정을 한 번 더 사는 것은 *"최소 수정이 재발을 못 막았다"* 는 이 작업의 전제와 모순된다. 덤으로 그 방식은 이펙트 본문에 setState를 넣어 `react-hooks/set-state-in-effect`를 suppress해야 한다(규칙이 실제로 발화함을 확인).

## 닫는 결함

| # | 증상 | 심각도 |
|---|---|---|
| ② `isPreferenceLoading` | 「✦ AI 추천 준비 중...」 텍스트가 **새 세션까지 따라온다**. 거짓 진행 표시 | 낮음 |
| ⑤ `isRecommendationsLoading` | 추천 스피너 고착 + `ApiRecommendations.tsx:30-39`가 조기 종료해 **「다시 추천」·「재시도」 버튼까지 사라진다** | **자력 탈출 불가** |
| ① `regenVersion` | 새 프로젝트 미리보기가 이전 프로젝트 버전을 요구 → 404. 본문이 `application/json`이라 **iframe에 원본 JSON 에러가 그대로 보인다**(실측) | 높음 |

결함 ①은 `regen: { projectId, version } | null`로 **신원을 값 안에 담아** 리셋 호출 자체를 불필요하게 만들었다 — `setRegenVersion(undefined)` 호출은 저장소 전체에 **0건**이었다.

## 손대지 않은 것 (설계의 절반이다)

- **페이로드 가드** `if (abortCtrl.signal.aborted) return;` 2곳 — *"내 결과가 아직 필요한가"* 를 묻는 것이고 `aborted`가 **정답**이다. 신원 가드로 바꾸지 말 것
- 카탈로그 이펙트의 `!aborted` 3곳 — abort 주체가 언마운트뿐이라 도달 불가
- `handleResetMode`·`handleModeSelect`·Gate 조기반환 — **무변경**
- `aiRequestAbortRef` 의미 — #289의 세션 오염 방지는 한 글자도 안 바뀐다
- `RePromptPanel` prop 타입 — 넓히면 현재 green 테스트(`RePromptPanel.test.tsx:315`)가 깨지고 `RePromptSection.tsx:14`가 타입 에러다. **별건 PR**

## 검증 (양방향 + 뮤테이션)

```
수정 적용:                    15 passed (15)
수정 되돌림:                   3 failed | 12 passed   ← 결함 3건 정확히 RED, 음성대조는 GREEN 유지
토큰 가드 무력화 (if(true)):    1 failed | 14 passed   ← 음성대조 1건만 실패
```

**세 번째가 핵심이다.** 음성대조 테스트는 결함 재현이 아니라 **가드 삭제를 막는 판별식**이고, 그게 실제로 그 역할을 하는지 직접 뮤테이션으로 확인했다(에이전트 보고를 그대로 쓰지 않았다).

| 게이트 | 결과 |
|---|---|
| `pnpm lint` | **0 errors** |
| `pnpm type-check` | **clean** |
| `pnpm test` | **196파일 / 2502 통과** |
| `pnpm build` | 성공 |
| `pnpm test:e2e` | **43/43** |
| `pnpm docs:check` | 5/5 |

특성화 파일(`page.test.tsx`)은 *"한 줄도 고치지 않는다"* 계약대로 **삭제 0줄 · 155줄 순수 추가**다.

## 남긴 것 (부풀리지 않고 명시)

- `RePromptPanel.tsx:106`의 `?? 1` — 오늘 도달 불가지만 **"버전 미상"을 최신본이 아니라 1번으로 바꾸는 잘못된 기본값**. 별건 PR
- `isLoadingCatalog`의 `!aborted` — 도달 불가, 일관성 결여만 남음
- `isSuggestionsLoading` — 상태는 고쳐졌으나 **오늘 화면에 드러나는 경로를 못 찾았다**(없다고 증명한 것은 아니다). 회귀 테스트 없음 → **"증상이 고쳐졌다"고 보고하면 안 된다**
- **실브라우저 실측 없음** — 근거는 happy-dom 재현 + 코드 읽기 + E2E 전건 통과까지다

회귀 테스트 작성은 **Grok 위임**(라우팅 `LOW`·테스트 전용), diff 검토와 양방향·뮤테이션 검증은 직접 수행. WBS F20 표를 실측에 맞춰 정정했다(행번호 드리프트 · "영구 true" · "로딩 스피너" 3건).

🤖 Generated with [Claude Code](https://claude.com/claude-code)