### PR TITLE
fix: signIn 은 네트워크 실패에 throw 하지 않는다 — #292 의 전제가 틀렸다

### DIFF
--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -72,24 +72,59 @@ describe('LoginPage local(Credentials) mode', () => {
     expect(forgotLink.getAttribute('href')).toBe('/forgot-password');
   });
 
-  // KNOWN-DEFECT: handleCredentialsLogin에서 setCredLoading(true) 후 signIn(line 26)이
-  // reject되면 try/catch/finally가 없어 credLoading이 true로 남고 에러도 안 보인다.
-  // 수정 전까지 이 테스트는 FAIL이 정상이다.
-  it('signIn이 거부되면(네트워크 실패) 버튼이 영구 비활성화되고 에러도 표시되지 않는다 (KNOWN-DEFECT)', async () => {
-    mocks.signIn.mockRejectedValue(new Error('network down'));
-    renderComponent(<LoginPage />);
-
-    const emailInput = screen.getByLabelText('이메일');
-    fireEvent.change(emailInput, { target: { value: 'admin@example.com' } });
-    fireEvent.change(screen.getByLabelText('비밀번호'), { target: { value: 'hunter2' } });
-    fireEvent.submit(emailInput.closest('form')!);
-
-    // 기대: 네트워크 실패 후에도 버튼이 다시 활성화되고 에러가 보여야 한다.
+  /** 제출 후 "버튼이 다시 눌리는 상태 + 에러 문구 표시"를 함께 단언한다. */
+  async function expectRecoverableError(): Promise<void> {
     await waitFor(() => {
       const button = screen.getByRole('button', { name: /로그인/ });
       expect(button.hasAttribute('disabled')).toBe(false);
     });
-    // credError는 role=alert 없는 plain div. 의도 문구는 아직 미정 → 관용 매처.
+    // credError는 role=alert 없는 plain div → 문구 매처로 확인한다.
     expect(screen.getByText(/오류|실패|잠시 후|다시 시도/)).toBeTruthy();
+  }
+
+  function submit(): void {
+    const emailInput = screen.getByLabelText('이메일');
+    fireEvent.change(emailInput, { target: { value: 'admin@example.com' } });
+    fireEvent.change(screen.getByLabelText('비밀번호'), { target: { value: 'hunter2' } });
+    fireEvent.submit(emailInput.closest('form')!);
+  }
+
+  // ⚠️ **이 테스트가 진짜 네트워크 실패 경로다.** 이전 버전은 `mockRejectedValue`로 목킹했는데
+  // 그건 **실제 라이브러리가 하지 않는 동작**이었다(next-auth 5.0.0-beta.32 실측):
+  //
+  //   fetch 실패 → `fetchData`가 `catch { logger.error(...); return null }`로 삼킴
+  //   → `getProviders()`가 null → `signIn`은 `window.location.href='/api/auth/error'`만 쓰고
+  //     **`return;`** — 즉 **undefined로 resolve**한다(reject 아님).
+  //
+  // 그래서 reject를 목킹한 테스트는 초록이었지만 **프로덕션 시나리오는 재현하지 못했다.**
+  // undefined를 성공으로 읽으면 `/dashboard`로 갔다가 세션이 없어 로그인으로 되돌아온다 —
+  // 원인 표시가 없는 왕복이 된다. `AUTH_TRUST_HOST` 누락으로 `/api/auth/*`가 500일 때도 같다.
+  it('signIn이 undefined로 resolve하면(네트워크·서버 도달 실패) 에러를 표시하고 버튼을 되살린다', async () => {
+    mocks.signIn.mockResolvedValue(undefined);
+    renderComponent(<LoginPage />);
+    submit();
+    await expectRecoverableError();
+  });
+
+  // 좁지만 실재하는 경로: providers·csrf는 성공하고 **callback만 실패**하면
+  // `new URL(data.url)`이 TypeError를 던져 signIn이 실제로 reject한다.
+  it('signIn이 거부되면(callback 단독 실패) 에러를 표시하고 버튼을 되살린다', async () => {
+    mocks.signIn.mockRejectedValue(new TypeError('Invalid URL'));
+    renderComponent(<LoginPage />);
+    submit();
+    await expectRecoverableError();
+  });
+
+  // 대조군 — 자격증명 오류는 **다른 문구**여야 한다. 같은 문구를 쓰면 사용자가 비밀번호를
+  // 의심하며 재시도해 계정 스로틀만 소모한다.
+  it('자격증명 오류 문구와 도달 실패 문구는 서로 다르다', async () => {
+    mocks.signIn.mockResolvedValue({ error: 'CredentialsSignin' });
+    renderComponent(<LoginPage />);
+    submit();
+
+    await waitFor(() => {
+      expect(screen.getByText('이메일 또는 비밀번호가 올바르지 않습니다.')).toBeTruthy();
+    });
+    expect(screen.queryByText(/네트워크 상태를 확인/)).toBeNull();
   });
 });

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -11,6 +11,14 @@ function getSafeRedirectParam(): string | null {
   return redirect.startsWith('/') ? redirect : null;
 }
 
