### PR TITLE
security: 인시던트 문서 범위를 이 저장소로 좁힌다 — 공개 문서가 노출 지도가 돼 있었다

### DIFF
--- a/docs/security/incident-response.md
+++ b/docs/security/incident-response.md
@@ -64,7 +64,7 @@ Railway 변수 **67 → 61개**. 살아 있어야 하는 9개(`NEXT_PUBLIC_AUTH_
 
 ## 사례 기록 — 2026-08-07 `.scamanager` 토큰 공개 노출 (⏳ 오너 회전 대기)
 
-근본원인 분석 중 발견됐다. **이 저장소 하나의 문제가 아니다.**
+근본원인 분석 중 발견됐다.
 
 | 항목 | 실측 |
 |---|---|
@@ -74,40 +74,10 @@ Railway 변수 **67 → 61개**. 살아 있어야 하는 9개(`NEXT_PUBLIC_AUTH_
 | 전송 | **평문 HTTP** + **URL 쿼리스트링**(`?token=…`) — 프록시·서버 액세스 로그에 남는다 |
 | 토큰 권한(스크립트 기준) | `GET /api/hook/verify` · `POST /api/hook/result`(리뷰 결과 **위조** 가능) |
 
-### 범위 — 워크스페이스 8개 저장소, 토큰은 저장소마다 다르다
-
-sha256 지문 대조 결과 **고유 토큰 8개**(공유 아님) → **회전은 저장소별로 각각** 필요하다.
-
-| 저장소 | 공개 | config 추적 | 전송 |
-|---|---|---|---|
-| **CustomWebService** | **PUBLIC** | 추적됨 → 이번에 해제 | HTTP |
-| **LangTrans** | **PUBLIC** | **추적 중** | **HTTP** |
-| **claude-grok-build-plugin** | **PUBLIC** | **추적 중** | HTTPS |
-| **xzawed-pais** | **PUBLIC** | **추적 중** | HTTPS |
-| SCAManager-test-samples | PRIVATE | 추적됨 | HTTP |
-| Noble-Watcher | PRIVATE | 미추적 ✔ | HTTP |
-| GoldCalc · TravellerInfo | **원격 없음**(아래) | 로컬에서 추적 중 | HTTP |
-
-**2026-08-08 재측정 — 위 표의 2건이 실제와 달랐다** (`gh api repos/.../contents/.scamanager`):
-
-- **`xzawedPAIS`는 존재하지 않는 이름이다. 실제는 `xzawed-pais`**(PUBLIC). 이 이름으로 찾으면
-  404가 나서 "이미 처리됐다"고 오인할 수 있다 — **런북이 헛다리를 짚게 하는 종류의 오류**다.
-- **GoldCalc · TravellerInfo는 GitHub에 없다**(`gh api` 404 · 소유 저장소 12개 목록에도 없음).
-  다만 로컬에 **원격추적 브랜치가 남아 있어 과거 푸시 흔적은 있다** → 삭제된 것으로 보인다.
-  **삭제 시점 이전에 공개였는지는 판정할 수 없다.** 모르는 것을 "안전"으로 적지 않는다 —
-  보수적으로 **회전 대상에 포함**한다. 로컬 `config.json`은 지금도 추적 중이고 평문 HTTP다.
-
-**비대상으로 확인된 것**(재조사 방지): `ArcanaInsight`는 `.scamanager/install-hook.sh`만 있고
-config 파일이 없다. `SCAManager` · `KeyCloakSDK` · `keycloak-sdk-php`는 `.scamanager` 자체가 없다.
-
-**현재 상태 요약**: 공개 저장소 **3곳(LangTrans · xzawed-pais · claude-grok-build-plugin)의
-HEAD에 토큰이 그대로 살아 있다.** CustomWebService만 HEAD가 정리됐고(히스토리는 남음),
-`config.example.json`의 토큰 자리는 자리표시자임을 확인했다.
-
-### 이번에 한 것 (이 저장소만)
+### 이번에 한 것
 
 - `.gitignore`에 `.scamanager/config.json` 추가 · `git rm --cached`로 추적 해제
-- `config.example.json` 추가(토큰 자리는 플레이스홀더)
+- `config.example.json` 추가(토큰 자리는 플레이스홀더 — 2026-08-08 확인)
 - 로컬 `config.json`은 남겨 훅 동작에 영향 없음
 
 ### ⚠️ 코드로는 끝나지 않는다 — 오너 액션
@@ -115,15 +85,17 @@ HEAD에 토큰이 그대로 살아 있다.** CustomWebService만 HEAD가 정리�
 **추적 해제는 앞으로의 노출만 막는다. 커밋 `b2186f4` 이하 히스토리에는 토큰이 그대로 있고,
 공개 저장소는 이미 클론·미러링됐을 수 있다. 유일한 실질 조치는 회전이다.**
 
-1. SCAManager에서 **공개 저장소 4곳의 토큰을 각각 폐기·재발급** — CustomWebService(히스토리에
-   잔존) · **LangTrans · xzawed-pais · claude-grok-build-plugin**(HEAD에 잔존, 2026-08-08 실측).
-   토큰은 저장소마다 다르므로 **한 번에 하나씩** 처리해야 한다
-2. 나머지 4곳(비공개 2 · 원격 삭제 2)도 같은 처리 권장 — 평문 HTTP 구간이 남아 있고,
-   삭제된 2곳은 **삭제 전 공개 여부를 판정할 수 없다**
-3. 각 저장소에서 `.gitignore` + `git rm --cached` 반복 — **CustomWebService에서 한 것과 동일**
-   (`config.example.json`으로 대체하면 훅 사용법은 유지된다)
-4. 서버를 **HTTPS 전용**으로, 토큰을 **쿼리스트링이 아니라 헤더**로 옮기는 것을 검토
+1. SCAManager에서 **이 저장소의 토큰을 폐기·재발급**한다. 토큰은 저장소마다 다르므로
+   이 조치는 **이 저장소에만** 해당한다
+2. 서버를 **HTTPS 전용**으로, 토큰을 **쿼리스트링이 아니라 헤더**로 옮기는 것을 검토
    (쿼리스트링 토큰은 액세스 로그에 영구 기록된다)
+
+> **범위 주의 — 이 문서는 이 저장소의 사건만 다룬다.**
+> `.scamanager`는 여러 저장소가 함께 쓰는 도구이므로 같은 형태의 노출이 다른 곳에도 있을 수
+> 있고, 실제로 2026-08-07~08에 워크스페이스 전수 조사를 해 **오너에게 직접 전달**했다.
+> 그 목록은 **여기에 싣지 않는다** — 공개 저장소에 "미회전 자격증명이 어디 있는지"를 적는 것은
+> 사건을 기록하는 게 아니라 **노출을 넓히는 것**이기 때문이다. 실제로 이 문서가 한때 그렇게
+> 자랐고, 2026-08-08 오너 지적으로 되돌렸다. 다른 저장소의 조치는 그 저장소에서 추적한다.
 
 > `.scamanager/pre-commit-secrets.sh`(gitleaks)가 저장소에 있는데 **`.git/hooks`에 설치돼
 > 있지 않다.** 설치돼 있었다면 최초 커밋에서 걸렸을 수 있다. 다만 그 훅은 gitleaks 바이너리가

--- a/docs/superpowers/plans/2026-07-31-project-wbs.md
+++ b/docs/superpowers/plans/2026-07-31-project-wbs.md
@@ -706,7 +706,7 @@ glob 함정**을 다시 확인했다 — `'src/app/(main)/**/*.tsx'`는 매칭 0
 | 3 | ~~**F14 잔여 3개**~~ → ✅ **종결(2026-08-06)**. 조사 결과 **0종 분해** 확정 [ADR](../../decisions/2026-08-06-long-file-decomposition-scope.md). "길어서 쪼개자"로 다시 열지 말 것 |
 | 3′ | ~~**F20 — builder 결함 4건 수정**~~ | ✅ **완료(2026-08-07~08)**. 결함 1~5는 **소유권 토큰**·**신원 값** 으로 닫았고, 결함 6은 절반이 거짓 전제였음이 드러나 [#300](https://github.com/xzawed/CustomWebService/pull/300)에서 다시 닫았다(위 「결함 6 정정」) |
 | 4 | **A9** — `CORRECTIONS` 2건 동작 변경 여부 | **오너 판단.** 코드는 그대로 두고 함정만 문서화한 상태다. 지금 사고는 아니므로 급하지 않지만, `Dog API`·`Lorem Picsum`을 폐기할 일이 생기면 **선행조건**이 된다 |
-| 5 | **H1 — SCA Manager 토큰 회전** | **오너 액션(무료).** 2026-08-08 실측: **공개 저장소 3곳의 HEAD에 토큰이 살아 있다.** 이 저장소는 [#290](https://github.com/xzawed/CustomWebService/pull/290)에서 HEAD만 정리됐고 **히스토리에는 남아 있다** — 추적 해제로는 끝나지 않고 **서비스 측 회전만이 실효**다. 저장소별로 토큰이 다르므로 하나씩. 대상 목록·정정 이력은 [incident-response.md](../../security/incident-response.md) 「사례 기록 — 2026-08-07」 절 |
+| 5 | **H1 — 이 저장소의 SCA Manager 토큰 회전** | **오너 액션(무료).** [#290](https://github.com/xzawed/CustomWebService/pull/290)이 HEAD만 정리했고 **커밋 `b2186f4`(2026-04-08) 이하 히스토리에는 토큰이 남아 있다** — 추적 해제로는 끝나지 않고 **서비스 측 회전만이 실효**다. 토큰은 저장소마다 다르므로 **이 항목은 이 저장소 하나**를 가리킨다. 상세는 [incident-response.md](../../security/incident-response.md) 「사례 기록 — 2026-08-07」 절 |
 | 6 | **H2 — `required_status_checks` 추가** | **오너 액션.** main 은 **이미 보호돼 있다** — 활성 ruleset `PRIMARY`(deletion · non_fast_forward · **pull_request**). 직접 push·강제푸시·삭제는 전부 막힌다. **비어 있는 것은 `required_status_checks` 하나뿐(규칙 0개)** 이라, CI 가 red 인 PR 도 머지 버튼이 눌린다. 즉 오늘 만든 게이트는 **보이기만 하고 막지는 않는다.** 넣을 후보: `Docs Integrity` · `Lint & Type Check` · `Unit & Integration Tests` · `Build`. 대가는 체크가 끝날 때까지 머지가 대기하는 것이다(오늘 관측된 10초·43초 머지는 불가능해진다) |
 
 > **다음 세션 시작점**(2026-08-08 갱신): **코드가 단독으로 할 수 있는 일은 남아 있지 않다.**


### PR DESCRIPTION
오너 지적으로 드러났다. **CustomWebService 는 LangTrans·xzawed-pais 등과 무관한데**, 이 저장소의 보안 문서가 워크스페이스 8개 저장소의 자격증명 상태표를 싣고 있었다.

## 범위 착오보다 나쁜 문제

표는 이렇게 적고 있었다 — 어느 저장소가 **지금 토큰을 HEAD 에 갖고 있는지**, 어느 것이 **평문 HTTP** 인지, **정확한 파일 경로**가 무엇인지. 회전이 안 된 상태에서, **공개 저장소에**.

> **노출을 기록하는 문서가 노출을 넓히는 쪽으로 자랐다.**

그리고 **그 마지막 편집이 내 것이다.** #305 에서 *"런북이 존재하지 않는 저장소를 지목한다"* 며 이름을 정정하고(`xzawedPAIS` → `xzawed-pais`) *"공개 3곳의 HEAD 에 토큰이 살아 있다"* 는 요약을 **새로 추가**했다. 정확도를 올린다는 명분으로 **지도를 더 쓸모 있게 만들었다.**

## 고친 것

| | |
|---|---|
| 삭제 | 타 저장소 상태표 · 재측정 기록 · "현재 상태 요약" |
| 축소 | 오너 액션 → **이 저장소의 토큰 하나** |
| 정정 | WBS `H1` 도 같은 범위로 |
| 유지 | **범위 주의** 문단 — 전수 조사를 했고 결과는 **오너에게 직접 전달**했으며, 그 목록을 여기 싣지 않는 이유를 적었다 |

기록이 조용히 사라지지 않게 하되 **지도는 남기지 않는다.**

## 남은 한계

**HEAD 에서 지워도 히스토리에는 남는다** — 이 사건의 토큰과 정확히 같은 원리다. 다만 현재 문서가 그것을 **유지·정밀화하는 것**은 멈춘다.

## 이 저장소의 실제 사안 (변하지 않음)

`.scamanager/config.json` 이 커밋 `b2186f4`(2026-04-08) 이후 약 4개월 공개돼 있었고, #290 이 HEAD 를 정리했으나 **히스토리에는 남아 있다.** 서비스 측 회전만이 실효다.

```
grep 전수: 타 저장소 보안 언급 0건
(남은 ArcanaInsight·SCAManager 2건은 Railway --service 설명 — 노출과 무관)
docs:check 9/9
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)