### PR TITLE
docs: HISTORICAL 문서를 현재 시제 층에서 archive 로 이동 (golden-api-set)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -101,7 +101,6 @@
 | [env-vars.md](reference/env-vars.md) | 환경변수 전체 |
 | [error-codes.md](reference/error-codes.md) | 에러 클래스·코드 |
 | [test-coverage-map.md](reference/test-coverage-map.md) | 테스트 커버 범위·공백 |
-| [golden-api-set.md](reference/golden-api-set.md) | **2026-05-01 스냅샷(HISTORICAL)** — 문서는 10개, 실제 `verified`는 46개. 현재 상태는 `GET /api/v1/admin/catalog-dump` |
 
 ## security/
 
@@ -130,6 +129,7 @@
 |------|------|
 | [guides/sqlite-cutover-runbook.md](archive/guides/sqlite-cutover-runbook.md) | Supabase→SQLite 컷오버 런북 (2026-06-23 완료) |
 | [superpowers/plans/2026-06-22-db-removal-sqlite-migration.md](archive/superpowers/plans/2026-06-22-db-removal-sqlite-migration.md) | SQLite 전환 WBS Phase 1–8 (역사) |
+| [reference/golden-api-set.md](archive/reference/golden-api-set.md) | 골든셋 API 10개 (2026-05-01 스냅샷). **현재 verified 는 46개** — 진실원은 DB, 확인은 GET /api/v1/admin/catalog-dump. 2026-08-07에 docs/reference/ 에서 이동(HISTORICAL 문서가 현재 시제 층에 있었다) |
 
 ## superpowers/specs/
 

--- a/docs/archive/reference/golden-api-set.md
+++ b/docs/archive/reference/golden-api-set.md
@@ -5,7 +5,7 @@
 > `verification_status = 'verified'` 집합이라고 적지만, 번들 시드 기준 실제 `verified`는
 > **46개**다(2026-08-06 실측). 활성/검증 상태의 **진실원은 DB**이며 운영 확인은
 > `GET /api/v1/admin/catalog-dump` 의 `summary`로 한다 —
-> [operations.md §1.4](../guides/operations.md).
+> [operations.md §1.4](../../guides/operations.md).
 > 아래 목록은 **그날 무엇을 왜 골랐는지의 기록**으로만 읽을 것.
 
 검증 날짜: **2026-05-01** (전수 재검증 + 즉시 사용 가능 기준 정리)
@@ -16,11 +16,11 @@
 
 > **2026-05-01 업데이트 (즉시 사용 가능 기준 정리)**: API 키 등록 없이 즉시 사용 가능한 API만 활성 유지.
 > TMDB·RAWG → is_active=false (키 등록 필요). The Cat API(auth_type→none 재분류)·NASA DEMO_KEY 신규 추가.
-> 전체 정리 내역: [docs/decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md](../decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md)
+> 전체 정리 내역: [docs/decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md](../../decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md)
 
 > **2026-06-21 스냅샷 (역사)**: REST Countries 폐기, 키 미설정 의존 API 비활성화, 당시 활성·키리스 위주 정리.
 > ✅ "verified 우선 추천"은 B-2(2026-06-22)로 구현 완료 — `POST /api/v1/suggest-apis`가 `broken` 제외·`verified` 우선.  
-> 상세: [docs/decisions/2026-06-22-verification-status-consumption.md](../decisions/2026-06-22-verification-status-consumption.md)
+> 상세: [docs/decisions/2026-06-22-verification-status-consumption.md](../../decisions/2026-06-22-verification-status-consumption.md)
 
 > **현행 헬스·키 검증 (CLI 없음)**: `pnpm catalog:healthcheck` / Supabase cron은 **제거됨**.  
 > 대신 배포 런타임 관리자 API: `GET /api/v1/admin/keys-verify`, `POST /api/v1/admin/verify-catalog`,  
@@ -78,7 +78,7 @@ curl -X POST -H "Authorization: Bearer $ADMIN_API_KEY" \
 ```
 
 부팅 시 `ensureCatalogEntries`가 시드 JSON 기준 신규 삽입·키리스 오분류 정정을 멱등으로 수행한다  
-([database.md](../architecture/database.md) §부팅).
+([database.md](../../architecture/database.md) §부팅).
 
 ### 이력 스크립트 (참고만)
 

--- a/docs/decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md
+++ b/docs/decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md
@@ -95,7 +95,7 @@ TMDB, RAWG, Unsplash, OpenWeatherMap, WeatherAPI.com
 ## 골든셋 변경
 
 TMDB·RAWG → 비활성화로 제거. The Cat API(auth_type 재분류)·NASA DEMO_KEY 신규 추가.
-상세: [docs/reference/golden-api-set.md](../reference/golden-api-set.md)
+상세: [docs/archive/reference/golden-api-set.md](../archive/reference/golden-api-set.md)
 
 ---
 


### PR DESCRIPTION
## 문제 — 문서가 스스로 "현재가 아니다"라고 하면서 현재 시제 층에 앉아 있었다

`docs/reference/golden-api-set.md`:

```
<!-- DOC_STATUS: HISTORICAL | superseded_by: docs/guides/operations.md -->
# 골든셋 API 목록
> ⛔ **2026-05-01 스냅샷 — 현재 상태가 아니다.** 이 문서는 10개를 verified 라고 적지만
> 실제는 **46개**다(2026-08-06 실측).
```

그런데 위치가 `docs/reference/` 였다. [docs/README.md](docs/README.md)의 층 정책 표는 그 디렉터리를 **"현재 시제 진실 — 지금 코드가 하는 일만"** 으로 정의한다.

**이런 배치는 grep·인덱스 탐색에서 현재 사실처럼 걸린다.** 오늘 세션에서 제가 낸 오류 3건이 전부 *"문서를 믿고 측정하지 않은 것"* 이었고, 그 문서들의 공통점이 **틀렸다는 표시가 본문 안에만 있고 위치·인덱스에는 없다는 것**이었다.

## 변경

- `docs/reference/` → `docs/archive/reference/` (`git mv` — 히스토리 보존)
- 파일 내부 상대경로 **4건** `../` → `../../` 교정, **파일 존재로 4/4 확인**
- 인바운드 링크 2곳 갱신 — [ADR 2026-05-01](docs/decisions/2026-05-01-api-catalog-immediate-usable-cleanup.md) · `docs/README.md`
- `docs/README.md`: reference 표에서 제거 → archive 표로 이동하며 **왜 옮겼는지** 명시

## 검증

`pnpm docs:check` **8/8 통과**

> 이동 직후 검사기가 ③ 링크 **4건 깨짐**을 잡아냈다. **이 검사가 없었으면 archive 안에서 조용히 죽은 링크가 됐을 것이다** — 문서 이동이 위험한 이유가 정확히 이것이고, 그래서 검사기가 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)