### PR TITLE
fix: ADS 표기(CLAUDE.md::$DATA)가 예산 조회를 우회하던 것

### DIFF
--- a/scripts/hooks/budgetPath.mjs
+++ b/scripts/hooks/budgetPath.mjs
@@ -178,5 +178,25 @@ export function resolveBudgetName(rawBase, budgetKeys, fsProbe) {
 
 /** 편집 대상의 파일명만 뽑는다(구분자 혼용·표기법 무관). */
 export function baseNameOf(p) {
-  return splitTail(p).base;
+  return stripAds(splitTail(p).base);
+}
+
+/**
+ * NTFS **대체 데이터 스트림**(ADS) 표기를 벗긴다 — `CLAUDE.md::$DATA` · `CLAUDE.md:stream`.
+ *
+ * 2026-08-08 실측: `fs.writeFileSync('…/CLAUDE.md::$DATA', …)` 는 **원본 파일을 덮는다**
+ * (inode 동일, 부수 엔트리 0). 그런데 훅은 통과시켰다 — `baseNameOf` 가 `CLAUDE.md::$DATA` 를
+ * 내놓아 **예산 이름 조회에서 걸러져 신원 검사에 도달하지 못했기** 때문이다.
+ * (신원 검사까지 갔다면 ino 가 같으므로 막혔다.)
+ *
+ * **현재 도구 표면에서는 악용이 어렵다** — Write/Edit 의 temp+rename 패턴은
+ * `…::$DATA.tmp.<pid>.<hex>` 가 잘못된 스트림 이름이 되어 ENOENT 로 실패한다(실측).
+ * 그래도 막는 이유는 이 저장소의 기준 그대로다 — **강제 게이트에 뚫린 구멍은 게이트가 아니고**,
+ * 그 판정이 하네스 구현 세부(temp+rename 여부)에 기대고 있으면 안 된다.
+ *
+ * 인덱스 0~1 의 콜론은 **드라이브 문자**(`F:CLAUDE.md`)이므로 건드리지 않는다.
+ */
+function stripAds(base) {
+  const i = base.indexOf(':', 2);
+  return i === -1 ? base : base.slice(0, i);
 }

--- a/src/__tests__/hooks/budgetPath.test.ts
+++ b/src/__tests__/hooks/budgetPath.test.ts
@@ -223,7 +223,20 @@ describe('baseNameOf — 구분자 혼용·표기법 무관', () => {
     [MSYS, 'CLAUDE.md'],
     ['f:/DEV/repo/CLAUDE.md', 'CLAUDE.md'],
     ['CLAUDE.md', 'CLAUDE.md'],
+    // ⚠️ NTFS 대체 데이터 스트림(ADS). 2026-08-08 실측: 이 표기로 쓰면 **원본이 덮인다**
+    // (inode 동일). 벗기지 않으면 예산 이름 조회에서 걸러져 **신원 검사에 도달조차 못 한다.**
+    [`${WIN}::$DATA`, 'CLAUDE.md'],
+    [`${WIN}:hidden`, 'CLAUDE.md'],
+    ['CLAUDE.md::$DATA', 'CLAUDE.md'],
   ])('%s → %s', (input, expected) => {
     expect(baseNameOf(input)).toBe(expected);
+  });
+
+  it('드라이브 문자 콜론은 벗기지 않는다 (통제군 — ADS 처리가 과하게 자르지 않음을 보인다)', () => {
+    expect(baseNameOf('F:CLAUDE.md')).toBe('F:CLAUDE.md');
+  });
+
+  it('콜론이 없는 이름은 그대로 (통제군)', () => {
+    expect(baseNameOf('README.md')).toBe('README.md');
   });
 });


### PR DESCRIPTION
주간 토큰 한도 때문에 서브에이전트 감사 대신 **내가 직접 프로브**했다. 경로 표기 **26종 전수** — 통제군 4 · 회귀 5 · 신규 후보 17.

## 결과: 우회 1건

```
ALLOW | 동일(ino) | CLAUDE.md::$DATA    <<< 우회
```

**나머지 16종 신규 후보는 안전했다.** 특히 문자열 정규화로는 못 잡았을 것들을 **신원 층이 전부 잡았다**:

| 후보 | 판정 |
|---|---|
| GUID 접두사 소문자 · 디바이스 대문자 · 구분자 혼용 | DENY |
| 확장길이+`..` · GUID+`..` | DENY |
| `\?\GLOBALROOT\??\F:\` | DENY |
| `\?\UNC\localhost\F$\` | DENY |
| 파일명 단독 (`CLAUDE.md`) | DENY |

> #308 의 접근 전환(문자열 → 파일시스템 신원)이 **실제로 값을 했다는 증거**다. 이 중 다수는 `canonical()` 시절이었다면 새 구멍이 됐을 형태다.

`trailing dot` · `trailing space` · `8.3` · `drive relative` · `file://` · `percent encoded` · `nested extlen` 은 ALLOW 지만 **그 경로로는 파일에 닿지 못한다**(전부 ENOENT) → 우회가 아니다.

## 원인 — 신원 검사에 **도달조차 못 했다**

`baseNameOf('…/CLAUDE.md::$DATA')` → `CLAUDE.md::$DATA` → 예산 **이름 조회**에서 걸러짐. 신원 검사까지 갔다면 ino 가 같으므로 막혔다. **#308 의 층 구조는 멀쩡했고, 그 앞단에서 새는 구멍**이었다.

## 실제 위험도 — 낮지만 닫는다

스크래치 파일 실측:

```
① fs.writeFileSync(path + '::$DATA')  → 원본을 덮는다 (ino 동일, 부수 엔트리 0)
② temp+rename 패턴                     → ENOENT 로 실패
```

Claude Code 의 Write/Edit 는 ② 를 쓰므로 **현재 도구 표면에서는 악용이 어렵다.** 그래도 막는 이유는 이 저장소의 기준 그대로다 — **강제 게이트에 뚫린 구멍은 게이트가 아니고**, 그 판정이 하네스 구현 세부에 기대고 있으면 안 된다.

수정은 한 줄이다. 드라이브 문자 콜론(`F:CLAUDE.md`)은 인덱스 0~1 이므로 건드리지 않는다 — **통제군 테스트로 고정**했다.

## 검증

```
26종 전수 재실행 → 우회 0건 · 통제군/회귀 불일치 0건
뮤테이션(stripAds 무력화) → 3건 실패
docs:check 9/9 · lint 0 errors · type-check clean
test 198파일 2,578 (기존 2,573 + 신규 5) · build 성공
```

## ⚠️ 한계를 적는다

**이건 프로브이지 감사가 아니다.** 오늘 감사들이 잡은 것 중 *"이 테스트가 CI 에서 무력하다"* 같은 **판단이 필요한 지적**은 이 방법으로 나오지 않는다. 프로브는 되찾았지만 판단은 못 되찾았다 — 독립 검증이 필요하면 나중에 별도로 돌려야 한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)