### PR TITLE
fix: 다섯 번째 구멍 — 경로 판정을 문자열에서 파일시스템 신원으로

### DIFF
--- a/scripts/hooks/budgetPath.mjs
+++ b/scripts/hooks/budgetPath.mjs
@@ -1,73 +1,169 @@
 // scripts/hooks/budgetPath.mjs
 //
-// **예산 훅의 경로 판정 로직 — 순수 함수로 분리했다.**
+// **예산 훅의 대상 판정 — 순수 함수. 파일시스템을 주입받는다.**
 //
-// 왜 분리했나: 훅 본체는 stdin 을 읽고 `process.exit` 하는 실행 스크립트라
-// 서브프로세스로만 시험할 수 있고, 그러면 **판정이 실행 플랫폼의 파일시스템에 묶인다.**
-// 2026-08-08 감사가 그 결과를 실측했다 — 파일명 대소문자 회귀 테스트 3건이
-// **Linux CI(전 잡 `ubuntu-latest`)에서는 수정 전 훅으로도 그대로 통과**했다.
-// 대소문자 구분 FS 에서는 기대값이 `allow` 인데 수정 전 훅도 `allow` 를 주기 때문이다.
-// 즉 **수정을 통째로 지워도 CI 는 초록이었다.**
+// ## 왜 문자열 정규화만으로는 안 되나 (2026-08-08)
 //
