### PR TITLE
ci: workflow_dispatch 추가 — 웹훅이 죽었을 때의 유일한 복구 수단

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,19 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # 수동 실행 — 웹훅이 죽었을 때의 **유일한 복구 수단**이다.
+  #
+  # 2026-08-06 GitHub Actions 장애(major_outage)에서 웹훅의 15%만 처리돼
+  # main 머지 3건 중 **CI 런이 1건만 생성**됐다. `FAILED`도 `SKIPPED`도 아닌
+  # **"런 부재"** 라 배포 목록에는 아무 흔적이 없었고, 그 결과 코드 PR 2건이
+  # **CI를 한 번도 통과하지 않은 채 병합·배포**됐다(그중 하나에 Linux에서
+  # 실패하는 테스트가 있었고, 다음 PR에 CI가 붙고 나서야 발견됐다).
+  #
+  # 그때 `gh workflow run` 은 422로 거부됐다 — 이 트리거가 없었기 때문이다.
+  # 웹훅은 우회할 수 없지만 dispatch 는 API 직접 호출이라 살아 있다.
+  #
+  # 사용: `gh workflow run "CI / CD" --ref <branch>`
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## 왜

2026-08-06 GitHub Actions `major_outage`에서 **웹훅의 15%만 처리**돼 main 머지 3건 중 **CI 런이 1건만 생성**됐다.

`FAILED`도 `SKIPPED`도 아닌 **"런 부재"** — 배포 목록에는 아무 흔적이 없다. 그 결과:

| PR | CI 런 | 결과 |
|---|---|---|
| #291 (문서) | 생성됨 | SUCCESS |
| **#292** (코드) | **없음** | 미검증 병합·배포 |
| **#293** (코드) | **없음** | 미검증 병합·배포 — **Linux에서 실패하는 테스트 포함** |

그 테스트는 다음 PR(#294)에 CI가 붙고 나서야 발견됐다. **그 사이 main은 검증되지 않은 상태였다.**

당시 복구를 시도했지만 —

```
$ gh workflow run "CI / CD" --ref <branch>
HTTP 422: No ref found for: <branch>
```

`on:` 에 `workflow_dispatch` 가 없어서다. **수동 복구 수단이 0개였다.**

## 무엇을

`on:` 에 `workflow_dispatch:` 한 줄 추가. 웹훅은 우회할 수 없지만 **dispatch는 REST API 직접 호출**이라 웹훅 파이프라인과 무관하다.

```
gh workflow run "CI / CD" --ref <branch>
```

**추가 트리거일 뿐이므로 기존 동작에 영향 없다.** 잡·권한·concurrency 무변경.

## 배경 연결

CLAUDE.md의 「조용히 깨지는 규칙」에 이미 *"병합했으면 배포가 실제로 됐는지 확인한다 — 조용한 미배포 **3종**"* 이 있고, [railway-deploy-troubleshooting.md](docs/guides/railway-deploy-troubleshooting.md)에 세 번째 유형(**런 부재**)의 판별법이 기록돼 있다. 이 PR로 **그 복구 절차가 실제로 존재하게 된다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)