### PR TITLE
fix: 재생성 버전 미상을 1번이 아니라 최신본으로 폴백 (#293 잔여)

### DIFF
--- a/src/app/(main)/builder/page.tsx
+++ b/src/app/(main)/builder/page.tsx
@@ -60,7 +60,9 @@ export default function BuilderPage() {
    * 신원을 값 안에 담으면 `setRegen(null)`을 **어디서도 부를 필요가 없다** — 즉 리셋 누락이
    * 버그가 될 수 없다. 이전 구현은 `setRegenVersion(undefined)` 호출이 저장소 전체에 0건이었다.
    */
-  const [regen, setRegen] = useState<{ projectId: string; version: number } | null>(null);
+  const [regen, setRegen] = useState<{ projectId: string; version: number | undefined } | null>(
+    null,
+  );
 
   /**
    * 비행 중인 AI 제안 요청(suggest-context · suggest-apis)의 취소 핸들.

--- a/src/components/builder/RePromptPanel.test.tsx
+++ b/src/components/builder/RePromptPanel.test.tsx
@@ -312,7 +312,14 @@ describe('RePromptPanel', () => {
     expect(onRegenerationComplete).toHaveBeenCalledTimes(1);
   });
 
-  it('version undefined 시 1 로 onRegenerationComplete', async () => {
+  // 이 테스트는 원래 `toHaveBeenCalledWith(1)` 이었다 — 즉 **"버전 미상"을 1번 버전으로**
+  // 바꾸는 동작을 고정하고 있었다. 1번은 가장 오래된 버전이라, 계약이 깨지는 날 사용자는
+  // **최신본 대신 최초 생성본**을 보게 된다(미리보기 URL 이 `&version=1` 로 붙는다).
+  //
+  // 미상일 때의 안전한 기본값은 "버전을 지정하지 않는 것"이다:
+  // `codeRepo.findByProject(projectId, undefined)` 가 `orderBy(desc(version))` 로 최신 1건을
+  // 돌려주므로, undefined 를 그대로 흘리면 자동으로 최신본이 된다(2026-08-07 코드 확인).
+  it('version 이 undefined 면 그대로 undefined 로 통지한다 (1로 메우지 않는다)', async () => {
     runClientRegeneration.mockImplementation(async (_input, deps) => {
       deps.completeRegeneration(undefined);
     });
@@ -331,7 +338,7 @@ describe('RePromptPanel', () => {
     });
 
     await waitFor(() => {
-      expect(onRegenerationComplete).toHaveBeenCalledWith(1);
+      expect(onRegenerationComplete).toHaveBeenCalledWith(undefined);
     });
   });
 

--- a/src/components/builder/RePromptPanel.tsx
+++ b/src/components/builder/RePromptPanel.tsx
@@ -9,7 +9,16 @@ type RegenStatus = 'idle' | 'suggesting' | 'generating' | 'done' | 'error';
 
 interface RePromptPanelProps {
   projectId: string;
-  onRegenerationComplete: (version: number) => void;
+  /**
+   * 재생성 완료 통지. **`undefined` = "버전 미상"** 이고, 그건 `1`이 아니다.
+   *
+   * 서버는 현재 항상 version 을 채우지만(SSE `generationSaver`·폴링 status 라우트 양쪽),
+   * 계약이 깨지는 날 `?? 1` 로 메우면 **가장 오래된 버전**을 최신인 척 보여준다.
+   * 미상일 때의 안전한 기본값은 "버전을 지정하지 않는 것"이다 —
+   * `codeRepo.findByProject(projectId, undefined)` 가 `orderBy(desc(version))` 로 **최신 1건**을
+   * 돌려주므로, undefined 를 그대로 흘리면 자동으로 최신본이 된다.
+   */
+  onRegenerationComplete: (version: number | undefined) => void;
 }
 
 export default function RePromptPanel({ projectId, onRegenerationComplete }: RePromptPanelProps) {
@@ -103,7 +112,8 @@ export default function RePromptPanel({ projectId, onRegenerationComplete }: ReP
             setStatus('done');
             setFeedback('');
             setSuggestions([]);
-            onRegenerationComplete(version ?? 1);
+            // `?? 1` 을 쓰지 않는다 — 미상을 **가장 오래된 버전**으로 바꾸는 잘못된 기본값이었다.
+            onRegenerationComplete(version);
           });
         },
         failRegeneration: (message) => {

--- a/src/components/dashboard/RePromptSection.test.tsx
+++ b/src/components/dashboard/RePromptSection.test.tsx
@@ -9,18 +9,25 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ refresh: mockRefresh }),
 }));
 
