### PR TITLE
docs: 진실원 문서가 단언하던 거짓 2건 정정 (코드 실측)

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -208,7 +208,7 @@ for (const r of c) if (r.auth_config?.env_var)
 |------|--------|---------|------|
 | `MAX_APIS_PER_PROJECT` | `5` | ➖ | 프로젝트당 최대 API 수 |
 | `MAX_DAILY_GENERATIONS` | `10` | ➖ | 사용자당 일일 생성 횟수 |
-| `MAX_DAILY_SUGGESTIONS` | `30` | ➖ | 사용자당 일일 AI 추천(suggest-*) 횟수. free 기본 30, pro 오버라이드 150. 코드: `src/lib/config/features.ts` · `RateLimitService.checkAndIncrementDailySuggestionLimit` |
+| `MAX_DAILY_SUGGESTIONS` | `30` | ➖ | 사용자당 일일 AI 추천(suggest-*) 횟수. ⚠️ **`PLAN_OVERRIDES.pro`(150)는 도달 불가한 죽은 설정이다** — `getLimits(plan = 'free')`의 호출부 6곳(`generate/regenerate/route`·`health/route`·`generationSaver`·`projectService`·`rateLimitService` ×2)이 **전부 인자 없이** 부르므로 실효값은 항상 `free`다(2026-08-07 코드 실측). 코드: `src/lib/config/features.ts` · `RateLimitService.checkAndIncrementDailySuggestionLimit` |
 | `MAX_PROJECTS_PER_USER` | `20` | ➖ | 사용자당 최대 프로젝트 수 |
 | `MAX_REGENERATIONS` | `5` | ➖ | 프로젝트당 재생성 횟수 |
 | `MAX_CODE_VERSIONS` | `10` | ➖ | 프로젝트당 최대 코드 버전 수. 초과 시 오래된 버전 삭제 |

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -17,7 +17,7 @@
 | `ForbiddenError` | `FORBIDDEN` | 403 | `접근 권한이 없습니다.` | 권한 없는 리소스 접근 시 |
 | `RateLimitError` | `RATE_LIMITED` | 429 | `요청 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.` | 일일 생성 한도 초과 시 |
 | `ConflictError` | `CONFLICT` | 409 | `이미 존재하는 리소스입니다.` | 이메일 중복 가입 등 리소스 충돌 시 |
-| `EmailNotVerifiedError` | `EMAIL_NOT_VERIFIED` | 403 | `이메일 인증이 필요합니다. 받은 편지함을 확인해주세요.` | 미인증 사용자의 생성·게시 등 차단 시 |
+| `EmailNotVerifiedError` | `EMAIL_NOT_VERIFIED` | 403 | `이메일 인증이 필요합니다. 받은 편지함을 확인해주세요.` | 미인증 사용자 차단. **걸린 곳은 7개 라우트뿐** — generate·regenerate·suggest 4종·admin/debug. **게시(publish)에는 걸려 있지 않다**(2026-08-07 코드 실측: `grep -rl assertEmailVerified src/app/api`) |
 | `GenerationError` | `GENERATION_FAILED` | 500 | `코드 생성에 실패했습니다.` | AI 코드 생성 파이프라인 실패 시 |
 
 > `DeployError` / `DEPLOY_FAILED` 는 외부 배포 스택 제거(2026-08-01)로 삭제됨. [ADR](../decisions/2026-08-01-remove-external-deploy-stack.md)


### PR DESCRIPTION
문서 축소([#295](https://github.com/xzawed/CustomWebService/pull/295)) 중 서브에이전트가 "판단 필요"로 올린 것을 **코드로 확인해 확정**했다. 둘 다 **진실원 문서가 사실이 아닌 것을 사실처럼** 적고 있었다 — 이번 축소가 겨냥한 부패의 정확한 표본이다.

## ① `error-codes.md` — `EMAIL_NOT_VERIFIED` 적용 범위

| | |
|---|---|
| 기존 서술 | *"미인증 사용자의 생성·**게시** 등 차단 시"* |
| 실측 | `assertEmailVerified` 는 **7개 라우트에만** 걸려 있다 — `generate` · `generate/regenerate` · `suggest-apis` · `suggest-context` · `suggest-modification` · `suggest-preferences` · `admin/debug` |
| 결론 | **게시(publish)에는 걸려 있지 않다** |

검증 명령을 본문에 남겼다: `grep -rl assertEmailVerified src/app/api`

## ② `env-vars.md` — `MAX_DAILY_SUGGESTIONS` 의 pro 오버라이드

| | |
|---|---|
| 기존 서술 | *"free 기본 30, **pro 오버라이드 150**"* |
| 실측 | `getLimits(plan = 'free')` 의 **호출부 6곳이 전부 인자 없이** 부른다 — `generate/regenerate/route` · `health/route` · `generationSaver` · `projectService` · `rateLimitService` ×2 |
| 결론 | `PLAN_OVERRIDES.pro`(150)는 **도달 불가한 죽은 설정**이고 실효값은 항상 `free` |

## 왜 이게 중요한가

둘 다 **어떤 게이트도 잡지 못하는 종류**다. 타입도 테스트도 lint도 문서의 서술이 코드와 맞는지 보지 않는다. `docs:check`는 경로·명령·행번호는 잡지만 **"이 문장이 참인가"는 잡지 못한다.**

오늘 제 오류 3건이 정확히 이 경로였다 — 문서를 믿고 측정하지 않았다. 그래서 이번엔 **정정하면서 검증 명령을 본문에 함께 박았다.** 다음 사람이 믿기 전에 돌려볼 수 있도록.

## 검증

`pnpm docs:check` **8/8 통과**

🤖 Generated with [Claude Code](https://claude.com/claude-code)