### PR TITLE
fix: 적대적 재검증이 확인한 결함 4건 + 게이트 정직화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ ADR은 "왜 이렇게 됐는지"이고 **대부분 이미 한 번 사고가 난 
 - **`x-forwarded-for`는 최우측만 신뢰**하고 `x-real-ip`는 신뢰하지 않는다. 최좌측·`x-real-ip`는
   클라이언트가 위조할 수 있어 per-IP 리밋이 무력화된다. 식별 불가 시 `'unknown'` 단일 버킷(fail-closed)
 - **인메모리 레이트리밋은 활성 윈도를 evict하지 않는다.** 우회보다 과차단이 안전하다 ·
-  [system-spec §4.1](docs/architecture/system-spec.md)
+  [system-spec §4.1 (인메모리 레이트리밋)](docs/architecture/system-spec.md)
 - **`railway.toml`에 `startCommand`를 넣지 말 것.** Dockerfile 배포에서 이미지 `ENTRYPOINT`를
   덮어써 `chown /data` + `su-exec`가 실행되지 않고 **컨테이너가 root로 뜬다** ·
   [트러블슈팅](docs/guides/railway-deploy-troubleshooting.md)
@@ -113,12 +113,15 @@ ADR은 "왜 이렇게 됐는지"이고 **대부분 이미 한 번 사고가 난 
   인증은 `@/lib/auth/local-auth-edge`를 **동적 import로만** — `local-auth-config`(scrypt) 정적 import 금지.
   임포트 추가 시 체인 전체를 역추적하고 `pnpm test:prod`로 확인
 - **AI 호출 타임아웃은 `Promise.race`만으로 끝내지 말고 `AbortSignal`을 함께 넘길 것.**
-  race가 이겨도 업스트림은 살아 있어 **토큰 비용이 이중 청구**된다 · [system-spec §4.3](docs/architecture/system-spec.md)
+  race가 이겨도 업스트림은 살아 있어 **토큰 비용이 이중 청구**된다 · [system-spec §3.3 (AI 호출 타임아웃)](docs/architecture/system-spec.md)
 - **병합했으면 배포가 실제로 됐는지 확인한다.** 조용한 미배포가 **3종** 있고 전부 health 200이라
   드러나지 않는다. 세 번째(**런 자체가 생성되지 않음**)는 배포 목록이 아니라 **런 목록**을 봐야
   보인다 · [트러블슈팅](docs/guides/railway-deploy-troubleshooting.md)
-- **추천 라우트(`suggest-*`)는 전부 `createForTask('suggestion')`(Haiku).** `create()` 기본(Sonnet 5)을
-  쓰면 **조용히 3배 단가** — 테스트도 CI도 비용은 안 잡는다
+- **모델 ID를 어디에도 하드코딩하지 말 것.** `createForTask('suggestion')`(Haiku) 또는 —
+  tool use가 필요해 `IAiProvider`를 못 쓰면 — `resolveTaskModel('suggestion')`을 거친다.
+  `create()` 기본(Sonnet 5)을 쓰면 **조용히 3배 단가**이고, 하드코딩하면 **`AI_MODEL_*` env가
+  그 경로에만 닿지 않는다**(허용목록 검증·경고도 건너뛴다). 실제로 `preferencesRecommender`·
+  `featureExtractor` 2곳이 그랬다(2026-08-07 발견·수정). **테스트도 CI도 비용은 안 잡는다**
 - **`RATE_LIMIT_BYPASS_USER_IDS` 적용 시 `logger.info('Rate limit bypass applied', ...)` 필수.**
   무로깅 우회는 감사 흔적이 사라진다 — 어떤 게이트도 이걸 검출하지 않는다
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -176,7 +176,7 @@
 
 | 이벤트 | 발행 위치 |
 |--------|----------|