-// 여기 있는 함수들은 파일시스템을 **주입받으므로**, 두 가지 FS 의미론을 전부
-// 어느 플랫폼에서나 시험할 수 있다. 그것이 이 파일의 존재 이유다.
-import path from 'node:path';
+// 이 훅은 "편집 대상이 저장소 루트의 CLAUDE.md·AGENTS.md 인가" 를 판정한다.
+// 그 판정을 **경로 문자열 정규화**로만 하다가 **다섯 번 뚫렸다.** 매번 "이제 막힌다"고
+// 선언한 직후에 다음 표기법이 나왔다:
+//
+//   1. 경로 형식        MSYS `/f/…` vs `F:\…`                      (#294)
+//   2. 상대 요소        `./` · `../` · `//`                        (#304)
+//   3. 파일명 대소문자  `claude.md`                                (#306)
+//   4. 확장길이·UNC     `\\?\F:\…` · `\\localhost\F$\…` · `//./…`  (#307)
+//   5. 볼륨 GUID        `\\?\Volume{…}\…`                          (이 파일)
+//
+// 다섯 번 다 같은 구조적 이유다 — **정규화는 "아는 표기법"의 거부목록**이고,
+// Windows 는 같은 파일을 가리키는 표기법이 계속 나온다. 여섯 번째가 없다고 믿을 근거가 없다.
+//
+// ## 그래서 층을 쌓는다 — 셋이 서로 다른 것을 잡는다 (2026-08-08 실측)
+//
+//   표기                    ino/dev   realpath 문자열              문자열 정규화
+//   정상 드라이브            동일      F:\…            일치          일치
+//   볼륨 GUID               동일      F:\…            일치          ✗ (몰랐던 표기)
+//   UNC 관리공유            동일      \\localhost\F$\… **불일치**    일치
+//   MSYS `/f/…`             ENOENT    ENOENT                        일치
+//   통제군(다른 파일)        다름      다름                          다름
+//
+// 즉 **ino 는 UNC 를 잡지만 realpath 문자열은 못 잡고, 둘 다 MSYS 는 못 잡는다.**
+// 하나만 쓰면 반드시 구멍이 남는다. 셋 중 **하나라도 같다고 하면 같은 파일**로 본다 —
+// 차단 게이트에서 안전한 방향은 "더 많이 막는 쪽"이고, 오탐은 통제군 테스트가 지킨다.
 
 /**
- * `F:\a\b` · `f:/a/b` · `/f/a/b` · `\\?\F:\a\b` · `//localhost/F$/a/b` 를
- * 전부 `f:/a/b` 로 접는다.
+ * 경로를 디렉터리/파일명으로 쪼갠다. 구분자 혼용을 허용하고 플랫폼에 의존하지 않는다.
  *
- * ⚠️ **세 번 뚫린 자리다. 여기를 고칠 때는 회귀 테스트를 먼저 늘려라.**
- *  1. 경로 형식(MSYS `/f/…` vs `F:\…`) — 훅 최초 구현이 아무것도 막지 못했다
- *  2. `./` · `../` · `//` — `path.posix.normalize` 누락 (#304)
- *  3. Windows 확장길이·디바이스·UNC 접두사 — 아래 (2026-08-08)
+ * ⚠️ **원본 구분자를 보존한다.** `dir` 을 다시 파일시스템에 넘기기 때문이다 —
+ * Windows 의 `\\?\` 확장길이 경로는 **정규화를 우회해 백슬래시만 받으므로**,
+ * `/` 로 바꿔서 넘기면 realpath 가 실패한다(2026-08-08 테스트가 이걸 잡았다).
+ */
+function splitTail(p) {
+  const s = String(p);
+  const i = Math.max(s.lastIndexOf('/'), s.lastIndexOf('\\'));
+  if (i === -1) return { dir: '.', base: s };
+  return { dir: s.slice(0, i) || s.slice(i, i + 1), base: s.slice(i + 1) };
+}
+
+/** 후행 슬래시를 **정규식 없이** 잘라낸다(`/\/+$/` 는 슬래시가 많은 입력에서 백트래킹한다). */
+function trimTrailingSlash(s) {
+  let end = s.length;
+  while (end > 0 && s[end - 1] === '/') end -= 1;
+  return s.slice(0, end);
+}
+
+/** 상대 요소(`.` · `..`)와 중복 슬래시를 접는다. `path.posix.normalize` 의 최소 대체물. */
+function collapse(s) {
+  const abs = s.startsWith('/');
+  const out = [];
+  for (const seg of s.split('/')) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') {
+      if (out.length > 0 && out[out.length - 1] !== '..') out.pop();
+      else if (!abs) out.push('..');
+      continue;
+    }
+    out.push(seg);
+  }
+  return (abs ? '/' : '') + out.join('/');
+}
+
+/**
+ * 문자열 층 — `F:\a\b` · `f:/a/b` · `/f/a/b` · `\\?\F:\a\b` · `//host/F$/a/b` 를 `f:/a/b` 로 접는다.
  *
- * 3번은 실제 Edit 도구로 종단 실증됐다: `\\?\F:\…\AGENTS.md` 로 편집하면 훅이
- * 통과시키고 **진짜 AGENTS.md 가 94줄(예산 80)이 됐다.** 같은 편집을 정상 경로로
- * 하면 차단된다. Node 와 Write/Edit 도구가 이 표기를 그대로 받아 같은 파일에 쓰기 때문이다.
+ * ⚠️ **이것만으로는 부족하다.** 이 함수는 아는 표기법만 접는 **거부목록**이고 다섯 번 뚫렸다.
+ * `isSameFile` 의 **마지막 층**으로만 쓴다 — 파일시스템이 해석하지 못하는 표기(MSYS `/f/…`)를 담당한다.
  */
 export function canonical(p) {
-  let s = String(p).replace(/\\/g, '/');
+  let s = String(p).replaceAll('\\', '/');
 
-  // 확장길이(`\\?\`)·디바이스(`\\.\`) 접두사를 벗긴다. 벗기면 `F:/…` 또는 `UNC/host/share/…` 가 남는다.
+  // 확장길이(`\\?\`)·디바이스(`\\.\`) 접두사를 벗긴다 → `F:/…` 또는 `UNC/host/share/…` 가 남는다.
   const device = /^\/\/[?.]\//.exec(s);
   if (device) {
     s = s.slice(device[0].length);
     s = s.replace(/^UNC\//i, '//'); // `\\?\UNC\host\share\…` → `//host/share/…`
   }
-
   // 관리 공유 `//host/F$/…` 는 `F:/…` 와 **같은 파일**이다.
   s = s.replace(/^\/\/[^/]+\/([A-Za-z])\$\//, '$1:/');
-
-  const msys = /^\/([A-Za-z])\/(.*)$/.exec(s); // /f/DEVELOPMENT/… → f:/DEVELOPMENT/…
+  // MSYS(Git Bash) `/f/…` → `f:/…`  ← 파일시스템이 해석하지 못하는 유일한 축이다
+  const msys = /^\/([A-Za-z])\/(.*)$/.exec(s);
   if (msys) s = `${msys[1]}:/${msys[2]}`;
 
-  s = path.posix.normalize(s); // ./ · ../ · // 를 접는다
-  return s
-    .replace(/^([A-Za-z]):/, (_, d) => `${d.toLowerCase()}:`)
-    .toLowerCase()
-    .replace(/\/+$/, '');
+  s = collapse(s);
+  return trimTrailingSlash(s.replace(/^([A-Za-z]):/, (_, d) => `${d.toLowerCase()}:`).toLowerCase());
+}
+
+/** realpath 결과 비교용 — 구분자와 대소문자만 맞춘다. */
+const normReal = (p) => trimTrailingSlash(String(p).replaceAll('\\', '/').toLowerCase());
+
+/** `{ ino, dev }` 를 문자열 키로. 둘 중 하나라도 0/undefined 면 신뢰하지 않는다(일부 FS 는 0을 준다). */
+function identityKey(st) {
+  if (!st) return null;
+  const ino = String(st.ino ?? '');
+  const dev = String(st.dev ?? '');
+  if (!ino || ino === '0' || !dev) return null;
+  return `${ino}/${dev}`;
+}
+
+const attempt = (fn) => {
+  try {
+    return fn();
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * 두 경로가 **같은 파일**을 가리키는가. 위 표를 근거로 세 층을 겹친다.
+ *
+ * @param {string} inputPath  편집 대상 경로 (어떤 표기법이든)
+ * @param {string} targetPath 예산이 걸린 실제 파일 경로
+ * @param {{ stat?: (p: string) => unknown, realpath?: (p: string) => string }} fsProbe
+ *        `fs.statSync` · `fs.realpathSync.native` 를 주입한다. **주입하는 이유는 테스트다** —
+ *        실제 파일시스템에 의존하면 판정이 실행 플랫폼에 묶여 CI 가 눈이 먼다(#307 에서 실제로 그랬다).
+ * @returns {boolean} 같은 파일이면 true. **판정할 수 없으면 false**(호출부가 fail-open 한다).
+ */
+export function isSameFile(inputPath, targetPath, fsProbe) {
+  // ① 파일시스템 신원 — 표기법과 무관하다. 볼륨 GUID·UNC 를 전부 잡는다.
+  if (fsProbe.stat) {
+    const a = identityKey(attempt(() => fsProbe.stat(inputPath)));
+    const b = identityKey(attempt(() => fsProbe.stat(targetPath)));
+    if (a !== null && a === b) return true;
+  }
+
+  // ② realpath 문자열 — ino 를 믿을 수 없는 파일시스템 대비.
+  if (fsProbe.realpath) {
+    const ra = attempt(() => fsProbe.realpath(inputPath));
+    const rb = attempt(() => fsProbe.realpath(targetPath));
+    if (ra && rb && normReal(ra) === normReal(rb)) return true;
+
+    // ②-b 대상이 아직 없을 수 있다(신규 Write). 부모 디렉터리 신원 + 파일명으로 본다.
+    if (!ra || !rb) {
+      const x = splitTail(inputPath);
+      const y = splitTail(targetPath);
+      if (x.base.toLowerCase() === y.base.toLowerCase()) {
+        const da = attempt(() => fsProbe.realpath(x.dir));
+        const db = attempt(() => fsProbe.realpath(y.dir));
+        if (da && db && normReal(da) === normReal(db)) return true;
+      }
+    }
+  }
+
+  // ③ 문자열 정규화 — 파일시스템이 **해석하지 못하는** 표기(MSYS `/f/…`) 전용 마지막 층.
+  return canonical(inputPath) === canonical(targetPath);
 }
 
 /**
- * 편집 대상이 예산 대상 파일인지 판정하고, 맞으면 **정규 이름**(BUDGETS 의 키)을 돌려준다.
+ * 편집 대상이 예산 대상인지 판정하고, 맞으면 **정규 이름**(BUDGETS 의 키)을 돌려준다.
  *
  * 대소문자 조회는 무시하되, **정말 같은 파일인지는 파일시스템에 물어본다** —
  * Windows·macOS 는 `claude.md` 가 CLAUDE.md 와 같은 파일이지만 Linux 는 **다른 파일**이고
  * 그때 막으면 오탐이다.
- *
- * @param {string} rawBase   편집 대상의 basename (원문 대소문자 그대로)
- * @param {string[]} budgetKeys 예산이 걸린 정규 파일명 목록
- * @param {{ listDir: () => string[], exists: (name: string) => boolean }} fsProbe
- *        저장소 루트의 실제 엔트리 목록과 존재 여부. **주입받는 이유는 테스트다** — 위 주석 참조.
- * @returns {string | null} 예산 대상이면 정규 이름, 아니면 null
  */
 export function resolveBudgetName(rawBase, budgetKeys, fsProbe) {
   const match = budgetKeys.find((k) => k.toLowerCase() === String(rawBase).toLowerCase());
   if (match === undefined) return null;
   if (rawBase === match) return match;
 
-  // 대소문자가 다르다 — 같은 파일인가?
   let entries;
   try {
     entries = fsProbe.listDir();
@@ -78,4 +174,9 @@ export function resolveBudgetName(rawBase, budgetKeys, fsProbe) {
   if (entries.includes(rawBase)) return null;
   // 엔트리에 없는데 존재한다면 대소문자 무시 FS → **같은 파일**이다
   return fsProbe.exists(rawBase) ? match : null;
+}
+
+/** 편집 대상의 파일명만 뽑는다(구분자 혼용·표기법 무관). */
+export function baseNameOf(p) {
+  return splitTail(p).base;
 }

--- a/scripts/hooks/guardAlwaysLoadedBudget.mjs
+++ b/scripts/hooks/guardAlwaysLoadedBudget.mjs
@@ -20,7 +20,7 @@
 // 차단은 stdout의 JSON `permissionDecision: "deny"` 로만 표현한다.
 import fs from 'node:fs';
 import path from 'node:path';
-import { canonical, resolveBudgetName } from './budgetPath.mjs';
+import { isSameFile, resolveBudgetName, baseNameOf } from './budgetPath.mjs';
 
 /**
  * 예산은 **`scripts/doc-budgets.json` 단일 출처**에서 읽는다.
@@ -83,7 +83,9 @@ const input = payload?.tool_input ?? payload?.toolInput ?? {};
 const filePath = input.file_path ?? input.filePath;
 if (!filePath) allow();
 
-const rawBase = path.basename(String(filePath));
+// ⚠️ `path.basename` 을 쓰지 않는다 — Windows 표기법(`\\?\Volume{…}\`)에서 플랫폼별로
+// 결과가 갈린다. 구분자만 보고 자르는 `baseNameOf` 로 통일한다.
+const rawBase = baseNameOf(String(filePath));
 
 // ⚠️ 예산 조회는 **대소문자를 무시해야 한다.**
 //
@@ -105,10 +107,21 @@ if (base === null) allow();
 
 const budget = BUDGETS[base];
 
-// 저장소 루트의 그 파일인지 확인 — 하위 디렉터리의 동명 파일은 대상이 아니다.
-if (canonical(String(filePath)) !== `${canonical(ROOT)}/${base.toLowerCase()}`) allow();
+const real = path.join(ROOT, base);
 
-const real = path.join(ROOT, base); // 읽기는 항상 저장소 루트 기준으로 — 위 비교가 동일성을 보장한다
+// 저장소 루트의 **그 파일**인지 확인 — 하위 디렉터리의 동명 파일은 대상이 아니다.
+//
+// ⚠️ 여기를 문자열 정규화로 하다가 **다섯 번 뚫렸다.** 이제는 표기법을 열거하지 않고
+// **파일시스템에 신원을 묻는다**(`realpath`). 근거·이력은 `budgetPath.mjs` 헤더에 있다.
+if (
+  !isSameFile(String(filePath), real, {
+    stat: (p) => fs.statSync(p),
+    realpath: (p) => fs.realpathSync.native(p),
+  })
+)
+  allow();
+
+// 읽기는 항상 저장소 루트 기준으로 — 위 동일성 확인이 그것을 보장한다
 const before = fs.existsSync(real) ? countLines(fs.readFileSync(real, 'utf8')) : 0;
 
 /** 편집 후 줄 수를 **실제로 계산**한다. 추정하지 않는다. */

--- a/src/__tests__/hooks/budgetPath.test.ts
+++ b/src/__tests__/hooks/budgetPath.test.ts
@@ -1,53 +1,166 @@
-// 예산 훅의 **경로 판정**을 플랫폼 무관하게 검증한다.
+// 예산 훅의 **대상 판정**을 플랫폼 무관하게 검증한다.
 //
 // 왜 이 파일이 따로 있나 (2026-08-08 감사 결과):
 // 형제 파일 `guardAlwaysLoadedBudget.test.ts` 는 훅을 **서브프로세스로** 돌리므로
 // 판정이 실행 플랫폼의 파일시스템에 묶인다. CI 는 전 잡이 `ubuntu-latest`(대소문자 구분)라
-// 파일명 대소문자 회귀 테스트 3건이 거기서는 `allow` 를 기대하는데,
-// **수정 전 훅도 같은 입력에 `allow`** 를 준다 → **수정을 지워도 CI 는 초록이었다.**
-// 개발자 머신(Windows)에서만 참인 초록이었고, G1 이 말하는 "초록색은 증거가 아니다"의 실례다.
+// 파일명 대소문자 회귀 테스트가 거기서는 **수정 전 훅으로도 통과**했다 —
+// 즉 수정을 지워도 CI 는 초록이었다. G1 의 "초록색은 증거가 아니다"의 실례다.
 //
-// 여기서는 파일시스템을 **주입**하므로 두 의미론을 어느 플랫폼에서나 시험한다.
+// 여기서는 파일시스템(`stat` · `realpath` · 디렉터리 목록)을 **주입**하므로
+// Windows 고유 표기법과 두 FS 의미론을 **어느 플랫폼에서나** 시험한다.
 import { describe, it, expect } from 'vitest';
-import { canonical, resolveBudgetName } from '../../../scripts/hooks/budgetPath.mjs';
+import {
+  canonical,
+  isSameFile,
+  resolveBudgetName,
+  baseNameOf,
+} from '../../../scripts/hooks/budgetPath.mjs';
 
 const B = String.fromCharCode(92); // 소스에 백슬래시 리터럴을 두지 않는다(이스케이프 사고 방지)
-const ROOT_FWD = 'f:/DEV/repo';
-const ROOT_WIN = `F:${B}DEV${B}repo`;
+const WIN = `F:${B}DEV${B}repo${B}CLAUDE.md`;
+const GUID = `${B}${B}?${B}Volume{e4fddb3d-d1fc-4f32-9063-dc7fe1038925}${B}DEV${B}repo${B}CLAUDE.md`;
+const UNC = `${B}${B}localhost${B}F$${B}DEV${B}repo${B}CLAUDE.md`;
+const EXTLEN = `${B}${B}?${B}F:${B}DEV${B}repo${B}CLAUDE.md`;
+const MSYS = '/f/DEV/repo/CLAUDE.md';
+const OTHER = `F:${B}DEV${B}repo${B}docs${B}README.md`;
 
-describe('canonical — 같은 파일을 가리키는 표기는 전부 같은 문자열로 접힌다', () => {
+/**
+ * 2026-08-08 실측을 그대로 옮긴 가짜 파일시스템.
+ *   · ino/dev  — 정상·GUID·UNC·확장길이가 전부 **동일**, MSYS 는 해석 불가(throw)
+ *   · realpath — GUID·확장길이는 `F:\…` 로 접히지만 **UNC 는 `\\localhost\F$\…` 로 남는다**
+ * 이 비대칭이 층을 쌓는 이유다. 한 층만으로는 반드시 구멍이 남는다.
+ */
+const SAME = new Set([WIN, GUID, UNC, EXTLEN]);
+const realFs = {
+  stat: (p: string) => {
+    if (SAME.has(p)) return { ino: '25051272927992280', dev: '713254832' };
+    if (p === OTHER) return { ino: '99999999999999999', dev: '713254832' };
+    throw new Error('ENOENT');
+  },
+  realpath: (p: string) => {
+    if (p === WIN || p === GUID || p === EXTLEN) return WIN;
+    if (p === UNC) return `${B}${B}localhost${B}F$${B}DEV${B}repo${B}CLAUDE.md`;
+    if (p === OTHER) return OTHER;
+    throw new Error('ENOENT');
+  },
+};
+
+describe('isSameFile — 다섯 번 뚫린 표기법이 전부 같은 파일로 판정된다', () => {
+  it.each([
+    ['정상 드라이브', WIN],
+    ['볼륨 GUID (#307 이후 남아 있던 다섯 번째 구멍)', GUID],
+    ['UNC 관리공유 (realpath 문자열은 불일치 — ino 층이 잡는다)', UNC],
+    ['확장길이 접두사', EXTLEN],
+    ['MSYS (파일시스템이 해석 못 함 — 문자열 층이 잡는다)', MSYS],
+  ])('%s', (_label, input) => {
+    expect(isSameFile(input, WIN, realFs)).toBe(true);
+  });
+
+  it('다른 파일은 false — 통제군(위 단언이 전부를 같게 만드는 게 아님을 보인다)', () => {
+    expect(isSameFile(OTHER, WIN, realFs)).toBe(false);
+    expect(isSameFile(`F:${B}DEV${B}repo${B}CLAUDE.md.bak`, WIN, realFs)).toBe(false);
+    expect(isSameFile('g:/DEV/repo/CLAUDE.md', WIN, realFs)).toBe(false);
+    expect(isSameFile('//fileserver/public/DEV/repo/CLAUDE.md', WIN, realFs)).toBe(false);
+  });
+
+  // 각 층이 **혼자서는** 부족함을 보인다 — 층을 지우는 리팩터가 조용히 통과하지 못하게 한다.
+  it('ino 층만으로는 MSYS 를 못 잡는다', () => {
+    const inoOnly = { stat: realFs.stat };
+    expect(isSameFile(GUID, WIN, inoOnly)).toBe(true);
+    expect(isSameFile(MSYS, WIN, inoOnly)).toBe(true); // ③ 문자열 층이 받아준다
+  });
+
+  it('realpath 층만으로는 UNC 를 못 잡는다 — 문자열이 다르기 때문', () => {
+    const realOnly = { realpath: realFs.realpath };
+    expect(normalizedRealpathAgree(realOnly, UNC, WIN)).toBe(false); // 층 자체는 실패하고
+    expect(isSameFile(UNC, WIN, realOnly)).toBe(true); // ③ 문자열 층이 받아준다
+  });
+
+  // ⚠️ 아래 두 건이 **realpath 층을 격리**한다. 이게 없으면 그 층을 통째로 지워도 전부 초록이었다
+  // (2026-08-08 뮤테이션에서 실제로 그랬다) — 볼륨 GUID 는 ① ino 나 ③ 문자열 중 하나가
+  // 항상 받아줘서 ② 의 기여가 가려졌기 때문이다. 층마다 **혼자 감당하는 사례**가 있어야 한다.
+  it('ino 를 쓸 수 없는 파일시스템에서는 realpath 층이 볼륨 GUID 를 혼자 잡는다', () => {
+    const realOnly = { realpath: realFs.realpath }; // stat 없음
+    // ③ 문자열 층은 GUID 를 못 접는다(위 canonical 단언 참조) → ② 만이 성립 근거다
+    expect(canonical(GUID)).not.toBe(canonical(WIN));
+    expect(isSameFile(GUID, WIN, realOnly)).toBe(true);
+  });
+
+  it('신규 파일(대상이 아직 없음)은 부모 디렉터리 신원으로 판정한다 — GUID 로 검증', () => {
+    const GUID_DIR = `${B}${B}?${B}Volume{e4fddb3d-d1fc-4f32-9063-dc7fe1038925}${B}DEV${B}repo`;
+    const noTarget = {
+      realpath: (p: string) => {
+        if (p === `F:${B}DEV${B}repo` || p === GUID_DIR) return `F:${B}DEV${B}repo`;
+        throw new Error('ENOENT'); // 파일 자체는 아직 없다
+      },
+    };
+    // ③ 이 GUID 를 못 접으므로, 통과한다면 ②-b(부모 디렉터리 신원)뿐이다
+    expect(isSameFile(GUID, WIN, noTarget)).toBe(true);
+    expect(isSameFile(`${GUID_DIR}${B}OTHER.md`, WIN, noTarget)).toBe(false);
+  });
+
+  it('ino 가 0 이면 신뢰하지 않는다 (일부 파일시스템은 0 을 준다)', () => {
+    const zeroIno = { stat: () => ({ ino: 0, dev: 1 }) };
+    expect(isSameFile('x:/a/ZERO.md', 'y:/b/ZERO.md', zeroIno)).toBe(false);
+  });
+
+  it('파일시스템이 전부 실패해도 던지지 않는다 (fail-open — 호출부가 allow 한다)', () => {
+    const broken = {
+      stat: () => {
+        throw new Error('EACCES');
+      },
+      realpath: () => {
+        throw new Error('EACCES');
+      },
+    };
+    expect(isSameFile('f:/a/X.md', 'f:/b/Y.md', broken)).toBe(false);
+    expect(isSameFile(WIN, WIN, broken)).toBe(true); // 문자열 층은 여전히 동작한다
+  });
+});
+
+/** 위 "realpath 층만으로는 UNC 를 못 잡는다" 단언의 보조 — 층 자체의 판정을 직접 본다. */
+function normalizedRealpathAgree(
+  probe: { realpath: (p: string) => string },
+  a: string,
+  b: string,
+): boolean {
+  const n = (p: string) => p.replaceAll(B, '/').toLowerCase();
+  try {
+    return n(probe.realpath(a)) === n(probe.realpath(b));
+  } catch {
+    return false;
+  }
+}
+
+describe('canonical — 문자열 층(마지막 층)', () => {
   const expected = 'f:/dev/repo/claude.md';
 
   it.each([
-    ['슬래시 소문자 드라이브', `${ROOT_FWD}/CLAUDE.md`],
-    ['백슬래시 대문자 드라이브', `${ROOT_WIN}${B}CLAUDE.md`],
-    ['MSYS(Git Bash)', '/f/DEV/repo/CLAUDE.md'],
-    ['상대 요소 ./', `${ROOT_FWD}/./CLAUDE.md`],
-    ['상대 요소 ../', `${ROOT_FWD}/docs/../CLAUDE.md`],
-    ['중복 슬래시', `${ROOT_FWD}//CLAUDE.md`],
-    // ⚠️ 아래 5종이 2026-08-08 에 실제로 훅을 우회했다. Write/Edit 도구가 이 표기를 받아
-    //    **같은 파일에 쓴다**(실측: `\\?\…\AGENTS.md` 편집이 진짜 AGENTS.md 를 94줄로 만들었다).
-    ['확장길이 백슬래시', `${B}${B}?${B}${ROOT_WIN}${B}CLAUDE.md`],
-    ['확장길이 슬래시', `//?/${ROOT_FWD}/CLAUDE.md`],
-    ['디바이스 경로', `//./${ROOT_FWD}/CLAUDE.md`],
-    ['UNC 관리공유(백슬래시)', `${B}${B}localhost${B}F$${B}DEV${B}repo${B}CLAUDE.md`],
-    ['UNC 관리공유(슬래시)', '//localhost/F$/DEV/repo/CLAUDE.md'],
+    ['슬래시', 'f:/DEV/repo/CLAUDE.md'],
+    ['백슬래시', WIN],
+    ['MSYS', MSYS],
+    ['상대 요소 ./', 'f:/DEV/./repo/CLAUDE.md'],
+    ['상대 요소 ../', 'f:/DEV/repo/docs/../CLAUDE.md'],
+    ['중복 슬래시', 'f:/DEV//repo/CLAUDE.md'],
+    ['확장길이', EXTLEN],
+    ['디바이스', '//./f:/DEV/repo/CLAUDE.md'],
+    ['UNC 관리공유', UNC],
     ['확장길이 UNC', `${B}${B}?${B}UNC${B}localhost${B}F$${B}DEV${B}repo${B}CLAUDE.md`],
   ])('%s', (_label, input) => {
     expect(canonical(input)).toBe(expected);
   });
 
-  it('다른 파일은 접히지 않는다 (통제군 — 위 단언이 전부를 같게 만드는 게 아님을 보인다)', () => {
-    expect(canonical(`${ROOT_FWD}/docs/CLAUDE.md`)).not.toBe(expected);
-    expect(canonical(`${ROOT_FWD}/CLAUDE.md.bak`)).not.toBe(expected);
-    expect(canonical('g:/DEV/repo/CLAUDE.md')).not.toBe(expected);
-    // 관리 공유가 아닌 평범한 UNC 공유는 드라이브로 접지 않는다
+  it('볼륨 GUID 는 접지 못한다 — 이것이 문자열 층의 한계이고 ①② 가 필요한 이유다', () => {
+    expect(canonical(GUID)).not.toBe(expected);
+  });
+
+  it('다른 파일은 접히지 않는다 (통제군)', () => {
+    expect(canonical(OTHER)).not.toBe(expected);
     expect(canonical('//fileserver/public/DEV/repo/CLAUDE.md')).not.toBe(expected);
   });
 });
 
 describe('resolveBudgetName — 대소문자 무시 FS', () => {
-  // 실제 엔트리는 'CLAUDE.md' 하나뿐이고, 'claude.md' 로 물으면 **존재한다**고 답한다.
   const fsProbe = {
     listDir: () => ['CLAUDE.md', 'AGENTS.md', 'README.md'],
     exists: (name: string) => ['claude.md', 'agents.md', 'readme.md'].includes(name.toLowerCase()),
@@ -55,7 +168,7 @@ describe('resolveBudgetName — 대소문자 무시 FS', () => {
   const keys = ['CLAUDE.md', 'AGENTS.md'];
 
   it.each(['CLAUDE.md', 'claude.md', 'Claude.md', 'CLAUDE.MD', 'AGENTS.md', 'agents.md'])(
-    '%s → 예산 대상으로 판정한다 (같은 파일이므로)',
+    '%s → 예산 대상 (같은 파일이므로)',
     (name) => {
       expect(resolveBudgetName(name, keys, fsProbe)).toBe(
         name.toLowerCase().startsWith('claude') ? 'CLAUDE.md' : 'AGENTS.md',
@@ -70,7 +183,6 @@ describe('resolveBudgetName — 대소문자 무시 FS', () => {
 });
 
 describe('resolveBudgetName — 대소문자 구분 FS (Linux)', () => {
-  // Linux 에서 `claude.md` 는 **진짜 다른 파일**이다. 막으면 오탐이다.
   const fsProbe = {
     listDir: () => ['CLAUDE.md', 'AGENTS.md'],
     exists: (name: string) => ['CLAUDE.md', 'AGENTS.md'].includes(name),
@@ -81,7 +193,7 @@ describe('resolveBudgetName — 대소문자 구분 FS (Linux)', () => {
     expect(resolveBudgetName('CLAUDE.md', keys, fsProbe)).toBe('CLAUDE.md');
   });
 
-  it('대소문자가 다르고 그 이름의 파일이 없으면 null — 새 파일이므로 예산 대상이 아니다', () => {
+  it('대소문자가 다르고 그 이름의 파일이 없으면 null — 새 파일이므로 대상이 아니다', () => {
     expect(resolveBudgetName('claude.md', keys, fsProbe)).toBeNull();
   });
 
@@ -92,10 +204,8 @@ describe('resolveBudgetName — 대소문자 구분 FS (Linux)', () => {
     };
     expect(resolveBudgetName('claude.md', keys, withBoth)).toBeNull();
   });
-});
 
-describe('resolveBudgetName — fail-open', () => {
-  it('디렉터리를 못 읽으면 null (훅 고장이 작업을 막으면 안 된다)', () => {
+  it('디렉터리를 못 읽으면 null (fail-open)', () => {
     const broken = {
       listDir: (): string[] => {
         throw new Error('EACCES');
@@ -103,5 +213,17 @@ describe('resolveBudgetName — fail-open', () => {
       exists: () => true,
     };
     expect(resolveBudgetName('claude.md', ['CLAUDE.md'], broken)).toBeNull();
+  });
+});
+
+describe('baseNameOf — 구분자 혼용·표기법 무관', () => {
+  it.each([
+    [WIN, 'CLAUDE.md'],
+    [GUID, 'CLAUDE.md'],
+    [MSYS, 'CLAUDE.md'],
+    ['f:/DEV/repo/CLAUDE.md', 'CLAUDE.md'],
+    ['CLAUDE.md', 'CLAUDE.md'],
+  ])('%s → %s', (input, expected) => {
+    expect(baseNameOf(input)).toBe(expected);
   });
 });

--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -104,12 +104,17 @@ describe('LoginPage local(Credentials) mode', () => {
   // `res === undefined`는 signIn이 `location.href`를 **이미 쓴 뒤**다.
   // happy-dom은 실제 이동을 하지 않아 여기서는 문구가 보이지만, 실제 브라우저는 그 페이지로 간다.
   //
-  // 목적지는 **한 곳이 아니다.** `next-auth/react.js`의 signIn에 `return;`이 둘 있다:
-  //   · `if (!providers)`                       → `/api/auth/error`   (도달 실패·서버 500)
-  //   · `if (!provider || !providers[provider])` → `/api/auth/signin`  (provider 미등록)
-  // 이 주석은 처음에 "**항상** /api/auth/error"라고 적었는데 거짓이었다 — 반례가 같은 함수
-  // 6줄 아래 있었다. 진단하는 사람이 `/api/auth/signin` 착지 보고를 "그럴 리 없다"로
-  // 기각하게 만드는 종류의 오류다(G1: 전칭 단정은 전수 확인 뒤에만).
+  // 목적지는 **한 곳이 아니다.** `next-auth/react.js`의 signIn에 `return;`이 **셋** 있다
+  // (중괄호 균형으로 함수 본문을 잘라 전수한 결과 — 9·16·47행):
+  //   · `if (!providers)`                        → `/api/auth/error`   (도달 실패·서버 500)
+  //   · `if (!provider || !providers[provider])`  → `/api/auth/signin`  (provider 미등록)
+  //   · `if (redirect)` 블록 끝                    → `data.url ?? redirectTo`
+  //      ↑ 우리는 `redirect: false`로 호출하므로 **이 경로는 도달 불가**다. 그래도 적는 이유는,
+  //        누가 `redirect` 기본값으로 바꾸면 `!res` 분기가 정상 흐름까지 잡아먹기 때문이다.
+  //
+  // ⚠️ 이 주석은 두 번 틀렸다 — 처음엔 "**항상** /api/auth/error"(반례가 6줄 아래),
+  // 다음엔 "return 이 **둘**"(셋이다). 둘 다 라이브 코드를 읽은 어조로 쓴 전칭 단정이었다.
+  // **세는 것은 눈으로 하지 말고 전수 출력해서 하라**(G4) — 세 번째는 그렇게 해서 나왔다.
   //
   // 그래서 이 수정의 **실제 프로덕션 효과**는 문구 노출이 아니라 이것이다:
   //   수정 전: signIn의 이동을 `location.assign('/dashboard')`가 덮어씀 → 세션 없어 로그인으로


### PR DESCRIPTION
#307 감사가 찾았다. 훅이 **다섯 번째로** 뚫렸고, 이번에는 증상이 아니라 **원인**을 고친다.

## 다섯 번째 구멍 (라이브 실증)

`\?\Volume{e4fddb3d-…}\…\CLAUDE.md` 는 `F:\…\CLAUDE.md` 와 **같은 파일**인데(inode `25051272927992280/713254832` 일치) 훅이 통과시켰다. 감사는 프로브에서 멈추지 않고 **실제 Edit 도구로 AGENTS.md 를 89줄(예산 80)로 만들어** 종단 실증했다.

## 근본 원인 — 정규화는 "아는 표기법"의 거부목록이다

| # | 뚫린 것 | 닫은 PR |
|---|---|---|
| 1 | 경로 형식 (MSYS `/f/…` vs `F:\…`) | #294 |
| 2 | 상대 요소 `./` · `../` · `//` | #304 |
| 3 | 파일명 대소문자 `claude.md` | #306 |
| 4 | 확장길이·UNC `\?\F:\…` · `\localhost\F$\…` | #307 |
| **5** | **볼륨 GUID `\?\Volume{…}\…`** | **이 PR** |

Windows 는 같은 파일을 가리키는 표기법이 계속 나온다. **여섯 번째가 없다고 믿을 근거가 없다.** 그래서 문자열을 그만 세고 **파일시스템에 신원을 묻는다.**

## 층을 셋 쌓았다 — 하나로는 안 된다 (실측이 그렇게 말했다)

```
표기                  ino/dev   realpath 문자열               문자열 정규화
정상 드라이브          동일      F:\…             일치          일치
볼륨 GUID             동일      F:\…             일치          ✗ 몰랐던 표기
UNC 관리공유          동일      \localhost\F$\…  불일치        일치
MSYS `/f/…`           ENOENT    ENOENT                         일치
통제군(다른 파일)      다름      다름                           다름
```

> **ino 는 UNC 를 잡지만 realpath 문자열은 못 잡고, 둘 다 MSYS 는 못 잡는다.**

실제로 **realpath 단독으로 짰다가 UNC·MSYS 두 곳이 회귀**했고(#307·#294 가 막았던 것) 프로브가 그 자리에서 잡았다. 셋 중 하나라도 같다고 하면 같은 파일로 본다 — 차단 게이트에서 안전한 방향은 "더 많이 막는 쪽"이고, 오탐은 통제군이 지킨다.

## 검증 — 라이브 프로브 (400줄 Write)

```
DENY  볼륨GUID ×4 (\?\ · //?/ · \.\ · //./)   ← 다섯 번째 구멍
DENY  \?\UNC\localhost\F$\…                    ← 회귀 없음
DENY  \?\F:\…                                  ← #307
DENY  F:/…  (정상)                              ← 통제군
DENY  /f/…  (MSYS)                              ← #294, 회귀 없음
ALLOW docs/README.md                            ← 통제군(대상 아님)
```

## 층별 격리 뮤테이션

| 제거한 층 | 실패 |
|---|---|
| ① ino 신원 | 1건 |
| ② realpath 문자열 | 2건 |
| ②-b 부모 디렉터리 | 1건 |
| ③ 문자열 정규화 | 4건 |
| 구분자 보존 | 3건 |

> **첫 시도에서는 ② 를 통째로 지워도 40건이 전부 통과했다** — GUID 를 ① 이나 ③ 이 항상 받아줘서 ② 의 기여가 가려졌기 때문이다. 층마다 **혼자 감당하는 사례**를 만들어 격리했다. 그 전까지 그 층은 "있지만 아무도 지키지 않는" 상태였다.

## 테스트가 구현 버그를 하나 잡았다

`splitTail` 이 구분자를 `/` 로 바꿔 부모 경로를 만들었는데, Windows 의 `\?\` 경로는 **정규화를 우회해 백슬래시만 받는다.** 가짜 파일시스템이 백슬래시 형태만 매핑해 둔 덕에 드러났다 → 원본 구분자를 보존하도록 수정.

## 로그인 주석 정정 — **두 번째다**

`signIn` 에 `return;` 이 "둘"이라고 적었는데 **셋**이다(9·16·47행 — 중괄호 균형으로 함수 본문을 잘라 전수). 세 번째는 `if (redirect)` 블록이라 우리 호출(`redirect: false`)에는 도달 불가지만, 기본값으로 바꾸면 `!res` 분기가 정상 흐름까지 잡아먹는다.

> 이 주석은 **두 번 틀렸다** — 처음엔 *"항상 /api/auth/error"*, 다음엔 *"둘"*. 둘 다 라이브 코드를 읽은 어조로 쓴 전칭 단정이었다. **세는 것은 눈이 아니라 전수 출력으로**(G4).

## 게이트

```
docs:check 9/9 · lint 0 errors · type-check clean
test 198파일 2,573 (기존 2,557 + 신규 16) · build 성공
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)