### PR TITLE
docs: README에 종료 공지 — 공개 저장소 첫 화면이 여전히 "Live"였다

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,29 @@
 > 무료 API를 골라 담고, 원하는 서비스를 설명하면 AI가 웹서비스를 자동 생성하고 서브도메인으로 즉시 게시하는 올인원 플랫폼
 
 [![license](https://img.shields.io/badge/license-Proprietary-red?style=flat-square)](./README.md#라이선스)
-[![status](https://img.shields.io/badge/status-v1.0.0%20Live-brightgreen?style=flat-square)](https://xzawed.xyz)
+[![status](https://img.shields.io/badge/status-2026--08--31%20%EC%A2%85%EB%A3%8C%20%EC%98%88%EC%A0%95-critical?style=flat-square)](https://xzawed.xyz)
 [![Next.js](https://img.shields.io/badge/Next.js-16+-black?style=flat-square&logo=next.js)](https://nextjs.org)
 [![AI](https://img.shields.io/badge/AI-Claude%20Opus%205-blueviolet?style=flat-square)](https://anthropic.com)
 [![Deploy](https://img.shields.io/badge/Deploy-Railway-8A2BE2?style=flat-square&logo=railway)](https://railway.app)
 
 **🌐 서비스 URL**: [xzawed.xyz](https://xzawed.xyz)
+
+> ## 🛑 서비스 종료 안내 — 2026년 8월 31일
+>
+> **이 서비스는 2026년 8월 31일자로 운영을 종료합니다.**
+> 종료 후에는 계정·프로젝트·게시된 사이트를 포함한 **모든 데이터가 삭제되며 복구할 수 없습니다.**
+>
+> | 항목 | 상태 |
+> |---|---|
+> | AI 코드 생성 | **2026-08-23부로 중단** — 제공자 사용 한도 해제일이 종료일 이후라 재개하지 않습니다 |
+> | 신규 회원가입 | **2026-08-23부로 중단** |
+> | 기존 계정 로그인·조회 | 종료일까지 가능 |
+>
+> **보관이 필요한 데이터가 있다면 종료 전에 내려받아 주세요.** 로그인한 상태에서
+> [`/api/v1/auth/export`](https://xzawed.xyz/api/v1/auth/export) 를 열면 프로젝트와
+> 생성된 코드(HTML/CSS/JS)가 JSON 파일로 내려받아집니다.
+>
+> 아래 내용은 운영 당시의 기록으로 남겨 둡니다.
 
 ---
 


### PR DESCRIPTION
어제 종료 문서 정리에서 **README를 빠뜨렸다.** Grok 조사 범위를 `docs/` 4개 디렉터리와
CLAUDE.md로 한정한 것이 원인이다 — 공개 저장소의 첫 화면인데 범위 밖이었다.

**빠뜨린 결과**: 종료 언급 0건 · 배지 `status: v1.0.0 Live` ·
본문은 *"AI가 웹페이지를 생성하고 서브도메인으로 즉시 게시"* 를 현재형으로 서술.

## 변경

- **상태 배지** → `2026-08-31 종료 예정`(critical).
  shields.io에서 **실제 렌더를 확인**했다 — SVG 안 텍스트가 `2026-08-31 종료 예정`
  (`--`가 하이픈으로 접히고 한글도 정상). 링크만 바꾸고 렌더를 안 보면 깨진 배지를 올리게 된다
- **종료 공지 블록** — 제목·서비스 URL 바로 아래.
  무엇이 **언제부터** 막혔는지 표로 구분했다: "종료 예정"만 적으면 방문자가
  **지금 왜 생성이 안 되는지**를 알 수 없다
- **데이터 회수 경로 명시** — 로그인 상태에서 `GET /api/v1/auth/export`

### 회수 경로를 적은 이유

이 엔드포인트는 **UI 호출부가 0건**이다(테스트 외 참조 없음). 즉 **URL을 모르면 도달할 수 없고**,
종료 후 데이터를 되찾을 방법이 사라진다. 이미
[`docs/reference/api-endpoints.md`](docs/reference/api-endpoints.md) ·
[`docs/architecture/auth.md`](docs/architecture/auth.md)에 공개돼 있어 새 노출이 아니며,
세션 인증을 요구한다(미인증 401).

## 하지 않은 것

- **본문 기능 설명 과거형 재작성** — 운영 당시 기록으로 남긴다. 8일 남은 시점에 대청소를 할
  이유가 없고, 상단 공지가 맥락을 준다
- **게시 사이트(`slug.xzawed.xyz`) 배너 주입** — 오너가 불필요로 결정.
  다만 구조는 기록해 둔다: [`src/app/site/[slug]/route.ts`](src/app/site/[slug]/route.ts)가
  **루트 레이아웃 밖의 유일한 페이지 경로**라 배너가 구조적으로 닿지 않는다
- `docs/README.md` — 문서 색인이지 사용자 대상 문서가 아니다

## 화면 공지 실측 (프로덕션, 2026-08-23)

```
/ /login /signup /catalog /dashboard /builder /settings/api-keys
/privacy /terms /disclaimer /forgot-password /verify-email
→ 12/12 HTTP 200 · 배너 노출 ✅ (로그인 영역 포함)
```

랜딩이 `(main)` 그룹 밖이라 루트 레이아웃에 배너를 둔 판단이 실측으로 확인됐다.

## 분담

문구는 공개 커뮤니케이션이라 Claude가 작성하고(`grok-routing`이 "프롬프트 문구는 Claude 보유"로
분류하는 영역), **기계적 치환 2곳만 Grok에 위임**했다 — diff **18+/1-**, 1파일, 범위 이탈 0,
CRLF 유지, `billing: subscription`.

`pnpm docs:check` **9/9 통과** · **소스 변경 0건**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
