### PR TITLE
ci: docs:check 를 PR 에서는 차단하게 한다 (main push 는 그대로 비차단)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,15 +40,22 @@ jobs:
   # 문서 정합성 — 트리거·경로·명령어는 테스트도 lint도 안 잡는 유일한 문서 요소다.
   # 실제로 죽어 있던 것이 2건 나왔다(ENV_VAR_DENYLIST · isNotFound).
   #
-  # ⚠️ needs 체인에 넣지 않는다(독립 잡). 또 최소 1주기는 continue-on-error로 둔다.
-  # 이유: 이 레포는 main에 브랜치 보호가 없고 Railway가 Wait for CI를 쓴다 —
-  # 문서 결함이 워크플로를 red로 만들면 **다음 코드 배포가 SKIPPED**되고,
-  # SKIPPED는 CI를 다시 green으로 만들어도 되살아나지 않는다.
-  # 관측 1주기 후 continue-on-error를 떼는 것은 별도 판단으로 한다.
+  # ⚠️ needs 체인에 넣지 않는다(독립 잡).
+  #
+  # **PR 에서는 차단하고, main push 에서는 차단하지 않는다.**
+  #   · main push 를 red 로 만들면 Railway 의 Wait for CI 가 **다음 코드 배포를 SKIPPED** 로
+  #     만들고, SKIPPED 는 CI 를 다시 green 으로 만들어도 되살아나지 않는다.
+  #     (main 에 브랜치 보호가 없어 이 경로가 실재한다 — 2026-08-07 실측: protection 404)
+  #   · 반면 **Railway 는 PR 런을 보지 않는다**(배포 대상 브랜치의 체크만 본다).
+  #     따라서 PR 에서 차단해도 배포 위험이 없고, **머지 전에 실제로 막힌다.**
+  #
+  # 2026-08-07 이전에는 무조건 `true` 였다. 그 결과 ⑥ 총량 예산·⑦ 행 참조·⑧ 절 포인터
+  # 위반이 전부 "보이지만 아무것도 막지 않는" 자문 층에 있었다 —
+  # 오너가 지적한 "계속되는 실수"의 구조가 정확히 그것이었다.
   docs-integrity:
     name: Docs Integrity
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## 문제 — 게이트가 자문 층에 있었다

`docs-integrity` 잡이 `continue-on-error: true` 로 **무조건** 비차단이었다. 그 결과 ⑥ 총량 예산 · ⑦ 행 참조 · ⑧ 절 포인터 위반이 전부 **"보이지만 아무것도 막지 않는"** 상태였다.

> 오너가 지적한 *"계속되는 실수"* 의 구조가 정확히 이것이다 — Anthropic 문서의 *"Hooks enforce, CLAUDE.md advises"* 에서 **advises 쪽**이다.

## 왜 그동안 무조건 비차단이었나 (근거는 유효하다)

- `main` 에 **브랜치 보호가 없다** — 2026-08-07 실측: `GET /branches/main/protection` → **404**
- Railway 가 Wait for CI 를 쓴다
- → 문서 결함이 main push 워크플로를 red 로 만들면 **다음 코드 배포가 `SKIPPED`** 되고, **`SKIPPED` 는 CI 를 다시 green 으로 만들어도 되살아나지 않는다**

## 분리 지점 — Railway 는 PR 런을 보지 않는다

배포 대상 브랜치(main)의 체크만 본다. 그래서 이벤트별로 가르면 **둘 다** 얻는다:

```yaml
continue-on-error: ${{ github.event_name != 'pull_request' }}
```

| 이벤트 | 값 | 효과 |
|---|---|---|
| `pull_request` | `false` | **문서 위반이 PR 을 막는다** — 머지 전에 걸린다 |
| `push`(main) | `true` | 워크플로 red 없음 → **배포 `SKIPPED` 위험 없음** |

같은 워크플로의 `e2e` 잡이 이미 `if: github.event_name == 'pull_request'` 를 쓰고 있어 이벤트 분기 선례가 있다.

## 남는 구멍 (부풀리지 않고 명시)

**main 에 직접 푸시하거나 PR 없이 머지하면 이 게이트는 적용되지 않는다.** 브랜치 보호가 없는 한 그 경로는 열려 있고, 그건 오너 판단 사항이다.

## 검증

이 PR 자체가 첫 시험대다 — `pull_request` 이벤트이므로 `docs-integrity` 가 **차단 모드로** 돈다. 로컬 `pnpm docs:check` 는 통과(8/8, 이 브랜치는 ⑧ 이전).

🤖 Generated with [Claude Code](https://claude.com/claude-code)