+/**
+ * 서버에 **도달하지 못한** 경우의 문구. 자격증명 오류와 반드시 구분한다 —
+ * 같은 문구를 쓰면 사용자가 비밀번호를 의심하며 재시도해 계정 스로틀만 소모한다.
+ * 이 문구는 계정 존재 여부와 무관하므로 오라클이 아니다.
+ */
+const REQUEST_FAILED_MESSAGE =
+  '로그인 요청에 실패했습니다. 네트워크 상태를 확인하고 잠시 후 다시 시도해 주세요.';
+
 export default function LoginPage() {
   // 셀프호스트 단일 관리자 — Auth.js Credentials(이메일/비번) 로그인.
   const [email, setEmail] = useState('');
@@ -27,19 +35,37 @@ export default function LoginPage() {
     try {
       res = await signIn('credentials', { email, password, redirect: false });
     } catch {
-      // signIn은 자격증명 오류를 `res.error`로 돌려주지만 **네트워크·서버 도달 실패는 throw**한다.
-      // 이 catch가 없으면 아래가 통째로 실행되지 않아 credLoading이 true로 굳고, 버튼이
-      // '로그인 중...'으로 영구 비활성화되며 **에러 문구조차 뜨지 않는다**(새로고침 외 탈출 불가).
-      // 자격증명 오류와 문구를 반드시 구분한다 — 같은 문구를 쓰면 사용자가 비밀번호를 의심하며
-      // 재시도해 계정 스로틀만 소모한다. 이 문구는 계정 존재 여부와 무관하므로 오라클이 아니다.
-      setCredError('로그인 요청에 실패했습니다. 네트워크 상태를 확인하고 잠시 후 다시 시도해 주세요.');
+      // 좁은 경로다: providers·csrf 조회는 성공하고 **callback 만 실패**할 때
+      // `new URL(data.url)` 이 TypeError 를 던진다. 아래 `!res` 분기가 나머지를 덮는다.
+      setCredError(REQUEST_FAILED_MESSAGE);
       setCredLoading(false);
       return;
     }
 
-    if (res?.error) {
+    // ⚠️ **`signIn` 은 네트워크·서버 도달 실패에 throw 하지 않는다.** (next-auth 5.0.0-beta.32 실측)
+    //
+    //   fetch 실패 → `fetchData` 가 `catch { logger.error(...); return null }` 로 삼킴
+    //   → `getProviders()` 가 null → signIn 은 `window.location.href='/api/auth/error'` 만 쓰고
+    //     **`return;`** — 즉 **undefined 로 resolve** 한다(reject 아님).
+    //
+    // 그래서 undefined 를 성공으로 읽으면 아래 `window.location.assign('/dashboard')` 가 실행되고,
+    // 세션이 없어 다시 로그인으로 튕긴다 — **원인 표시가 없는 왕복**이 된다.
+    // `AUTH_TRUST_HOST` 누락으로 `/api/auth/*` 가 500 일 때도 같은 경로다.
+    //
+    // 실측 근거: `fetch` 를 거부시켜 실제 signIn 을 호출하면
+    //   reject=false · 반환값=undefined · location.href 쓰기=["/api/auth/error"]
+    if (!res) {
+      setCredError(REQUEST_FAILED_MESSAGE);
+      setCredLoading(false);
+      return;
+    }
+
+    if (res.error) {
       // 스로틀 초과도 여기로 온다(authorize가 null 반환). 계정 존재 여부가 새지 않도록
       // **항상 같은 문구**여야 한다 — docs/decisions/2026-07-30-login-rate-limit.md
+      // 위 두 분기(도달 실패)와 문구를 구분한다 — 같은 문구를 쓰면 사용자가 비밀번호를
+      // 의심하며 재시도해 계정 스로틀만 소모한다. 도달 실패 문구는 계정 존재 여부와
+      // 무관하므로 오라클이 아니다.
       setCredError('이메일 또는 비밀번호가 올바르지 않습니다.');
       setCredLoading(false);
       return;

--- a/src/app/api/v1/admin/debug/route.ts
+++ b/src/app/api/v1/admin/debug/route.ts
@@ -40,7 +40,10 @@ export async function GET(request: Request): Promise<Response> {
           models: describeTaskModels(),
           // 이메일 발송 설정 여부. `RESEND_API_KEY`가 없으면 `emailService`가 조용히
           // no-op이 되고, 그러면 이메일 인증이 영원히 완료되지 않아 `assertEmailVerified()`가
-          // generate·regenerate·deploy를 403으로 막는다 — **신규 사용자가 제품을 아예 못 쓴다.**
+          // **generate·regenerate·suggest 4종·이 라우트 7곳**을 403으로 막는다
+          // — **신규 사용자가 제품을 아예 못 쓴다.**
+          // (`deploy`는 2026-08-01 외부 배포 스택 제거로 사라졌고, **게시(publish)에는
+          //  애초에 이 게이트가 없다** — 2026-08-07 실측: `grep -rl assertEmailVerified src/app/api`)
           // 그런데 그 상태를 밖에서 관측할 방법이 없어 Railway 콘솔을 봐야만 알 수 있었다.
           // ⚠️ 값은 절대 노출하지 않는다. 설정 여부(boolean)와 발신 도메인만 노출한다.
           email: {


### PR DESCRIPTION
> **이 PR 은 내 이전 PR(#292)의 잘못된 전제와 잘못된 보고를 정정한다.**

## 무엇이 틀렸나

#292 는 *"signIn 은 자격증명 오류를 `res.error` 로 돌려주지만 **네트워크·서버 도달 실패는 throw 한다**"* 는 전제로 `catch` 를 추가하고 그 시나리오를 고쳤다고 보고했다. **전제가 라이브러리 실제 동작과 반대다.**

설치된 `next-auth@5.0.0-beta.32` 를 직접 로드해 `fetch` 를 거부시킨 실측:

```
fetch 호출         : 1
signIn reject?     : false
signIn 반환값      : undefined
location.href 쓰기 : ["/api/auth/error"]
```

체인(코드 확인):

```js
// lib/client.js — fetchData
catch (error) { logger.error(new ClientFetchError(...)); return null; }

// react.js — signIn
const providers = await getProviders();
if (!providers) { window.location.href = `${baseUrl}/error`; return; }  // ← undefined 로 resolve
```

그래서 #292 가 추가한 `catch` 는 헤드라인 시나리오에서 **절대 실행되지 않고**, `res?.error` 도 falsy 라 코드가 **성공 경로**로 빠진다.

## 두 가지를 정정한다

**① 보고가 틀렸다.** #292 가 "결함"이라 부른 증상(버튼 영구 비활성화 + 에러 문구 없음)은 **login 에 대해서는 재현되지 않는다.** 수정 전 코드도 `undefined` 를 받아 똑같이 성공 경로로 빠졌다 — 그래서 원래 `?.` 가 있었다.

> signup 절반은 **진짜다.** raw `fetch` 는 네트워크 실패에 실제로 reject 하므로 `setLoading(false)` 가 도달하지 못했다.

**② 진짜 문제는 다르다.** `undefined` 를 성공으로 읽으면 `/dashboard` 로 이동하고, 세션이 없어 로그인으로 되돌아온다 — **원인 표시가 없는 왕복**이 된다. `AUTH_TRUST_HOST` 누락으로 `/api/auth/*` 가 500 일 때도 같은 경로다.

## 수정

| | |
|---|---|
| `if (!res)` 가드 추가 | 도달 실패를 성공으로 읽지 않는다 |
| `catch` 유지 | providers·csrf 는 성공하고 **callback 만** 실패하면 `new URL(data.url)` 이 실제로 던진다 |
| `REQUEST_FAILED_MESSAGE` 상수 분리 | 자격증명 오류와 **반드시 구분** — 같은 문구면 사용자가 비밀번호를 의심하며 재시도해 계정 스로틀만 소모한다. 도달 실패 문구는 계정 존재 여부와 무관해 오라클이 아니다 |

## 테스트 — 거짓 전제를 고정하던 것을 교체

기존 테스트는 `mocks.signIn.mockRejectedValue(...)` 로 **라이브러리가 하지 않는 동작**을 목킹했다. 초록이었지만 프로덕션 시나리오는 재현하지 못했다.

> **G1: 초록색은 증거가 아니다.** 내가 CLAUDE.md 에 쓴 게이트가 나 자신에게 적용됐다.

- `mockResolvedValue(undefined)` — **실제** 네트워크·서버 도달 실패 경로
- `mockRejectedValue(new TypeError('Invalid URL'))` — 좁지만 실재하는 callback 단독 실패
- **대조군**: 자격증명 오류 문구와 도달 실패 문구가 **서로 다른지** 단언

**검증(양방향)**: 수정 전 코드(가드 제거 + `res?.error` 복원)로 되돌리면 **새 테스트 1건만 실패**하고 나머지 6건은 통과한다.

## 부수

`admin/debug/route.ts` 주석의 `assertEmailVerified` 적용 범위 오기 정정 — `deploy` 는 2026-08-01 제거됐고 **publish 에는 이 게이트가 없다**(실측).

## 게이트

```
type-check clean · lint 0 errors · test 197파일 2,521 · build · E2E 43/43
```

## 발견 경로

세션 종료 전 **적대적 재검증 워크플로**("다 맞다는 결론을 실패 신호로 취급하라"). **돌리지 않았으면 프로덕션에 그대로 남았다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)