-| `USER_SIGNED_UP` | `authService.signup()` — 회원가입 완료 시 |
+| `USER_SIGNED_UP` | `api/v1/auth/signup/route.ts` — 가입 성공 직후. **서비스가 아니라 라우트가 발행한다**(`USER_DELETED`와 같은 자리) |
 | `USER_DELETED` | `DELETE /api/v1/auth/account` — 계정 삭제 커밋 **이후** |
 | `PROJECT_CREATED` / `PROJECT_DELETED` / `PROJECT_PUBLISHED` / `PROJECT_UNPUBLISHED` | `projectService.ts` |
 | `CODE_GENERATED` | `generationSaver.ts` |

--- a/docs/architecture/system-spec.md
+++ b/docs/architecture/system-spec.md
@@ -292,9 +292,14 @@ CSP를 만질 때는 `middleware.ts` · `site/[slug]/route.ts` · `preview/[proj
   복구 경보를 빼면 억제가 정보를 삼킨다
 - 상태는 **클로저 로컬**(모듈 레벨 플래그 금지) — 인스턴스 독립이라 테스트가 `vi.resetModules()`를 안 써도 된다
 
-> `errorRateMonitor`가 `await sendSlackAlert`를 해도 되는 이유는 `EventBus.emit`이 핸들러를
-> `.catch`로 감싸기 때문이다. **스케줄러에는 그 래퍼가 없다** — EventBus 소비자 코드를 그대로
-> 복사하면 안 된다.
+> `errorRateMonitor`가 `await sendSlackAlert`를 해도 되는 이유는 `EventBus.emit`이 핸들러 실패를
+> **비동기 거부(`.catch`)와 동기 throw(`try`) 양쪽 다** 삼키기 때문이다.
+> **스케줄러에는 그 래퍼가 없다** — EventBus 소비자 코드를 그대로 복사하면 안 된다.
+>
+> ⚠️ `try`가 없으면 `.catch`만으로는 부족하다: `Promise.resolve(handler(event))`는 핸들러를
+> **먼저 평가**하므로 동기 throw는 `.catch`가 붙기 전에 새어 나가 **emit 호출부(계정 삭제·
+> 생성 파이프라인·카탈로그 활성화)를 통째로 실패시킨다.** 2026-08-07에 실측으로 확인하고 막았다.
+> 회귀 테스트: `eventBus.test.ts`의 「동기적으로 throw 하는 핸들러가 emit 호출부를 깨뜨리지 않는다」.
 >
 > 클로저 로컬이라는 성질의 귀결: **재배포를 넘으면 복구 경보를 검증할 수 없다**
 > (`null → true`는 첫 성공이지 복구가 아니다). 2026-07-31 프로덕션에서 실증됨.

--- a/scripts/checkDocIntegrity.ts
+++ b/scripts/checkDocIntegrity.ts
@@ -1,7 +1,7 @@
 // scripts/checkDocIntegrity.ts
 // Run: pnpm docs:check
 //
-// 문서 정합성 검사 8종. 트리거·경로·명령어는 **테스트도 lint도 안 잡는** 유일한
+// 문서 정합성 검사 9종. 트리거·경로·명령어는 **테스트도 lint도 안 잡는** 유일한
 // 문서 요소이고, 실제로 죽어 있던 것이 이미 2건 나왔다
 // (ENV_VAR_DENYLIST — 보안 ADR / isNotFound — SQLite 컷오버 때 제거).
 //
@@ -352,7 +352,14 @@ if (currentTenseLines > CURRENT_TENSE_BUDGET) {
 // ── ⑦ `파일:행` 참조가 실제 행 수 안에 있는가 ─────────────────────────────
 // ②는 파일 **존재**만 본다. 행 번호는 코드가 자라면 조용히 어긋나고, 어긋난 채로
 // "config/generation.ts:32를 보라"고 하면 다음 사람이 엉뚱한 줄을 읽는다.
-// 실제로 이 저장소에서 WBS의 `574·694행`이 `625·745행`으로 드리프트해 있었다.
+//
+// ⚠️ **범위 한계를 알고 쓸 것 (2026-08-07 재검증에서 지적됨).**
+//  (a) `` `path/file.ts:NNN` `` 형태만 본다. WBS의 "625·745행이 …" 처럼 **파일명이 같은 줄에
+//      없는 산문 참조**는 못 잡는다 — 이 검사의 동기가 된 바로 그 드리프트가 그 형태였다.
+//      "가장 가까운 파일 언급과 묶는" 휴리스틱은 오탐을 만들어 검사 신뢰를 깎으므로 넣지 않는다.
+//  (b) **총 행수 초과만** 잡는다. 파일 범위 *안*에서 어긋난 참조(더 흔한 드리프트)는
+//      구조적으로 못 잡는다 — 그 줄에 무엇이 있어야 하는지를 모르기 때문이다.
+// 즉 ⑦은 "명백히 죽은 참조"만 거른다. 행 참조를 쓸 때는 그 사실을 감안할 것.
 for (const f of allMd) {
   if (isHistory(f)) continue;
   const lines = stripFences(fs.readFileSync(f, 'utf8')).split(/\r?\n/);
@@ -373,6 +380,63 @@ for (const f of allMd) {
   });
 }
 
+// ── ⑧ `system-spec §N.N` 절 포인터가 실재하는가 ────────────────────────────
+// ⑦이 **행** 참조 드리프트를 잡는다면 이건 **절** 참조 드리프트를 잡는다. 같은 부류다 —
+// 대상 문서가 개편되면 번호가 조용히 어긋나고, 포인터를 따라간 사람은 엉뚱한 규칙을 읽는다.
+//
+// 2026-08-07 실측: CLAUDE.md가 AI 타임아웃 규칙을 `system-spec §4.3`으로 가리켰는데
+// §4.3은 **CSP 규칙**이었다(실제 위치는 §3.3). 링크 자체는 유효해서 ③이 못 잡았고,
+// 행 번호가 아니라 절 번호라 ⑦도 못 잡았다 — **어느 검사에도 안 걸리는 사각지대**였다.
+//
+// ⚠️ **이 검사의 한계를 알고 쓸 것.** 번호만 적힌 포인터는 *존재 여부*만 본다 —
+// 위의 §4.3처럼 **실재하지만 엉뚱한 절**을 가리키는 것은 못 잡는다(오늘의 그 버그다).
+// 그래서 **제목 힌트**를 함께 적으면 그것까지 검증한다:
+//     `system-spec §3.3 (AI 호출 타임아웃)`   ← 괄호 안이 실제 제목에 포함되는지 확인
+// 힌트를 붙이는 것이 권장이고, 붙이지 않으면 약한 검사만 걸린다.
+{
+  const specPath = path.join(ROOT, 'docs/architecture/system-spec.md');
+  if (fs.existsSync(specPath)) {
+    const sections = new Map<string, string>();
+    for (const line of fs.readFileSync(specPath, 'utf8').split(/\r?\n/)) {
+      const m = /^#{2,4}\s+([0-9]+(?:\.[0-9]+)*)\s+(.*)$/.exec(line);
+      if (m) sections.set(m[1], m[2]);
+    }
+    for (const f of allMd) {
+      if (isHistory(f)) continue;
+      const lines = stripFences(fs.readFileSync(f, 'utf8')).split(/\r?\n/);
+      lines.forEach((line, i) => {
+        if (isGuardrail(lines, i)) return;
+        // `system-spec §3.3` 또는 `system-spec §3.3 (제목 힌트)`
+        for (const m of line.matchAll(/system-spec §([0-9]+(?:\.[0-9]+)*)(?:\s*\(([^)]{2,40})\))?/g)) {
+          const [, num, hint] = m;
+          const title = sections.get(num);
+          if (title === undefined) {
+            add(
+              '⑧ 절 포인터',
+              `${rel(f)}:${i + 1}`,
+              `\`system-spec §${num}\` — system-spec.md에 그런 절이 없다 ` +
+                `(실재: ${[...sections.keys()].sort().join(' · ')})`,
+            );
+            continue;
+          }
+          // 힌트가 있으면 **가리키는 절이 맞는지**까지 본다 — 번호만으로는 못 잡는 층이다.
+          if (hint) {
+            const norm = (s: string): string => s.replace(/[\s`*🔇]/g, '');
+            if (!norm(title).includes(norm(hint))) {
+              add(
+                '⑧ 절 포인터',
+                `${rel(f)}:${i + 1}`,
+                `\`system-spec §${num} (${hint})\` — §${num}의 실제 제목은 "${title}"이다. ` +
+                  `번호나 힌트 중 하나가 틀렸다`,
+              );
+            }
+          }
+        }
+      });
+    }
+  }
+}
+
 // ── 보고 ──────────────────────────────────────────────────────────────────
 const byCheck = new Map<string, Violation[]>();
 for (const v of violations) {
@@ -385,7 +449,7 @@ console.log(`문서 정합성 검사 — md ${allMd.length}개 · ADR ${adrs.len
 
 // 검사 개수는 세어서 출력한다 — 상수로 박으면 검사를 추가할 때 조용히 어긋난다
 // (실제로 헤더가 "4종"인데 출력이 "5/5"인 드리프트가 있었다).
-const TOTAL_CHECKS = 8;
+const TOTAL_CHECKS = 9;
 
 if (violations.length === 0) {
   console.log(`위반 없음 (${TOTAL_CHECKS}/${TOTAL_CHECKS} 통과)`);

--- a/src/__tests__/api/auth.test.ts
+++ b/src/__tests__/api/auth.test.ts
@@ -21,6 +21,9 @@ vi.mock('@/lib/config/featureFlags', () => ({
   isFeatureEnabled: (name: string) => isFeatureEnabled(name) as boolean,
 }));
 
+const eventBusEmit = vi.fn();
+vi.mock('@/lib/events/eventBus', () => ({ eventBus: { emit: (e: unknown) => eventBusEmit(e) } }));
+
 import { POST as signupPOST } from '@/app/api/v1/auth/signup/route';
 import { POST as verifyPOST } from '@/app/api/v1/auth/verify-email/route';
 import { POST as forgotPOST } from '@/app/api/v1/auth/forgot-password/route';
@@ -55,6 +58,21 @@ describe('auth routes', () => {
     const res = await signupPOST(jsonReq('https://app/api/v1/auth/signup', { email: 'a@b.com', password: 'pw12345678' }, `ip-${Math.random()}`));
     expect(res.status).toBe(201);
     expect(signup).toHaveBeenCalledWith('a@b.com', 'pw12345678', 'https://app');
+  });
+
+  // 계정 **삭제**는 `USER_DELETED`로 감사 로그에 남는데 **생성**은 안 남고 있었다 —
+  // `USER_SIGNED_UP`이 `src/types/events.ts`에 정의만 되고 발행처가 0곳이었다(2026-08-07 발견).
+  // 계정 생성은 보안 감사에서 삭제만큼 중요하다.
+  it('signup 성공 시 USER_SIGNED_UP을 발행한다 (감사 로그)', async () => {
+    signup.mockResolvedValue({ userId: 'u1' });
+    await signupPOST(jsonReq('https://app/api/v1/auth/signup', { email: 'a@b.com', password: 'pw12345678' }, `ip-${Math.random()}`));
+    expect(eventBusEmit).toHaveBeenCalledWith({ type: 'USER_SIGNED_UP', payload: { userId: 'u1' } });
+  });
+
+  it('가입이 막히면(enable_signup=false) USER_SIGNED_UP을 발행하지 않는다', async () => {
+    isFeatureEnabled.mockReturnValue(false);
+    await signupPOST(jsonReq('https://app/api/v1/auth/signup', { email: 'a@b.com', password: 'pw12345678' }, `ip-${Math.random()}`));
+    expect(eventBusEmit).not.toHaveBeenCalled();
   });
 
   it('enable_signup=false이면 503 SIGNUP_DISABLED이고 signup을 호출하지 않는다', async () => {

--- a/src/app/(main)/builder/page.tsx
+++ b/src/app/(main)/builder/page.tsx
@@ -84,10 +84,15 @@ export default function BuilderPage() {
    * **로딩 플래그의 존재를 알 필요가 없다.** 새 abort 지점이 생겨도 자동으로 옳다.
    * (abort 지점마다 해제 코드를 추가하는 방식은 그 곱셈을 절반만 채우다 #289에서 재도입됐다.)
    *
-   * ⚠️ 불변조건: `++xxxReqIdRef.current` 다음 줄이 `setIsXLoading(true)`여야 하고 그 직후가
-   * 대응하는 `finally`를 가진 `try`여야 한다. 사이에 `await`나 조기 return을 넣으면
-   * "true를 쓴 실행에는 반드시 대응하는 finally가 있다"가 깨져 고착이 그대로 돌아온다.
-   * 정적으로 강제되지 않는다 — `page.test.tsx`의 **선점 음성대조 테스트가 유일한 방어**다.
+   * ⚠️ 불변조건: `++xxxReqIdRef.current` 와 대응하는 `finally` 를 가진 `try` 사이에
+   * **`await` 도 조기 `return` 도 넣지 말 것.** 동기 `setState` 는 끼어도 된다
+   * (실제로 suggestions·recommendations 는 초기화 2줄이 사이에 있다 — 그건 괜찮다).
+   * 어기면 "true 를 쓴 실행에는 반드시 대응하는 finally 가 있다"가 깨져 고착이 돌아온다.
+   *
+   * ⚠️ **이 배치 규칙은 어떤 테스트도 지키지 않는다.** `page.test.tsx` 의 선점 음성대조는
+   * **토큰 비교**(이전 요청의 finally 가 최신 로딩을 끄면 안 된다)를 지킬 뿐, 증가와 `try`
+   * 사이에 조기 return 을 끼워 넣는 변경은 **통과시킨다**. 즉 여기는 리뷰로만 지켜진다 —
+   * "테스트가 막아준다"고 믿지 말 것.
    */
   const suggestionsReqIdRef = useRef(0);
   const recommendationsReqIdRef = useRef(0);

--- a/src/app/api/v1/auth/signup/route.ts
+++ b/src/app/api/v1/auth/signup/route.ts
@@ -3,6 +3,7 @@ import { signupSchema } from '@/types/schemas';
 import { parseJsonBody, enforceRateLimit, getBaseUrl } from '@/lib/auth/routeHelpers';
 import { handleApiError, jsonResponse } from '@/lib/utils/errors';
 import { isFeatureEnabled } from '@/lib/config/featureFlags';
+import { eventBus } from '@/lib/events/eventBus';
 
 export async function POST(request: Request): Promise<Response> {
   try {
@@ -22,7 +23,12 @@ export async function POST(request: Request): Promise<Response> {
     const data = await parseJsonBody(request, signupSchema);
 
     const baseUrl = getBaseUrl(request);
-    await createAuthService().signup(data.email, data.password, baseUrl);
+    const { userId } = await createAuthService().signup(data.email, data.password, baseUrl);
+
+    // 계정 **삭제**는 감사 로그에 남는데(`USER_DELETED`) **생성**은 안 남고 있었다 —
+    // `USER_SIGNED_UP` 이 `src/types/events.ts` 에 정의만 되고 발행처가 0곳이었다(2026-08-07 발견).
+    // 계정 생성은 보안 감사에서 삭제만큼 중요하다. `eventPersister` 가 자동으로 DB 에 기록한다.
+    eventBus.emit({ type: 'USER_SIGNED_UP', payload: { userId } });
 
     return jsonResponse(
       { success: true, data: { message: '가입이 완료되었습니다. 이메일 인증 링크를 확인해주세요.' } },

--- a/src/lib/ai/featureExtractor.ts
+++ b/src/lib/ai/featureExtractor.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
+import { resolveTaskModel } from '@/providers/ai/AiProviderFactory';
 
 export interface Feature {
   id: string; // snake_case identifier, e.g. "city-search"
@@ -80,7 +81,9 @@ export async function extractFeatures(
     const client = new Anthropic({ apiKey, timeout: 30_000 });
 
     const response = await client.messages.create({
-      model: 'claude-haiku-4-5',
+      // tool use 가 필요해 `IAiProvider` 를 못 쓴다. 모델 해석만 팩토리와 공유한다 —
+      // 하드코딩하면 `AI_MODEL_SUGGESTION` 이 이 경로에만 닿지 않는다.
+      model: resolveTaskModel('suggestion'),
       max_tokens: 1024,
       system: SYSTEM_PROMPT,
       tools: [EXTRACT_FEATURES_TOOL],

--- a/src/lib/ai/preferencesRecommender.ts
+++ b/src/lib/ai/preferencesRecommender.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
+import { resolveTaskModel } from '@/providers/ai/AiProviderFactory';
 import type {
   RelevanceGateResult,
   PreferenceSuggestion,
@@ -127,7 +128,9 @@ export async function recommendPreferences(input: RecommendInput): Promise<Relev
       .join('\n');
 
     const response = await client.messages.create({
-      model: 'claude-haiku-4-5',
+      // tool use 가 필요해 `IAiProvider` 를 못 쓴다. 모델 해석만 팩토리와 공유한다 —
+      // 하드코딩하면 `AI_MODEL_SUGGESTION` 이 이 경로에만 닿지 않는다.
+      model: resolveTaskModel('suggestion'),
       max_tokens: 1024,
       system: SYSTEM_PROMPT,
       tools: [RECOMMEND_PREFERENCES_TOOL],

--- a/src/lib/events/eventBus.test.ts
+++ b/src/lib/events/eventBus.test.ts
@@ -153,6 +153,37 @@ describe('EventBus', () => {
       unsubscribe();
     });
 
+    // ⚠️ **비동기 거부와 동기 throw 는 다른 경로다.**
+    // `Promise.resolve(handler(event))` 는 `handler(event)` 를 **먼저 평가**하므로,
+    // 핸들러가 동기적으로 던지면 `.catch` 가 붙기 전에 예외가 나간다.
+    // 그러면 emit 호출부 — 계정 삭제·생성 파이프라인·카탈로그 활성화 — 가 통째로 실패한다.
+    // 이벤트는 감사·부가 기록이지 본 작업의 성공 조건이 아니므로 **절대 전파되면 안 된다.**
+    // (2026-08-07 실측으로 전파를 확인하고 `try` 로 막았다.)
+    it('동기적으로 throw 하는 핸들러가 emit 호출부를 깨뜨리지 않는다', async () => {
+      const { logger } = await import('@/lib/utils/logger');
+      const syncThrower = vi.fn(() => {
+        throw new Error('동기 throw');
+      });
+      const normalHandler = vi.fn();
+
+      const unsub1 = eventBus.on(syncThrower);
+      const unsub2 = eventBus.on(normalHandler);
+
+      // 호출부가 깨지지 않는다 — 이게 핵심 단언이다
+      expect(() => eventBus.emit(TEST_EVENT)).not.toThrow();
+      await new Promise((r) => setTimeout(r, 10));
+
+      // 그리고 뒤 핸들러도 계속 호출된다
+      expect(normalHandler).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'EventBus handler threw synchronously',
+        expect.objectContaining({ type: 'USER_SIGNED_UP' }),
+      );
+
+      unsub1();
+      unsub2();
+    });
+
     it('async 에러 핸들러가 여러 개여도 모두 logger.warn을 호출한다', async () => {
       const { logger } = await import('@/lib/utils/logger');
       const errorHandler1 = vi.fn().mockRejectedValue(new Error('에러1'));

--- a/src/lib/events/eventBus.ts
+++ b/src/lib/events/eventBus.ts
@@ -13,11 +13,26 @@ class EventBus {
     };
   }
 
+  /**
+   * **핸들러 실패가 호출부를 절대 깨뜨리지 않는다.** 이벤트는 감사·부가 기록이지
+   * 본 작업의 성공 조건이 아니다 — 계정 삭제·생성 파이프라인·카탈로그 활성화가 전부
+   * 이걸 부르고, 여기서 예외가 새면 **그 도메인 작업 자체가 실패**한다.
+   *
+   * ⚠️ `try` 가 필요한 이유: `Promise.resolve(handler(event))` 는 `handler(event)` 를
+   * **먼저 평가**하므로, 핸들러가 **동기적으로 throw** 하면 `.catch` 가 붙기 전에 예외가
+   * 나가 버린다. 즉 `.catch` 만으로는 **비동기 거부만** 막힌다.
+   * (2026-08-07 실측으로 확인 — 문서는 "emit이 핸들러를 .catch로 감싼다"고만 적고 있었다.
+   *  현행 핸들러는 전부 `async` 라 사고는 없었지만, 비-async 핸들러 하나면 깨진다.)
+   */
   emit(event: DomainEvent): void {
     for (const handler of this.handlers) {
-      Promise.resolve(handler(event)).catch((err) => {
-        logger.warn('EventBus handler error', { type: event.type, error: err });
-      });
+      try {
+        Promise.resolve(handler(event)).catch((err) => {
+          logger.warn('EventBus handler error', { type: event.type, error: err });
+        });
+      } catch (err) {
+        logger.warn('EventBus handler threw synchronously', { type: event.type, error: err });
+      }
     }
   }
 }

--- a/src/providers/ai/AiProviderFactory.ts
+++ b/src/providers/ai/AiProviderFactory.ts
@@ -30,7 +30,18 @@ const TASK_ENV_VARS: Record<AiTaskType, string> = {
   generation: 'AI_MODEL_GENERATION',
 };
 
-function resolveTaskModel(task: AiTaskType): AllowedClaudeModel {
+/**
+ * task 별 실효 모델 ID. **`IAiProvider` 를 쓰지 않고 Anthropic SDK 를 직접 호출하는 곳도
+ * 반드시 이걸 통해야 한다** — 안 그러면 `AI_MODEL_*` env 가 그 경로에만 닿지 않고,
+ * 허용목록 검증·경고도 건너뛴다.
+ *
+ * 실제로 그런 우회가 2곳 있었다(2026-08-07 발견): `preferencesRecommender` ·
+ * `featureExtractor` 가 `model: 'claude-haiku-4-5'` 를 하드코딩하고 있었다.
+ * 값이 기본값과 우연히 같아 비용 사고는 없었지만, env 로 모델을 바꿔도 그 둘만 안 바뀌었다.
+ * tool use(`tools`/`tool_choice`)가 필요해 `IAiProvider` 를 못 쓰는 경우가 그 이유이므로,
+ * **모델 해석만 공유**하는 것이 올바른 접합점이다.
+ */
+export function resolveTaskModel(task: AiTaskType): AllowedClaudeModel {
   const envVar = TASK_ENV_VARS[task];
   const fallback = TASK_DEFAULTS[task];
   const raw = process.env[envVar]?.trim();


### PR DESCRIPTION
세션 종료 전 **적대적 재검증 워크플로**("다 맞다는 결론을 실패 신호로 취급하라")가 올린 것 중 **내가 직접 재확인한 것만** 처리한다.

## ① 모델 ID 하드코딩 2곳 — env 가 닿지 않았다

`preferencesRecommender.ts` · `featureExtractor.ts` 가 tool use 때문에 `IAiProvider` 를 못 쓰고 SDK 를 직접 부르면서 `model: 'claude-haiku-4-5'` 를 하드코딩했다. 값이 기본값과 우연히 같아 **비용 사고는 없었지만** —

- `AI_MODEL_SUGGESTION` 이 그 둘에만 닿지 않았다
- 허용목록 검증·경고도 건너뛰었다

→ `resolveTaskModel` 을 export 해 **모델 해석만 공유**한다.

| env | 실효 모델 |
|---|---|
| `claude-sonnet-5` | `claude-sonnet-5` ✅ |
| 미설정 | `claude-haiku-4-5` ✅ 기본 보존 |
| `gpt-4`(허용목록 밖) | `claude-haiku-4-5` ✅ 폴백+경고 |

**CLAUDE.md 의 규칙이 거짓이었다** — *"추천 라우트는 전부 `createForTask('suggestion')`"* 인데 `suggest-preferences` 는 팩토리를 안 거친다. **"모델 ID를 어디에도 하드코딩하지 말 것"** 으로 재작성했다.

## ② `USER_SIGNED_UP` 발행처가 0곳이었다

`src/types/events.ts` 에 정의만 되고 아무도 발행하지 않았다. 계정 **삭제**는 `USER_DELETED` 로 감사 로그에 남는데 **생성**은 안 남고 있었다 — 비대칭이다.

→ 가입 라우트에서 emit. 테스트 2건(발행 확인 + 킬스위치 시 미발행). **뮤테이션**: emit 을 지우면 그 1건만 실패.

## ③ `system-spec` 절 포인터 오류 + 검사 신설 (8종 → 9종)

CLAUDE.md 가 AI 타임아웃 규칙을 `§4.3` 으로 가리켰는데 **§4.3 은 CSP 규칙**이었다(실제 §3.3). 링크는 유효해 ③이, 행이 아니라 절이라 ⑦이 — **어느 검사에도 안 걸렸다.**

> ⚠️ **첫 구현은 뮤테이션에 안 걸렸다.** 번호 존재만 보니 `§4.3` 은 실재하므로 통과했다 — **오늘의 그 버그를 못 잡는 검사**였다.
> 그래서 **제목 힌트 검증**을 추가했다: `system-spec §3.3 (AI 호출 타임아웃)`. 번호만 바꾸면 실제 제목(`CSP는 site·preview 라우트가…`)을 들이대며 실패한다. 뮤테이션 2종으로 확인.

## ④ 불변조건 주석이 방어 수단을 잘못 지목했다

토큰 주석이 *"선점 음성대조 테스트가 **유일한 방어**"* 라 했지만, 그 테스트가 지키는 것은 **토큰 비교**이지 **배치 규칙**(증가~`try` 사이 `await`·조기 return 금지)이 아니다. 증가 직후에 조기 return 을 끼우는 변경은 **그 테스트를 통과하면서** 고착을 되살린다.

또 *"다음 줄이 `setTrue` 이고 **그 직후가** `try`"* 라는 문자 규정이 **3곳 중 2곳에서 이미 위반**돼 있었다(동기 `setState` 2줄이 사이에 있다 — 실질은 지켜진다).

→ 실제 요건으로 고치고 **"이 배치 규칙은 어떤 테스트도 지키지 않는다 — 리뷰로만 지켜진다"** 를 명시했다.

## ⑤ 검사 ⑦의 범위 한계 명시 (코드 변경 없음)

⑦의 **동기가 된** WBS 행 드리프트(`625·745행`)는 **파일명이 같은 줄에 없는 산문 참조**라 ⑦이 구조적으로 못 잡는다.

*"가장 가까운 파일 언급과 묶는"* 휴리스틱은 오탐을 만들어 검사 신뢰를 깎으므로 **넣지 않고 한계를 주석에 적었다.** — 오늘 내 검사기가 **7번** 틀린 것이 정확히 그런 휴리스틱이었다.

## 게이트

```
docs:check 9/9 · lint 0 errors · type-check clean
test 197파일 2,521 · build · E2E 43/43
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)