+/**
+ * 목이 통지할 버전. 테스트에서 바꿔 **미상(undefined)** 경로까지 덮는다.
+ * `RePromptPanel`은 서버가 version을 안 주면 `undefined`를 그대로 흘린다
+ * (`?? 1`은 "미상"을 **가장 오래된 1번**으로 바꾸는 잘못된 기본값이라 제거됐다).
+ */
+let nextVersion: number | undefined = 3;
+
 vi.mock('@/components/builder/RePromptPanel', () => ({
   default: ({
     projectId,
     onRegenerationComplete,
   }: {
     projectId: string;
-    onRegenerationComplete: (version: number) => void;
+    onRegenerationComplete: (version: number | undefined) => void;
   }) => (
     <button
       data-testid="reprompt-panel"
       data-project-id={projectId}
-      onClick={() => onRegenerationComplete(3)}
+      onClick={() => onRegenerationComplete(nextVersion)}
     >
       trigger
     </button>
@@ -30,6 +37,7 @@ vi.mock('@/components/builder/RePromptPanel', () => ({
 describe('RePromptSection', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    nextVersion = 3;
   });
 
   it('초기 버전 번호를 헤더에 표시한다', () => {
@@ -56,5 +64,21 @@ describe('RePromptSection', () => {
       screen.getByTestId('reprompt-panel').click();
     });
     expect(screen.getByText(/현재 v3/)).toBeTruthy();
+  });
+
+  // 서버가 version을 안 준 경우(미상). "현재 v{N}"은 사람이 읽는 라벨이라
+  // 빈 값이나 잘못된 숫자를 보이느니 **직전 값을 유지**하는 편이 낫고,
+  // 실제 최신값은 `router.refresh()`가 서버에서 다시 가져온다.
+  it('version이 undefined면 헤더 값을 유지하고 refresh만 한다', async () => {
+    nextVersion = undefined;
+    render(<RePromptSection projectId="proj-1" currentVersion={2} />);
+
+    await act(async () => {
+      screen.getByTestId('reprompt-panel').click();
+    });
+
+    // 직전 값 유지 — "현재 v" 뒤가 비거나 NaN이 되지 않는다
+    expect(screen.getByText(/현재 v2/)).toBeTruthy();
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/dashboard/RePromptSection.tsx
+++ b/src/components/dashboard/RePromptSection.tsx
@@ -24,7 +24,10 @@ export function RePromptSection({ projectId, currentVersion }: RePromptSectionPr
       <RePromptPanel
         projectId={projectId}
         onRegenerationComplete={(version) => {
-          setLatestVersion(version);
+          // 미상이면 표시값을 건드리지 않는다 — 헤더의 "현재 v{N}" 은 사람이 읽는 라벨이라
+          // 빈 값이나 잘못된 숫자를 보이느니 직전 값을 유지하는 편이 낫다.
+          // (`router.refresh()` 가 서버에서 실제 최신값을 다시 가져온다.)
+          if (version !== undefined) setLatestVersion(version);
           router.refresh();
         }}
       />


### PR DESCRIPTION
[#293](https://github.com/xzawed/CustomWebService/pull/293)에서 *"오늘 도달 불가지만 **잘못된 기본값**"* 으로 확정하고 별건으로 미뤄둔 것.

## 무엇이 틀렸나

`RePromptPanel.tsx:106` 의 `onRegenerationComplete(version ?? 1)` 은 **"버전 미상"을 1번 버전으로** 바꾼다. **1번은 가장 오래된 버전**이다.

서버 계약이 깨지는 날 사용자는 최신본 대신 **최초 생성본**을 보게 되고, 미리보기 URL 에 `&version=1` 이 붙어 그게 최신인 것처럼 보인다.

## 안전한 기본값은 "버전을 지정하지 않는 것"

코드 확인 — `SqliteCodeRepository.findByProject` (109–131행):

```ts
async findByProject(projectId: string, version?: number) {
  if (version !== undefined) { /* eq(version) 정확 일치 */ }
  // version 미지정: 최신 버전 1건
  ... .orderBy(desc(schema.generatedCodes.version)).limit(1)
}
```

**`undefined` 를 그대로 흘리면 자동으로 최신본이 된다.**

## 수정

- `onRegenerationComplete: (version: number \| undefined) => void`
- `version ?? 1` → `version`
- 소비처 2곳:
  - `builder/page.tsx` — `regen` 타입을 `version: number \| undefined` 로 넓힘. `PreviewFrame` 이 `undefined` 를 받으면 `&version=` 을 안 붙이므로 자동으로 최신본
  - `dashboard/RePromptSection.tsx` — 미상이면 표시값을 건드리지 않는다. "현재 v{N}" 은 사람이 읽는 라벨이라 빈 값·잘못된 숫자보다 직전 값 유지가 낫고, `router.refresh()` 가 서버에서 실제 최신값을 다시 가져온다

## 테스트가 결함을 고정하고 있었다

기존: `expect(onRegenerationComplete).toHaveBeenCalledWith(1)` — **틀린 기본값을 계약으로 못박고 있었다.**

→ `toHaveBeenCalledWith(undefined)` 로 바꾸고, **왜 1이 틀린 기본값인지** 주석에 남겼다.

**검증(양방향)**: `?? 1` 을 되돌리면 그 테스트만 실패한다 —
`AssertionError: expected "vi.fn()" to be called with arguments: [ undefined ]`

## 게이트

```
type-check clean · lint 0 errors · test 197파일 2,519 · build · E2E 43/43 · docs:check 8/8
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)