### PR TITLE
fix: 예산 게이트 경화 — 단일 출처화 + 경로 정규화 우회 차단

### DIFF
--- a/scripts/checkDocIntegrity.ts
+++ b/scripts/checkDocIntegrity.ts
@@ -295,21 +295,29 @@ if (fs.existsSync(RULES_DIR)) {
 //
 // 예산을 올리려면 **왜 올려야 하는지를 이 주석에 적고** 올려라. 숫자만 바꾸면
 // 다음 사람이 같은 이유로 또 올리고, 1년 뒤 다시 449줄이 된다.
-const BUDGETS: { file: string; maxLines: number; why: string }[] = [
-  { file: 'CLAUDE.md', maxLines: 220, why: '목표 200줄 + 통상 편집 여유 10%' },
-  { file: 'AGENTS.md', maxLines: 80, why: '포인터 전용 — 규칙 본문 금지' },
-];
+// ⚠️ 값은 **`scripts/doc-budgets.json` 단일 출처**다. 여기에 숫자를 다시 적지 말 것 —
+// 훅(`scripts/hooks/guardAlwaysLoadedBudget.mjs`)과 그 테스트도 같은 파일을 읽는다.
+// 세 곳에 하드코딩돼 있던 것을 2026-08-07에 합쳤다(한쪽만 올리면 훅과 CI가 다른 말을 한다).
+type DocBudgets = {
+  alwaysLoaded: Record<string, number>;
+  currentTenseDirs: string[];
+  currentTenseMaxLines: number;
+  _rationale: Record<string, string>;
+};
+const budgets = JSON.parse(
+  fs.readFileSync(path.join(ROOT, 'scripts/doc-budgets.json'), 'utf8'),
+) as DocBudgets;
 
-for (const b of BUDGETS) {
-  const p = path.join(ROOT, b.file);
+for (const [file, maxLines] of Object.entries(budgets.alwaysLoaded)) {
+  const p = path.join(ROOT, file);
   if (!fs.existsSync(p)) continue;
   const n = fs.readFileSync(p, 'utf8').split(/\r?\n/).length;
-  if (n > b.maxLines) {
+  if (n > maxLines) {
     add(
       '⑥ 항상 로드 예산',
-      `${b.file}:${n}`,
-      `${n}줄 > 예산 ${b.maxLines}줄 (${b.why}). ` +
-        `줄이거나, 예산을 올려야 할 근거를 scripts/checkDocIntegrity.ts의 BUDGETS 주석에 적고 올릴 것`,
+      `${file}:${n}`,
+      `${n}줄 > 예산 ${maxLines}줄 (${budgets._rationale[file] ?? ''}). ` +
+        `줄이거나, 예산을 올려야 할 근거를 scripts/doc-budgets.json의 _rationale에 적고 올릴 것`,
     );
   }
 }
@@ -329,8 +337,8 @@ for (const b of BUDGETS) {
 // 여기서 지키는 것은 "지금도 참이어야 하는" 현재 시제 문서군뿐이다.
 //
 // 예산을 올리려면 **왜 올리는지를 여기 적고** 올릴 것. 숫자만 바꾸면 다시 불어난다.
-const CURRENT_TENSE_DIRS = ['docs/guides', 'docs/architecture', 'docs/reference', 'docs/security'];
-const CURRENT_TENSE_BUDGET = 6500; // 2026-08-07 축소 직후 5,928줄 + 약 10% 여유
+const CURRENT_TENSE_DIRS = budgets.currentTenseDirs;
+const CURRENT_TENSE_BUDGET = budgets.currentTenseMaxLines;
 
 const currentTenseFiles = allMd.filter((f) =>
   CURRENT_TENSE_DIRS.some((d) => rel(f).startsWith(`${d}/`)),

--- a/scripts/doc-budgets.json
+++ b/scripts/doc-budgets.json
@@ -1,0 +1,34 @@
+{
+  "_why": [
+    "문서 총량 예산의 **단일 출처**. 이 값은 세 곳이 읽는다 —",
+    "  scripts/checkDocIntegrity.ts (CI 가시화) ·",
+    "  scripts/hooks/guardAlwaysLoadedBudget.mjs (PreToolUse 실차단) ·",
+    "  src/__tests__/hooks/guardAlwaysLoadedBudget.test.ts (그 훅의 회귀 테스트).",
+    "",
+    "2026-08-07 이전에는 같은 숫자가 그 세 파일에 **각각 하드코딩**돼 있었고 동기화를",
+    "강제하는 것이 없었다. 한쪽만 올리면 훅과 CI 가 조용히 다른 말을 한다 —",
+    "CLAUDE.md 의 '두 곳에 적히는 순간 한쪽이 썩는다'가 그 게이트 자신에게 적용된 셈이었다.",
+    "",
+    "예산을 올릴 때는 **여기만** 고치고, 왜 올리는지를 _rationale 에 남길 것.",
+    "숫자만 바꾸면 다음 사람이 같은 이유로 또 올리고, 결국 다시 449줄이 된다."
+  ],
+
+  "alwaysLoaded": {
+    "CLAUDE.md": 220,
+    "AGENTS.md": 80
+  },
+
+  "currentTenseDirs": [
+    "docs/guides",
+    "docs/architecture",
+    "docs/reference",
+    "docs/security"
+  ],
+  "currentTenseMaxLines": 6500,
+
+  "_rationale": {
+    "CLAUDE.md": "목표 200줄(Anthropic 권고) + 통상 편집 여유 10%. 2026-08-07에 449줄에서 축소.",
+    "AGENTS.md": "포인터 전용 — 규칙 본문 금지.",
+    "currentTenseMaxLines": "2026-08-07 축소 직후 5,928줄 + 약 10% 여유. docs/decisions 는 대상이 아니다(ADR 은 사고 기록이고 append-only 로 자라는 것이 정상)."
+  }
+}

--- a/scripts/hooks/guardAlwaysLoadedBudget.mjs
+++ b/scripts/hooks/guardAlwaysLoadedBudget.mjs
@@ -21,11 +21,21 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-/** scripts/checkDocIntegrity.ts 의 BUDGETS 와 **같은 값을 유지할 것.** 어긋나면 CI와 훅이 다른 말을 한다. */
-const BUDGETS = {
-  'CLAUDE.md': 220,
-  'AGENTS.md': 80,
-};
+/**
+ * 예산은 **`scripts/doc-budgets.json` 단일 출처**에서 읽는다.
+ * 2026-08-07 이전에는 여기·`checkDocIntegrity.ts`·훅 테스트 **세 곳에 하드코딩**돼 있었고
+ * 동기화를 강제하는 것이 없었다 — 한쪽만 올리면 훅과 CI가 조용히 다른 말을 한다.
+ *
+ * 읽기 실패는 **fail-open**이다(훅 고장이 작업을 막으면 안 된다). 그 경우 CI의 ⑥이 잡는다.
+ */
+const BUDGETS = (() => {
+  try {
+    const p = path.resolve(import.meta.dirname, '..', 'doc-budgets.json');
+    return JSON.parse(fs.readFileSync(p, 'utf8')).alwaysLoaded ?? {};
+  } catch {
+    return {};
+  }
+})();
 
 const countLines = (s) => s.split(/\r?\n/).length;
 

--- a/scripts/hooks/guardAlwaysLoadedBudget.mjs
+++ b/scripts/hooks/guardAlwaysLoadedBudget.mjs
@@ -89,11 +89,18 @@ if (budget === undefined) allow();
 // (MSYS 형식)를 주는데 Windows Node의 `path.resolve`는 그걸 현재 드라이브 기준으로 해석해
 // `F:\f\DEVELOPMENT\...` 로 만든다. 그래서 단순 문자열 비교는 **항상 불일치 → 항상 통과**했다.
 // 시험하지 않았으면 아무것도 막지 못하는 훅을 배선할 뻔했다.
-/** `F:\a\b` · `f:/a/b` · `/f/a/b` 를 전부 `f:/a/b` 로 정규화한다(Windows FS는 대소문자 무시). */
+/**
+ * `F:\a\b` · `f:/a/b` · `/f/a/b` 를 전부 `f:/a/b` 로 정규화한다(Windows FS는 대소문자 무시).
+ *
+ * ⚠️ **`path.posix.normalize` 가 필수다.** 없으면 `./` · `../` · 중복 슬래시가 전부 훅을
+ * 통과한다 — 2026-08-07 실측: `<root>/docs/../AGENTS.md` 로 300줄 Write 가 ALLOW 됐다.
+ * 실수로 발생할 형태는 아니지만, **강제 게이트에 뚫린 구멍은 게이트가 아니다.**
+ */
 function canonical(p) {
   let s = String(p).replace(/\\/g, '/');
   const msys = /^\/([A-Za-z])\/(.*)$/.exec(s); // /f/DEVELOPMENT/... → f:/DEVELOPMENT/...
   if (msys) s = `${msys[1]}:/${msys[2]}`;
+  s = path.posix.normalize(s); // ./ · ../ · // 를 접는다
   return s.replace(/^([A-Za-z]):/, (_, d) => `${d.toLowerCase()}:`).toLowerCase().replace(/\/+$/, '');
 }
 

--- a/src/__tests__/hooks/guardAlwaysLoadedBudget.test.ts
+++ b/src/__tests__/hooks/guardAlwaysLoadedBudget.test.ts
@@ -15,8 +15,15 @@ import path from 'node:path';
 const ROOT = process.cwd();
 const HOOK = path.join(ROOT, 'scripts/hooks/guardAlwaysLoadedBudget.mjs');
 
-/** scripts/hooks/guardAlwaysLoadedBudget.mjs 의 BUDGETS 와 같아야 한다 */
-const BUDGET = { 'CLAUDE.md': 220, 'AGENTS.md': 80 } as const;
+/**
+ * 예산은 **`scripts/doc-budgets.json` 단일 출처**에서 읽는다 — 훅·CI 검사기와 같은 파일이다.
+ * 여기에 숫자를 다시 적으면 그 순간 네 번째 사본이 된다.
+ */
+const BUDGET = (
+  JSON.parse(fs.readFileSync(path.join(ROOT, 'scripts/doc-budgets.json'), 'utf8')) as {
+    alwaysLoaded: Record<string, number>;
+  }
+).alwaysLoaded;
 
 type Decision = 'allow' | 'deny';
 
@@ -44,7 +51,7 @@ const write = (filePath: string, content: string) => ({
 });
 
 describe('guardAlwaysLoadedBudget — 예산 초과 차단', () => {
-  // AGENTS.md 를 기준 파일로 쓴다: 예산(80) 이내(현행 ~57줄)라 "초과로 만드는 편집"을
+  // AGENTS.md 를 기준 파일로 쓴다: 예산 이내(포인터 전용이라 여유가 크다)라 "초과로 만드는 편집"을
   // 그대로 시험할 수 있다. CLAUDE.md 는 축소 작업 중 일시적으로 예산을 넘을 수 있어
   // 기준으로 삼으면 테스트가 저장소 상태에 의존하게 된다.
   const agents = path.join(ROOT, 'AGENTS.md');

--- a/src/__tests__/hooks/guardAlwaysLoadedBudget.test.ts
+++ b/src/__tests__/hooks/guardAlwaysLoadedBudget.test.ts
@@ -92,6 +92,17 @@ describe('guardAlwaysLoadedBudget — 예산 초과 차단', () => {
     expect(runHook(write(msys, linesOf(300))).decision).toBe('deny');
   });
 
+  // ⚠️ 2026-08-07 실측: 정규화가 없던 시절 `<root>/docs/../AGENTS.md` 로 300줄 Write 가
+  // **ALLOW** 됐다. 실수로 나올 형태는 아니지만 **강제 게이트에 뚫린 구멍은 게이트가 아니다.**
+  it.each([
+    ['./ 를 포함한 경로', (p: string) => p.replace(/([^/\\]+)$/, './$1')],
+    ['../ 로 우회하는 경로', (p: string) => p.replace(/([^/\\]+)$/, 'docs/../$1')],
+    ['중복 슬래시', (p: string) => p.replace(/([^/\\]+)$/, '/$1')],
+  ])('%s 도 정규화해서 차단한다', (_name, mangle) => {
+    const agentsPath = path.join(ROOT, 'AGENTS.md').split(path.sep).join('/');
+    expect(runHook(write(mangle(agentsPath), linesOf(300))).decision).toBe('deny');
+  });
+
   it('드라이브 문자 대소문자가 달라도 차단한다', () => {
     const upper = agents.replace(/^([a-z]):/, (_, d: string) => `${d.toUpperCase()}:`);
     const lower = agents.replace(/^([A-Z]):/, (_, d: string) => `${d.toLowerCase()}:`);


### PR DESCRIPTION
적대적 재검증이 올린 **게이트 자체의 결함 2건**을 닫는다. 둘 다 *"게이트를 만들었다"* 는 보고를 거짓으로 만들 수 있던 것이다.

---

## ① 예산 상수가 3곳에 복제돼 있었다

`CLAUDE.md` 220 · `AGENTS.md` 80 · 현재시제 6500 이 세 파일에 **각각 하드코딩**돼 있었고 동기화를 강제하는 것이 없었다:

| 파일 | 역할 |
|---|---|
| `scripts/checkDocIntegrity.ts` | CI 가시화 (⑥·⑥-b) |
| `scripts/hooks/guardAlwaysLoadedBudget.mjs` | **PreToolUse 실차단** |
| `src/__tests__/hooks/guardAlwaysLoadedBudget.test.ts` | 그 훅의 회귀 테스트 |

한쪽만 올리면 **훅과 CI 가 조용히 다른 말을 한다.** 예산을 올리는 사람은 대개 막힌 곳(훅)만 고친다.

> `CLAUDE.md` 가 *"두 곳에 적히는 순간 한쪽이 썩는다"* 고 적고 있는데, **그 규칙을 강제하려고 만든 장치 자신이 세 곳에 적혀 있었다.**

→ `scripts/doc-budgets.json` 단일 출처. `_why`·`_rationale` 로 **왜 이 값인지**를 함께 둔다.
훅의 읽기는 **fail-open**(파일이 깨져도 종료 코드 0) — 훅 고장이 작업을 막으면 안 되고, 그 경우는 CI ⑥ 이 잡는다.

**검증**: JSON 만 `220 → 150` 으로 바꿔 세 소비처를 각각 확인 —
① docs:check 가 `206줄 > 예산 150줄` 로 잡음 ② 훅이 새 값을 읽음 ③ 테스트 자동 정합. 원복 후 9/9.
세 소비처의 예산 숫자 하드코딩 **0건**(주석 포함).

---

## ② 경로 정규화 누락으로 게이트가 우회됐다

정규화 없이 문자열 비교만 해서 아래가 전부 **ALLOW** 됐다 (2026-08-07 실측):

```
<root>/./AGENTS.md          300줄 Write → ALLOW
<root>/docs/../AGENTS.md    300줄 Write → ALLOW
<root>//AGENTS.md           300줄 Write → ALLOW
정상 경로                    300줄 Write → DENY
```

실수로 나올 형태는 아니지만 **강제 게이트에 뚫린 구멍은 게이트가 아니다.**

→ `canonical()` 에 `path.posix.normalize` 추가. MSYS(`/f/...`) → 드라이브 형식 변환 **뒤에** 접어야 `../` 가 드라이브 경계를 넘지 않는다.

**검증(양방향)**: 회귀 테스트 3건(`it.each`) 추가. `normalize` 를 제거하면 **정확히 그 3건**이 실패하고 15건은 통과한다. 오탐 대조 유지 — `docs/README.md`(대상 아님) · `docs/AGENTS.md`(하위 동명) 는 ALLOW.

---

## 게이트

```
docs:check 9/9 · lint 0 errors · type-check clean
test 197파일 2,528 · build · E2E 43/43
```

## 발견 경로

적대적 재검증의 「경미」 지적 2건. **실제로 우회되는지 프로브로 확인한 뒤** 수정했다 — 지적을 그대로 믿지도, 그대로 버리지도 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)